### PR TITLE
BH-975: Add plugin update checking functionality.

### DIFF
--- a/includes/updates/update-callbacks.php
+++ b/includes/updates/update-callbacks.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Plugin updates related callbacks.
+ *
+ * @package WPE_Content_Model
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter( 'pre_set_site_transient_update_plugins', 'wpe_content_model_check_for_plugin_updates' );
+/**
+ * Callback for WordPress 'pre_set_site_transient_update_plugins' filter.
+ *
+ * Check for plugin updates by retrieving data from the plugin update source.
+ *
+ * This will let WordPress know an update is available.
+ *
+ * @param object $data WordPress update object.
+ *
+ * @return object $data An updated object if an update exists, default object if not.
+ */
+function wpe_content_model_check_for_plugin_updates( $data ) {
+	if ( empty( $data ) ) {
+		return $data;
+	}
+
+	$response = wpe_content_model_get_remote_plugin_info();
+	if ( empty( $response->requires_at_least ) || empty( $response->version ) ) {
+		return $data;
+	}
+
+	$current_plugin_data = get_plugin_data( WPE_CONTENT_MODEL_FILE );
+	$meets_wp_req        = version_compare( get_bloginfo( 'version' ), $response->requires_at_least, '>=' );
+
+	// Only update the response if there's a newer version, otherwise WP shows an update notice for the same version.
+	if ( $meets_wp_req && version_compare( $current_plugin_data['Version'], $response->version, '<' ) ) {
+		$response->plugin                         = plugin_basename( WPE_CONTENT_MODEL_FILE );
+		$data->response[ WPE_CONTENT_MODEL_PATH ] = $response;
+	}
+
+	return $data;
+}
+
+add_filter( 'plugins_api', 'wpe_content_model_custom_plugin_api_request', 10, 3 );
+/**
+ * Callback for WordPress 'plugins_api' filter.
+ *
+ * Return a custom response for this plugin from the custom endpoint.
+ *
+ * @link https://developer.wordpress.org/reference/hooks/plugins_api/
+ *
+ * @param false|object|array $api The result object or array. Default false.
+ * @param string             $action The type of information being requested from the Plugin Installation API.
+ * @param object             $args Plugin API arguments.
+ *
+ * @return false|stdClass $response Plugin API arguments.
+ */
+function wpe_content_model_custom_plugin_api_request( $api, $action, $args ) {
+	if ( empty( $args->slug ) || WPE_CONTENT_MODEL_SLUG !== $args->slug ) {
+		return $api;
+	}
+
+	$response = wpe_content_model_get_plugin_data( $args );
+	if ( empty( $response ) || is_wp_error( $response ) ) {
+		return $api;
+	}
+
+	return $response;
+}
+
+add_action( 'admin_notices', 'wpe_content_model_delegate_plugin_row_notice' );
+/**
+ * Callback for WordPress 'admin_notices' action.
+ *
+ * Delegate actions to display an error message on the plugin table row if present.
+ *
+ * @link https://developer.wordpress.org/reference/hooks/admin_notices/
+ *
+ * @return void
+ */
+function wpe_content_model_delegate_plugin_row_notice() {
+	$screen = get_current_screen();
+	if ( 'plugins' !== $screen->id ) {
+		return;
+	}
+
+	$error = wpe_content_model_get_plugin_api_error();
+	if ( ! $error ) {
+		return;
+	}
+
+	$plugin_basename = plugin_basename( WPE_CONTENT_MODEL_FILE );
+
+	remove_action( "after_plugin_row_{$plugin_basename}", 'wp_plugin_update_row' );
+	add_action( "after_plugin_row_{$plugin_basename}", 'wpe_content_model_display_plugin_row_notice', 10, 2 );
+}
+
+/**
+ * Callback for WordPress 'after_plugin_row_{plugin_basename}' action.
+ *
+ * Callback added in wpe_content_model_add_plugin_page_notices().
+ *
+ * Show a notice in the plugin table row when there is an error present.
+ *
+ * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+ * @param array  $plugin_data An array of plugin data.
+ *
+ * @return void
+ */
+function wpe_content_model_display_plugin_row_notice( $plugin_file, $plugin_data ) {
+	$error = wpe_content_model_get_plugin_api_error();
+
+	?>
+	<tr class="plugin-update-tr active" id="wpe-content-model-update" data-slug="wpe-content-model" data-plugin="wpe-content-model/wpe-content-model.php">
+		<td colspan="3" class="plugin-update">
+			<div class="update-message notice inline notice-error notice-alt">
+				<p>
+					<?php echo wp_kses_post( wpe_content_model_get_api_error_text( $error ) ); ?>
+				</p>
+			</div>
+		</td>
+	</tr>
+	<?php
+}
+
+add_action( 'admin_notices', 'wpe_content_model_display_update_page_notice' );
+/**
+ * Callback for WordPress 'admin_notices' action.
+ *
+ * Display an error notice on the "WordPress Updates" page if present.
+ *
+ * @link https://developer.wordpress.org/reference/hooks/admin_notices/
+ *
+ * @return void
+ */
+function wpe_content_model_display_update_page_notice() {
+	$screen = get_current_screen();
+	if ( 'update-core' !== $screen->id ) {
+		return;
+	}
+
+	$error = wpe_content_model_get_plugin_api_error();
+	if ( ! $error ) {
+		return;
+	}
+
+	?>
+	<div class="error">
+		<p>
+			<?php echo wp_kses_post( wpe_content_model_get_api_error_text( $error ) ); ?>
+		</p>
+	</div>
+	<?php
+}

--- a/includes/updates/update-functions.php
+++ b/includes/updates/update-functions.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Plugin updates related functions.
+ *
+ * @package WPE_Content_Model
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Retrieve and convert custom endpoint response for the WordPress plugin api.
+ *
+ * Retrieve data from a custom endpoint then create a custom object that can be used by WordPress.
+ *
+ * @param object $args Plugin API arguments.
+ *
+ * @return false|stdClass $api Plugin API arguments.
+ */
+function wpe_content_model_get_plugin_data( object $args ) {
+	$product_info = wpe_content_model_get_remote_plugin_info();
+	if ( empty( $product_info ) || is_wp_error( $product_info ) ) {
+		return;
+	}
+
+	$current_plugin_data = get_plugin_data( WPE_CONTENT_MODEL_FILE );
+	$meets_wp_req        = version_compare( get_bloginfo( 'version' ), $product_info->requires_at_least, '>=' );
+
+	$api                        = new stdClass();
+	$api->author                = 'WP Engine';
+	$api->homepage              = 'https://wpengine.com';
+	$api->name                  = $product_info->name;
+	$api->requires              = isset( $product_info->requires_at_least ) ? $product_info->requires_at_least : $current_plugin_data['RequiresWP'];
+	$api->sections['changelog'] = isset( $product_info->sections->changelog ) ? $product_info->sections->changelog : '<h4>1.0</h4><ul><li>Initial release.</li></ul>';
+	$api->slug                  = $args->slug;
+
+	// Only pass along the update info if the requirements are met and there's actually a newer version.
+	if ( $meets_wp_req && version_compare( $current_plugin_data['Version'], $product_info->version, '<' ) ) {
+		$api->version       = $product_info->version;
+		$api->download_link = $product_info->download_link;
+	}
+
+	return $api;
+}
+
+/**
+ * Fetches and returns the plugin info api error.
+ *
+ * @return mixed|false The plugin api error or false.
+ */
+function wpe_content_model_get_plugin_api_error() {
+	return get_option( 'wpe_content_model_product_info_api_error', false );
+}
+
+/**
+ * Retrieve remote plugin information from the custom endpoint.
+ *
+ * @return stdClass
+ */
+function wpe_content_model_get_remote_plugin_info() {
+	$current_plugin_data = get_plugin_data( WPE_CONTENT_MODEL_FILE );
+	$response            = get_transient( 'wpe_content_model_product_info' );
+
+	if ( false === $response ) {
+		$request_args = array(
+			'timeout'    => ( ( defined( 'DOING_CRON' ) && DOING_CRON ) ? 30 : 3 ),
+			'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ),
+			'body'       => array(
+				'version' => $current_plugin_data['Version'],
+			),
+		);
+
+		$response = wpe_content_model_request_plugin_updates( $request_args );
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			if ( is_wp_error( $response ) ) {
+				update_option( 'wpe_content_model_product_info_api_error', $response->get_error_code(), false );
+			} else {
+				$response_body = json_decode( wp_remote_retrieve_body( $response ), false );
+				$error_code    = ! empty( $response_body->error_code ) ? $response_body->error_code : 'unknown';
+				update_option( 'wpe_content_model_product_info_api_error', $error_code, false );
+			}
+
+			$response = new stdClass();
+
+			set_transient( 'wpe_content_model_product_info', $response, MINUTE_IN_SECONDS * 5 );
+
+			return $response;
+		}
+
+		delete_option( 'wpe_content_model_product_info_api_error' );
+
+		$response = json_decode(
+			wp_remote_retrieve_body( $response )
+		);
+
+		set_transient( 'wpe_content_model_product_info', $response, HOUR_IN_SECONDS * 12 );
+	}
+
+	return $response;
+}
+
+/**
+ * Get the remote plugin api error message.
+ *
+ * @param string $reason The reason/error code received the API.
+ *
+ * @return string The error message.
+ */
+function wpe_content_model_get_api_error_text( $reason ) {
+	switch ( $reason ) {
+		case 'key-unknown':
+			return __( 'The product you requested information for is unknown. Please contact support.', 'wpe-content-model' );
+
+		default:
+			/* translators: %1$s: Link to account portal. %2$s: The text that is linked. */
+			return sprintf(
+				__(
+					'There was an unknown error connecting to the update service. This issue could be temporary. Please contact support if this error persists.',
+					'wpe-content-model'
+				),
+				'https://my.wpengine.com/products',
+				esc_html__( 'WP Engine Account Portal', 'wpe-content-model' )
+			);
+	}
+}
+
+/**
+ * Retrieve plugin update information via http GET request.
+ *
+ * @uses wp_remote_get()
+ * @link https://developer.wordpress.org/reference/functions/wp_remote_get/
+ *
+ * @param array $args Array of request args.
+ *
+ * @return array|WP_Error A response as an array or WP_Error.
+ */
+function wpe_content_model_request_plugin_updates( $args ) {
+	return wp_remote_get(
+		'https://wp-product-info.wpesvc.net/v1/plugins/wpe-content-model',
+		$args
+	);
+}

--- a/wpe-content-model.php
+++ b/wpe-content-model.php
@@ -31,6 +31,8 @@ function wpe_content_model_loader(): void {
 	require_once __DIR__ . '/includes/content-registration/custom-post-types-registration.php';
 	require_once __DIR__ . '/includes/rest-api/rest-api-endpoint-registration.php';
 	require_once __DIR__ . '/includes/publisher/class-publisher-form-editing-experience.php';
+	require_once WPE_CONTENT_MODEL_DIR . '/includes/updates/update-functions.php';
+	require_once WPE_CONTENT_MODEL_DIR . '/includes/updates/update-callbacks.php';
 
 	$form_editing_experience = new \WPE\ContentModel\FormEditingExperience();
 	$form_editing_experience->bootstrap();


### PR DESCRIPTION
Communicates with WPE's wp-product-info service to get update information.

Plugin information received from wp-product-info is stored in the `wpe_content_model_product_info` transient.

Error information received from wp-product-info is stored in the `wpe_content_model_product_info_api_error` option, and is cleared upon a successful communication with the service.

Adapted from previous work in wpe-headless plugin.

### Testing steps
**Note:** make sure you test this on a site where you don't have existing git stashes or anything else you don't want to lose. Updating the plugin from this branch will result in the whole folder being replaced by WP, and anything you had saved in git will be lost.

- [x] Install the [Transients Manager](https://wordpress.org/plugins/transients-manager/) plugin. You'll need this to clear the plugin info transient mentioned above.
- [x] Check for updates
- [x] Go to Tools > Transients and verify the `wpe_content_model_product_info` exists with a proper object.

To test an error communicating with the info service:
- [x] Open `update-functions.php`, find `wpe_content_model_request_plugin_updates()`, and edit the host name to a bad host, or update the endpoint after `plugins` to be incorrect so that it triggers an error.
- [x] Delete all transients.
- [x] Check for updates.
- [x] See error messages under Dashboard > Updates and Plugins > Installed Plugins

To test a successful update:
- [x] Edit the plugin version in `wpe-content-model.php` to `0.0.1` or something lower than the current version.
- [x] Delete all transients.
- [x] Check for updates again. You should see that an update is available under Dashboard > Updates and Plugins > Installed Plugins.
- [x] Note that errors are now gone.
- [x] Install the update and ensure it updated.