### PR TITLE
tools: make phpcs ignore node_modules

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -7,6 +7,7 @@
 	<!-- Exclude composer vendor directory -->
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/tests/</exclude-pattern>
+	<exclude-pattern>/node_modules/</exclude-pattern>
 
 	<!-- Exclude CircleCI composer file -->
 	<exclude-pattern>composer-setup.php</exclude-pattern>


### PR DESCRIPTION
The 'flatted' JS dependency contains PHP that is currently picked up by phpcs.