### PR TITLE
ci: Adjust filters configuration on CircleCI workflow jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ workflows:
           filename: wpe-content-model.php
           requires:
             - checkout
-          # Enable running this job when a tag is published
+          # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
@@ -346,7 +346,7 @@ workflows:
           slug: wpe-content-model
           requires:
             - plugin-checkout
-          # Enable running this job when a tag is published
+          # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
@@ -354,7 +354,7 @@ workflows:
           slug: wpe-content-model
           requires:
             - plugin-composer
-          # Enable running this job when a tag is published
+          # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
@@ -362,9 +362,17 @@ workflows:
           slug: wpe-content-model
           requires:
             - plugin-test
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
       - plugin-e2e-test:
           requires:
             - plugin-npm-build
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
       - plugin-bundle-zip:
           slug: wpe-content-model
           requires:


### PR DESCRIPTION
This PR adjusts the configuration of the `plugin-npm-build` and `plugin-e2e-tests` jobs in the workflow so that they run on every commit and tag.

Previous attempts to deploy a tagged release failed because these jobs did not run. See https://app.circleci.com/pipelines/github/wpengine/wpe-content-model/544/workflows/ef992fd4-49a5-4e7e-aee9-f042e1765c6d

fix: Updated existing comments to better reflect what they describe.