### PR TITLE
fix: Correct empty repeater add button placement

### DIFF
--- a/includes/settings/js/src/components/fields/Repeater.jsx
+++ b/includes/settings/js/src/components/fields/Repeater.jsx
@@ -61,7 +61,7 @@ const Repeater = ({fields={}, model, parent, setInfoTag}) => {
 					</ul>
 				) : (
 					<>
-						<ul className="subfield-list">
+						<ul className="subfield-list empty">
 							<li className="empty">
 								<span>&nbsp;</span>
 								<span>&nbsp;</span>

--- a/includes/settings/scss/_field-list.scss
+++ b/includes/settings/scss/_field-list.scss
@@ -114,6 +114,10 @@
 	margin-top: -16px;
 }
 
+.subfield-list.empty .add-item {
+	margin-top: -48px;
+}
+
 .subfield-list .add-item button {
 	height: 32px;
 	margin-left: -4px;


### PR DESCRIPTION
#47 introduced a visual regression when a repeater field has no subfields. This PR corrects it.

### Before
<img width="1303" alt="Screenshot 2021-04-06 at 12 19 59" src="https://user-images.githubusercontent.com/647669/113696531-6e22b900-96d2-11eb-8848-c64b6e5b9f10.png">

### After
<img width="1283" alt="Screenshot 2021-04-06 at 12 19 46" src="https://user-images.githubusercontent.com/647669/113696548-74189a00-96d2-11eb-88e8-08cfa98435d0.png">
