### PR TITLE
BH-995: hide “screen options” on publisher entries

### DIFF
--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -70,6 +70,7 @@ final class FormEditingExperience {
 		add_filter( 'redirect_post_location', [ $this, 'append_error_to_location' ], 10, 2 );
 		add_action( 'admin_notices', [ $this, 'display_save_post_errors' ] );
 		add_filter( 'the_title', [ $this, 'filter_post_titles' ], 10, 2 );
+		add_filter( 'screen_options_show_screen', [ $this, 'hide_screen_options' ], 10, 2 );
 	}
 
 	/**
@@ -387,5 +388,21 @@ final class FormEditingExperience {
 		// Use a generated title when entry title fields or field data are absent.
 		$post_type_singular = $this->models[ $post_type ]['singular_name'] ?? esc_html__( 'No Title', 'wpe-content-model' );
 		return $post_type_singular . ' ' . $id;
+	}
+
+	/**
+	 * Hides the “Screen Options” drop-down on post types registered by this plugin.
+	 *
+	 * @param bool       $show_screen The current state of the screen options dropdown.
+	 * @param \WP_Screen $screen Information about the current screen.
+	 *
+	 * @return bool The new state of the screen options dropdown. (False to disable.)
+	 */
+	public function hide_screen_options( bool $show_screen, $screen ): bool {
+		if ( in_array( $screen->post_type, array_keys( $this->models ), true ) ) {
+			return false;
+		}
+
+		return $show_screen;
 	}
 }


### PR DESCRIPTION
Removes the Screen Options drop-down from content model post type entry screens. Rationale:
- The drop-down has limited use.
- “Post published” notices currently overlay the drop-down due to our custom page title.

If we want to keep Screen Options, I can adjust the CSS for the notifications to prevent the overlay issue instead.

### Before

<img width="1224" alt="Screenshot 2021-05-27 at 13 38 19" src="https://user-images.githubusercontent.com/647669/119819794-0d08ac00-bef1-11eb-9eb0-033b8ca7b341.png">

<img width="1226" alt="Screenshot 2021-05-27 at 13 39 03" src="https://user-images.githubusercontent.com/647669/119819789-0bd77f00-bef1-11eb-973b-c1d6c3204424.png">

### After

<img width="1235" alt="Screenshot 2021-05-27 at 13 38 42" src="https://user-images.githubusercontent.com/647669/119819791-0c701580-bef1-11eb-8e64-7dc100ff0539.png">

<img width="1222" alt="Screenshot 2021-05-27 at 13 39 19" src="https://user-images.githubusercontent.com/647669/119819785-0aa65200-bef1-11eb-9e92-089fcf6719a7.png">

