### PR TITLE
design: remove form box shadow when editing fields

### DIFF
--- a/includes/settings/js/src/components/fields/Field.jsx
+++ b/includes/settings/js/src/components/fields/Field.jsx
@@ -115,7 +115,7 @@ function Field({
 					})}
 				</div>
 			)}
-			<div className="field-form">
+			<div className={editing ? 'field-form editing' : 'field-form'}>
 				<h3>
 					{editing ? `Editing` : `New`} {formFieldTitle} Field
 				</h3>

--- a/includes/settings/scss/_open-field.scss
+++ b/includes/settings/scss/_open-field.scss
@@ -41,6 +41,10 @@ li.open-field {
 	padding: 32px;
 }
 
+.field-form.editing {
+	box-shadow: none;
+}
+
 .field-form h3 {
 	margin: 0;
 	font-weight: 700;


### PR DESCRIPTION
Removes the shadow above the form when editing a field to address feedback from Mikolaj.

This shadow should only appear when adding a new field. (It separates the form from the field selector buttons above the form.)

The difference is subtle but you can see it on the top edge of the form:

### Before

<img width="1309" alt="Screenshot 2021-03-25 at 18 21 12" src="https://user-images.githubusercontent.com/647669/112516155-4872e700-8d97-11eb-82c0-be694c7f035d.png">

### After

<img width="1316" alt="Screenshot 2021-03-25 at 18 21 36" src="https://user-images.githubusercontent.com/647669/112516175-4d379b00-8d97-11eb-86e0-4b6c445e73ee.png">

