### PR TITLE
fix: Exclude docker/codeception configs from zip

### DIFF
--- a/.zipignore
+++ b/.zipignore
@@ -27,6 +27,7 @@ deploy.sh
 *package-lock.json*
 *.zipignore
 *.docker/*
-codeception.dist.yml
+*docker-compose.yml
+*codeception.dist.yml
 .env.testing.sample
 .env.testing


### PR DESCRIPTION
### To test
1. `npm run build`
2. `cd .. && zip --verbose -x@wpe-content-model/.zipignore -r "wpe-content-model.0.1.0.zip" wpe-content-model`
3. Unzip the zip file.

The folder should not contain docker, codeception, or other developer config files.