### PR TITLE
BH-920: Execute `npm run build` before bundling plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,28 @@ jobs:
           json: build/<<parameters.slug>>.$BUILD_VERSION.json
           version: $BUILD_VERSION
 
+  plugin-npm-build:
+    executor:
+      name: node/default
+      tag: lts
+    parameters:
+      slug:
+        type: string
+    working_directory: .
+    steps:
+      - attach_workspace:
+          at: .
+      - node/install-packages:
+          app-dir: <<parameters.slug>>
+      - run:
+          name: NPM build
+          command: |
+            npm run build
+          working_directory: <<parameters.slug>>
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
 
 workflows:
   # Workflows defined for each package and plugin.
@@ -216,10 +238,14 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - plugin-bundle-zip:
+      - plugin-npm-build:
           slug: wpe-content-model
           requires:
             - plugin-test
+      - plugin-bundle-zip:
+          slug: wpe-content-model
+          requires:
+            - plugin-npm-build
           # Run this job on every commit/PR so the plugin is available as a build artifact
           filters:
             tags:


### PR DESCRIPTION
Add plugin-npm-build job.
    
Add job to workflow.
    
Require plugin-npm-build before running plugin-bundle-zip.
