### PR TITLE
fix: camelcase and strip spaces from GraphQL names

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -180,8 +180,8 @@ function generate_custom_post_type_args( array $args ): array {
 		'taxonomies'          => $args['taxonomies'] ?? [],
 		'labels'              => $labels,
 		'show_in_graphql'     => $args['show_in_graphql'] ?? true,
-		'graphql_single_name' => $args['graphql_single_name'] ?? lcfirst( $singular ),
-		'graphql_plural_name' => $args['graphql_plural_name'] ?? lcfirst( $plural ),
+		'graphql_single_name' => $args['graphql_single_name'] ?? camelcase( $singular ),
+		'graphql_plural_name' => $args['graphql_plural_name'] ?? camelcase( $plural ),
 	];
 }
 


### PR DESCRIPTION
So that multi-word models work correctly in GraphQL queries.

WPGraphQL expects a [“camel case string with no punctuation or spaces”](https://www.wpgraphql.com/docs/custom-post-types/) in single and plural names, so we need to strip spaces. Our existing `camelcase()` function does this and also calls `lcfirst()`.

### To test
1. Delete any existing multi-word models you had created.
2. Create a new model named “Soul Dogs” with one field.
3. Create a new Soul Dog entry.
3. Run this query at GraphQL → GraphiQL IDE:

```
{
  soulDogs(first: 10) {
    nodes {
      ...SoulDogFields
    }
  }
}

fragment SoulDogFields on SoulDog {
  title
}
```

You should see a good response instead of an error.
