### PR TITLE
tools: do not lint JS in dist folders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
 		sourceType: "module",
 	},
 	extends: ["plugin:react/recommended", "plugin:prettier/recommended"],
+	ignorePatterns: ["**/dist/*.js*"],
 	plugins: [],
 	// add your custom rules here
 	rules: {


### PR DESCRIPTION
`npm run lint` was picking up `wpe-content-model/includes/settings/dist/index.js`, which we don't need to lint because it's a built file.
