### PR TITLE
fix: Ensure publisher entry data is saved for models with camelCase names

### DIFF
--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -14,6 +14,7 @@ export default function Field(props) {
 
 // @todo wire up to react-hook-form, validate data, display errors.
 function fieldMarkup(field, modelSlug) {
+	modelSlug = modelSlug.toLowerCase();
 	switch (field.type) {
 		case "media":
 			return <MediaUploader field={field} modelSlug={modelSlug} />;


### PR DESCRIPTION
No entry data gets saved for models with camelCase names at the moment  because field name attributes look like `wpe-content-model[jazzCats][name]`. (Camelcase `jazzCats`.)

This PR converts model names to lowercase to give `wpe-content-model[jazzcats][name]`, which is what WP needs to save the post meta.

## To test
1. Create a model called “Jazz Cats” with one field.
2. Add a new Jazz Cat.

You should see the data you entered into the field after refreshing the entry.