### PR TITLE
chore: add Babel and test files to zipignore

### DIFF
--- a/.zipignore
+++ b/.zipignore
@@ -1,6 +1,8 @@
 *.git*
 *.DS_Store*
 *.babelrc*
+*.cache/*
+*.idea/*
 *.eslintignore*
 *.eslintrc.json*
 *.circleci*
@@ -25,3 +27,6 @@ deploy.sh
 *package-lock.json*
 *.zipignore
 *.docker/*
+codeception.dist.yml
+.env.testing.sample
+.env.testing


### PR DESCRIPTION
So that running this command (from the directory above the plugin) does not include unwanted files.

```
zip --verbose -x@wpe-content-model/.zipignore -r "wpe-content-model.0.1.0.zip" wpe-content-model
```