### PR TITLE
fix: use title in GraphQL query if model has no fields

### DIFF
--- a/includes/settings/js/src/utils.js
+++ b/includes/settings/js/src/utils.js
@@ -107,6 +107,10 @@ export const getGraphiQLLink = (modelData) => {
 		.filter((id) => fields[id]?.type !== "repeater") // @todo: handle repeater fields.
 		.map((id) => fields[id]?.slug);
 
+	if (fieldSlugs.length === 0) {
+		fieldSlugs.push("title");
+	}
+
 	const query = `
 {
   ${modelData.slug}(first: 10) {


### PR DESCRIPTION
Without this, models without fields would not load in GraphiQL should someone click “Open in GraphiQL” on that model.

An alternative is to hide the “Open in GraphiQL” model option if a model has no fields, but this seems better for consistency.

### To test
With the WPGraphQL plugin installed and active:

1. Create a model with no fields.
2. Use “Open in GraphiQL” from the model options.

GraphiQL should open with a query that uses the `title`.