### PR TITLE
BH-876: Add REST API routes for creating, deleting, and fetching a content model definition.

### DIFF
--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Registers custom REST API endpoints for content modeling.
+ *
+ * @package WPE_Content_Model
+ */
+
+declare(strict_types=1);
+
+namespace WPE\ContentModel\REST_API;
+
+use WP_Error;
+use WP_REST_Request;
+use function WPE\ContentModel\ContentRegistration\generate_custom_post_type_args;
+use function WPE\ContentModel\ContentRegistration\get_registered_content_types;
+use function WPE\ContentModel\ContentRegistration\update_registered_content_types;
+
+add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes' );
+/**
+ * Registers custom routes with the WP REST API.
+ */
+function register_rest_routes(): void {
+	// @todo Route for updating a single content type.
+
+	// Route for retrieving a single content type.
+	register_rest_route(
+		'wpe',
+		'/content-model/([A-Za-z])\w+/',
+		[
+			'methods'             => 'GET',
+			'callback'            => __NAMESPACE__ . '\dispatch_get_content_model',
+			'permission_callback' => static function () {
+				return current_user_can( 'manage_options' );
+			},
+		]
+	);
+
+	// Route for creating a single content type.
+	register_rest_route(
+		'wpe',
+		'/content-model',
+		[
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\dispatch_create_content_model',
+			'permission_callback' => static function () {
+				return current_user_can( 'manage_options' );
+			},
+		]
+	);
+
+	// Route for deleting a single content type.
+	register_rest_route(
+		'wpe',
+		'/content-model/([A-Za-z])\w+/',
+		[
+			'methods'             => 'DELETE',
+			'callback'            => __NAMESPACE__ . '\dispatch_delete_model',
+			'permission_callback' => static function () {
+				return current_user_can( 'manage_options' );
+			},
+		]
+	);
+}
+
+/**
+ * Handles model GET requests from the REST API.
+ *
+ * @param WP_REST_Request $request The REST API request object.
+ *
+ * @return WP_Error|\WP_HTTP_Response|\WP_REST_Response
+ */
+function dispatch_get_content_model( WP_REST_Request $request ) {
+	$route         = $request->get_route();
+	$slug          = substr( strrchr( $route, '/' ), 1 );
+	$content_types = get_registered_content_types();
+
+	if ( empty( $content_types[ $slug ] ) ) {
+		return rest_ensure_response(
+			[
+				'success' => false,
+				'errors'  => esc_html__( 'The requested content model does not exist.', 'wpe-content-model' ),
+			]
+		);
+	}
+
+	return rest_ensure_response(
+		[
+			'data' => $content_types[ $slug ],
+		]
+	);
+}
+
+/**
+ * Handles model POST requests from the REST API.
+ *
+ * @param WP_REST_Request $request The REST API request object.
+ *
+ * @return WP_Error|\WP_HTTP_Response|\WP_REST_Response
+ */
+function dispatch_create_content_model( WP_REST_Request $request ) {
+	$params = $request->get_params();
+
+	// @todo simplify create_model() signature to single array?
+	$model = create_model( $params['postTypeSlug'], $params );
+
+	if ( is_wp_error( $model ) ) {
+		return rest_ensure_response(
+			[
+				'success' => false,
+				'errors'  => $model->get_all_error_data(),
+			]
+		);
+	}
+
+	return rest_ensure_response( [ 'success' => true ] );
+}
+
+/**
+ * Handles model DELETE requests from the REST API.
+ *
+ * @param WP_REST_Request $request The REST API request object.
+ *
+ * @return WP_Error|\WP_HTTP_Response|\WP_REST_Response
+ */
+function dispatch_delete_model( WP_REST_Request $request ) {
+	$route         = $request->get_route();
+	$slug          = substr( strrchr( $route, '/' ), 1 );
+	$content_types = get_registered_content_types();
+
+	if ( empty( $content_types[ $slug ] ) ) {
+		return rest_ensure_response(
+			[
+				'success' => false,
+				'errors'  => esc_html__( 'The specified content model does not exist.', 'wpe-content-model' ),
+			]
+		);
+	}
+
+	unset( $content_types[ $slug ] );
+
+	$updated = update_registered_content_types( $content_types );
+
+	return rest_ensure_response(
+		[
+			'success' => $updated,
+		]
+	);
+}
+
+/**
+ * Creates a custom content model.
+ *
+ * @param string $post_type_slug The post type slug.
+ * @param array  $args Model arguments.
+ *
+ * @return WP_Error|bool
+ */
+function create_model( string $post_type_slug, array $args ) {
+	$errors = [];
+
+	if ( empty( $post_type_slug ) ) {
+		$errors[] = [
+			'field'   => 'postTypeSlug',
+			'message' => esc_html__( 'Please provide a postTypeSlug.', 'wpe-content-model' ),
+		];
+	}
+
+	if ( empty( $args['singular'] ) || empty( $args['plural'] ) ) {
+		$errors[] = [
+			'field'   => 'labels',
+			'message' => esc_html__( 'Please provide singular and plural labels when creating a content model.', 'wpe-content-model' ),
+		];
+	}
+
+	$content_types = get_registered_content_types();
+	if ( ! empty( $content_types[ $post_type_slug ] ) ) {
+		$errors[] = [
+			'code'    => 'already-exists',
+			'message' => esc_html__( 'Content model already exists. Please update the existing one or delete it and recreate.', 'wpe-content-model' ),
+		];
+	}
+
+	// @todo validate field types
+	try {
+		$args = wp_parse_args( $args, generate_custom_post_type_args( $args ) );
+	} catch ( \InvalidArgumentException $exception ) {
+		$errors[] = [
+			'code'    => 'invalid-args',
+			'message' => $exception->getMessage(),
+		];
+	}
+
+	if ( ! empty( $errors ) ) {
+		return new WP_Error( 'model-not-created', esc_html__( 'Model not created.', 'wpe-content-model' ), [ 'errors' => $errors ] );
+	}
+
+	$content_types[ $post_type_slug ] = $args;
+
+	$created = update_registered_content_types( $content_types );
+
+	if ( ! $created ) {
+		return new WP_Error( 'model-not-created', esc_html__( 'Model not created. Reason unknown.', 'wpe-content-model' ) );
+	}
+
+	return true;
+}
+
+/**
+ * Deletes the specified model from the database.
+ *
+ * @param string $post_type_slug The post type slug.
+ *
+ * @return bool|WP_Error WP_Error if invalid parameters passed, otherwise true/false.
+ */
+function delete_model( string $post_type_slug ) {
+	if ( empty( $post_type_slug ) ) {
+		return new WP_Error( 'model-not-deleted', esc_html__( 'Please provide a post-type-slug.', 'wpe-content-model' ) );
+	}
+
+	$content_types = get_registered_content_types();
+
+	if ( empty( $content_types[ $post_type_slug ] ) ) {
+		return new WP_Error( 'model-not-deleted', esc_html__( 'Content type does not exist.', 'wpe-content-model' ) );
+	}
+
+	unset( $content_types[ $post_type_slug ] );
+	return update_registered_content_types( $content_types );
+}

--- a/tests/integration/content-registration/example-data/expected-post-types.php
+++ b/tests/integration/content-registration/example-data/expected-post-types.php
@@ -8,7 +8,7 @@ return array (
 		array (
 			'name' => 'Dogs',
 			'singular_name' => 'Dog',
-			'description' => 'A description of dogs',
+			'description' => '',
 			'public' => false,
 			'publicly_queryable' => false,
 			'show_ui' => true,

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -5,9 +5,10 @@
  * @package WPE_Content_Model
  */
 
+use function WPE\ContentModel\ContentRegistration\generate_custom_post_type_args;
 use function \WPE\ContentModel\ContentRegistration\generate_custom_post_type_labels;
-use function \WPE\ContentModel\ContentRegistration\register_content_types;
 use PHPUnit\Runner\Exception as PHPUnitRunnerException;
+use function WPE\ContentModel\ContentRegistration\update_registered_content_types;
 
 /**
  * Post type registration case.
@@ -28,7 +29,7 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		update_option( 'wpe_content_model_post_types', $this->expected_post_types() );
+		update_registered_content_types( $this->expected_post_types() );
 
 		// @todo why is this not running automatically?
 		do_action( 'init' );
@@ -63,6 +64,8 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 		global $wp_rest_server;
 		$wp_rest_server = null;
 		$this->server = null;
+		delete_option( 'wpe_content_model_post_types' );
+		$this->all_registered_post_types = null;
 	}
 
 	public function test_dog_post_type_accessible_via_rest_api(): void {
@@ -146,6 +149,18 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 		} catch ( Exception $exception ) {
 			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
 		}
+	}
+
+	public function test_generate_custom_post_type_args_throws_exception_when_invalid_arguments_passed(): void {
+		self::expectException( \InvalidArgumentException::class );
+		generate_custom_post_type_args( [] );
+	}
+
+	public function test_generate_custom_post_type_args_generates_expected_data(): void {
+		$generated_args = generate_custom_post_type_args( [ 'singular' => 'Dog', 'plural' => 'Dogs' ] );
+		$expected_args = $this->expected_post_types()['dog'];
+		unset( $expected_args['fields'] );
+		self::assertSame( $generated_args, $expected_args );
 	}
 
 	private function expected_post_types(): array {

--- a/tests/integration/content-registration/test-settings-functions.php
+++ b/tests/integration/content-registration/test-settings-functions.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Tests for settings-related functions.
+ */
+
+use function WPE\ContentModel\ContentRegistration\get_registered_content_types;
+use function WPE\ContentModel\ContentRegistration\update_registered_content_type;
+use function WPE\ContentModel\ContentRegistration\update_registered_content_types;
+
+/**
+ * Class SettingsFunctionsTestCases
+ *
+ * @package WPE_Content_Model
+ */
+class SettingsFunctionsTestCases extends WP_UnitTestCase {
+
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'wpe_content_model_post_types' );
+	}
+
+	/**
+	 * @covers ::\WPE\ContentModel\ContentRegistration\get_register_content_types()
+	 */
+	public function test_get_registered_content_types_returns_empty_array_when_no_content_types_exist(): void {
+		self::assertSame( get_registered_content_types(), [] );
+	}
+
+	/**
+	 * @covers ::\WPE\ContentModel\ContentRegistration\get_register_content_types()
+	 */
+	public function test_get_registered_content_types_returns_expected_data(): void {
+		update_registered_content_types( $this->expected_post_types() );
+		self::assertSame( get_registered_content_types(), $this->expected_post_types() );
+	}
+
+	/**
+	 * @covers ::\WPE\ContentModel\ContentRegistration\update_registered_content_type()
+	 */
+	public function test_update_registered_content_type_returns_false_when_specified_content_type_does_not_exist(): void {
+		self::assertFalse( update_registered_content_type( 'nope', [] ) );
+	}
+
+	/**
+	 * @covers ::\WPE\ContentModel\ContentRegistration\update_registered_content_type()
+	 */
+	public function test_update_registered_content_type_properly_updates_existing_content_type(): void {
+		$org = $this->expected_post_types();
+		update_registered_content_types( $org );
+
+		$new = $org;
+		$new['cat']['show_in_graphql'] = true;
+
+		self::assertTrue( update_registered_content_type( 'cat', $new['cat'] ) );
+		self::assertSame( get_registered_content_types(), $new );
+	}
+
+	/**
+	 * @covers ::\WPE\ContentModel\ContentRegistration\update_registered_content_types()
+	 */
+	public function test_update_registered_content_types_saves_to_database(): void {
+		self::assertTrue( update_registered_content_types( $this->expected_post_types() ) );
+		self::assertSame( get_registered_content_types(), $this->expected_post_types() );
+	}
+	private function expected_post_types(): array {
+		return include __DIR__ . '/example-data/expected-post-types.php';
+	}
+}

--- a/wpe-content-model.php
+++ b/wpe-content-model.php
@@ -29,4 +29,5 @@ add_action( 'plugins_loaded', 'wpe_content_model_loader' );
 function wpe_content_model_loader(): void {
 	require_once __DIR__ . '/includes/settings/settings-callbacks.php';
 	require_once __DIR__ . '/includes/content-registration/custom-post-types-registration.php';
+	require_once __DIR__ . '/includes/rest-api/rest-api-endpoint-registration.php';
 }


### PR DESCRIPTION
First part of BH-876. JS app parts to come in another PR.

Add REST API routes for creating, deleting, and fetching a content model definition.

Add helper functions for saving content model definitions to the database.

Add tests for helper functions.