### PR TITLE
design: use white background for field color

### DIFF
--- a/includes/settings/js/src/components/fields/Field.jsx
+++ b/includes/settings/js/src/components/fields/Field.jsx
@@ -50,18 +50,18 @@ function Field({
 							provided.draggableProps.style
 						)}
 					>
-						<li className="closed" key={id}>
-					<span className="reorder">
-						<button
-							{...provided.dragHandleProps}
-							onFocus={() => {
-								setInfoTag(reorderInfoTag);
-							}}
-							onBlur={() => setInfoTag(null)}
-						>
-							<Icon type="reorder"/>
-						</button>
-					</span>
+						<li key={id} className={snapshot.isDragging ? "closed dragging" : "closed"}>
+							<span className="reorder">
+								<button
+									{...provided.dragHandleProps}
+									onFocus={() => {
+										setInfoTag(reorderInfoTag);
+									}}
+									onBlur={() => setInfoTag(null)}
+								>
+									<Icon type="reorder"/>
+								</button>
+							</span>
 							<button
 								className="edit"
 								onClick={() => dispatch({type: 'openField', id: data.id, model: model.slug})}
@@ -81,7 +81,7 @@ function Field({
 								)
 							}
 						</li>
-						<li className="add-item">
+						<li className={snapshot.isDragging ? "add-item dragging" : "add-item"}>
 							<button
 								onClick={() => dispatch({
 									type: 'addField',

--- a/includes/settings/scss/_field-list.scss
+++ b/includes/settings/scss/_field-list.scss
@@ -1,10 +1,19 @@
 @import 'variables';
 
 .field-list li {
+	background: $color-white;
 	display: flex;
 	flex-flow: wrap;
 	justify-content: space-between;
 	margin-bottom: 32px;
+}
+
+.field-list li.dragging {
+	opacity: 0.8;
+}
+
+.field-list li.add-item {
+	background: transparent;
 }
 
 .field-list li.closed:hover {


### PR DESCRIPTION
Instead of a transparent background.

Also sets field opacity to 0.8 during drag-and-drop.

In response to design feedback from Mikolaj.