### PR TITLE
Make REST status for unsuccessful field creation 400 instead of 200

### DIFF
--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -158,7 +158,7 @@ function dispatch_create_content_model_field( WP_REST_Request $request ) {
 		return new WP_Error(
 			'wpe_invalid_content_model',
 			'The specified content model does not exist.',
-			array( 'status' => 404 )
+			array( 'status' => 400 )
 		);
 	}
 

--- a/tests/integration/content-registration/test-rest-field-endpoint.php
+++ b/tests/integration/content-registration/test-rest-field-endpoint.php
@@ -48,7 +48,7 @@ class TestRestFieldEndpoint extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 400, $response->get_status() );
 		$this->assertArrayHasKey( 'message', $data );
 		$this->assertEquals( 'The specified content model does not exist.', $data[ 'message' ] );
 	}


### PR DESCRIPTION
So that failed REST requests to create a field return a non-200 status.