### PR TITLE
refactor: pass 'text' instead of 'new' field type

### DIFF
--- a/includes/settings/js/src/components/EditContentModel.jsx
+++ b/includes/settings/js/src/components/EditContentModel.jsx
@@ -34,7 +34,7 @@ export default function EditContentModel() {
 	function addField(position) {
 		const newId = Date.now();
 		setFields(oldFields => {
-			const newData = { ...oldFields.data, [newId]: { id: newId, type: 'new', open: true, position } }
+			const newData = { ...oldFields.data, [newId]: { id: newId, type: 'text', open: true, position } }
 			return { data: newData, order: getFieldOrder(newData) };
 		});
 	}

--- a/includes/settings/js/src/components/fields/Field.jsx
+++ b/includes/settings/js/src/components/fields/Field.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState} from 'react';
 import MediaForm from "./MediaForm";
 import TextForm from "./TextForm";
 import NumberForm from "./NumberForm";
@@ -7,13 +7,6 @@ import {AddIcon, OptionsIcon, ReorderIcon, TextIcon, BooleanIcon, NumberIcon, Me
 
 function Field({type='text', position, open=false, cancelAction, id, data={}, addAction, updateAction, positionAfter}) {
 	const [activeForm, setActiveForm] = useState(type);
-
-	useEffect(() => {
-		if ( type === 'new' ) {
-			type = 'text';
-			setActiveForm(type)
-		}
-	}, [])
 
 	function showTypeIcon() {
 		switch(type) {


### PR DESCRIPTION
Removes unnecessary useEffect in Field.jsx.

The 'open' prop denotes a field that should be open and treated as new or editable; the 'new' type is not used.

This prevents the flicker on the Text button when first opening a new field form. The form no longer needs to re-render when useEffect changes the type from 'new' to 'text'.