### PR TITLE
Prevent intermittent “field is missing” error when clicking “Done” in Advanced Settings

### DIFF
--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -31,7 +31,10 @@ function Form({ id, position, type, editing, storedData }) {
 		setError,
 		reset,
 		trigger,
-	} = useForm({ mode: "onChange" });
+	} = useForm({
+		mode: "onChange",
+		defaultValues: storedData,
+	});
 	const [nameCount, setNameCount] = useState(storedData?.name?.length || 0);
 	const [optionsModalIsOpen, setOptionsModalIsOpen] = useState(false);
 	const { models, dispatch } = useContext(ModelsContext);
@@ -98,10 +101,9 @@ function Form({ id, position, type, editing, storedData }) {
 		if (type in advancedSettings) {
 			Object.keys(advancedSettings[type]["fields"]).forEach((field) => {
 				register(field, advancedSettings[type]["fields"][field]);
-				setValue(field, storedData[field]);
 			});
 		}
-	}, [register]);
+	}, [register, advancedSettings]);
 
 	function apiAddField(data) {
 		apiFetch({


### PR DESCRIPTION
Opening the Advanced Settings modal in a Text field and clicking “Done” would occasionally result in a “field is missing” warning for the fields in the modal, which prevented it from closing. (Thanks to @matthewguywright for reporting this.)

<img width="506" alt="Screenshot 2021-06-09 at 18 34 39" src="https://user-images.githubusercontent.com/647669/121487911-da6fb080-c9d2-11eb-9a56-38e67655b740.png">

This PR addresses the issue by:

- Making `advancedSettings` a dep of `useEffect`. This is designed to prevent possible timing issues where `useEffect` could run when `advancedSettings` is undefined, which would prevent fields from being registered (hence “field is missing”).
- Passing the value of the advanced fields into the form at the top level as `defaultValues` instead of using `setValue`. This prevents an issue (caused by the addition of `advancedSettings` as a useEffect dep) where values would be reset if you closed the modal with “Done” and then opened it again.

I haven't added tests because this is a timing issue. I found it hard to reproduce consistently locally, and I could not reproduce it at all in the Codeception environment. (We already have a test that clicks the modal's “Done” button and I couldn't get it to fail.)

For review purposes you can test like this:

1. Create a Text field.
2. Add a min and max value in the Advanced Settings.
3. Confirm that clicking “Done” closes the Advanced Settings modal.

It is expected to see modal fields clear if you click Cancel in the modal instead of Done for this PR's branch; that issue is fixed separately in #141.