### PR TITLE
BH-984: improve client-side validation of fields

### DIFF
--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -2,20 +2,49 @@ import React, { useState } from "react";
 import MediaUploader from "./MediaUploader";
 import Icon from "../../../../components/icons";
 
+const defaultError = "This field is required";
+
 export default function Field(props) {
 	const { field, modelSlug } = props;
+	const [errors, setErrors] = useState({});
+
+	/**
+	 * Adjusts the custom error feedback messages displayed below fields based
+	 * on the HTML5 validation failure type.
+	 *
+	 * @param {object} event onChange
+	 * @param {object} field
+	 */
+	function validate(event, field) {
+		if (event.target.validity.valid) {
+			return;
+		}
+
+		let error = defaultError;
+
+		if (field.type === "text") {
+			if (event.target.validity.tooShort) {
+				error = "Text is too short";
+			} else if (event.target.validity.tooLong) {
+				error = "Text is too long";
+			}
+		}
+
+		setErrors({ ...errors, [field.slug]: error });
+	}
+
 	return (
 		<>
 			<div id={`field-${field.slug}`} className={`field ${field.type}`}>
-				{fieldMarkup(field, modelSlug)}
+				{fieldMarkup(field, modelSlug, errors, validate)}
 			</div>
 		</>
 	);
 }
 
-// @todo wire up to react-hook-form, validate data, display errors.
-function fieldMarkup(field, modelSlug) {
+function fieldMarkup(field, modelSlug, errors, validate) {
 	modelSlug = modelSlug.toLowerCase();
+
 	switch (field.type) {
 		case "media":
 			return (
@@ -26,6 +55,31 @@ function fieldMarkup(field, modelSlug) {
 				/>
 			);
 		case "text":
+			return (
+				<>
+					<label
+						htmlFor={`wpe-content-model[${modelSlug}][${field.slug}]`}
+					>
+						{field.name}
+					</label>
+					<br />
+					<input
+						type={`${field.type}`}
+						name={`wpe-content-model[${modelSlug}][${field.slug}]`}
+						id={`wpe-content-model[${modelSlug}][${field.slug}]`}
+						defaultValue={field.value}
+						required={field.required}
+						onChange={(event) => validate(event, field)}
+						maxLength={field.textLength === "short" ? 50 : 500}
+					/>
+					<span className="error">
+						<Icon type="error" />
+						<span role="alert">
+							{errors[field.slug] ?? defaultError}
+						</span>
+					</span>
+				</>
+			);
 		case "number": // @todo split this out to support mix/max/step/etc.
 		case "date": // @todo split this out for proper browser and datepicker support
 			return (
@@ -45,7 +99,7 @@ function fieldMarkup(field, modelSlug) {
 					/>
 					<span className="error">
 						<Icon type="error" />
-						<span role="alert">This field is required</span>
+						<span role="alert">{defaultError}</span>
 					</span>
 				</>
 			);
@@ -67,7 +121,7 @@ function fieldMarkup(field, modelSlug) {
 					/>
 					<span className="error">
 						<Icon type="error" />
-						<span role="alert">This field is required</span>
+						<span role="alert">{defaultError}</span>
 					</span>
 				</>
 			);
@@ -91,7 +145,7 @@ function fieldMarkup(field, modelSlug) {
 						/>
 						<span className="error">
 							<Icon type="error" />
-							<span role="alert">This field is required</span>
+							<span role="alert">{defaultError}</span>
 						</span>
 						{/* span is used for custom checkbox styling purposes */}
 						<span className="checkmark"></span>


### PR DESCRIPTION
- Adds maxLength to the text field to enforce the textLength field property on the client side.
- Adds an example of inline client side errors to fields for min/max text length.

https://user-images.githubusercontent.com/647669/119130540-a68b1600-ba38-11eb-9b20-23ece475730f.mp4

### Notes
The max length error is not visible in most browsers because they hard-limit the field length to maxlength, so it can never exceed it. (This is also why I have not submitted an acceptance test in this PR.)

We don't currently set a minlength property on our input fields, but we plan to allow this in the future ([BH-997](https://wpengine.atlassian.net/browse/BH-997)). To see the min length error as in the screencast above you will need to add a minLength property to the text input in `includes/publisher/js/src/components/Field.jsx`.

