### PR TITLE
fix: Use lowercase for new model menu slugs

### DIFF
--- a/includes/settings/js/src/utils.js
+++ b/includes/settings/js/src/utils.js
@@ -32,7 +32,8 @@ export function insertSidebarMenuItem(model) {
  * @returns {string} - HTML list item markup for the specified content model.
  */
 export function generateSidebarMenuItem(model) {
-	const {slug, labels: {name}} = model;
+	let {slug, labels: {name}} = model;
+	slug = slug.toLowerCase();
 	return (
 		`<li class="wp-has-submenu wp-not-current-submenu menu-top menu-icon-${slug}" id="menu-posts-${slug}">
 				<a href="edit.php?post_type=${slug}" class="wp-has-submenu wp-not-current-submenu menu-top menu-icon-${slug}" aria-haspopup="true">


### PR DESCRIPTION
Corrects the dynamically created menu item link for new models with a camelCase API ID.

### To test
1. Create a new model with plural name "Rabbit Food".
2. Click the "Rabbit Food" posts menu item in the admin sidebar.

It should resolve to `/wp-admin/edit.php?post_type=rabbitfood` instead of `/wp-admin/edit.php?post_type=rabbitFood`.