### PR TITLE
BH-1052: Increase clickable area on dropdown menu items

### DIFF
--- a/includes/settings/scss/_model-list.scss
+++ b/includes/settings/scss/_model-list.scss
@@ -73,7 +73,6 @@
 }
 
 .dropdown-content:not(.hidden) {
-	align-items: flex-start;
 	background: $color-white;
 	border-radius: 2px;
 	box-shadow: 0px 5px 20px rgba(68, 68, 68, 0.15);
@@ -81,17 +80,16 @@
 	flex-direction: column;
 	height: auto;
 	justify-content: center;
-	padding: 10px 20px;
+	padding: 10px 0;
 	position: absolute;
 	right: -4px;
 	z-index: 100;
 
 	a {
-		align-items: center;
 		color: $color-primary;
-		display: flex;
+		display: block;
 		line-height: 25px;
-		margin: 5px auto;
+		padding: 5px 20px;
 		text-align: center;
 		text-decoration: none;
 		white-space: nowrap;


### PR DESCRIPTION
### Before
<img width="195" alt="Screen Shot 2021-06-11 at 10 34 18 AM" src="https://user-images.githubusercontent.com/4661832/121703279-a9f64800-caa0-11eb-88d3-46ce704d4e76.png">
<img width="202" alt="Screen Shot 2021-06-11 at 10 34 26 AM" src="https://user-images.githubusercontent.com/4661832/121703306-af539280-caa0-11eb-9842-50bc0ceff4bd.png">

----

### After
<img width="191" alt="Screen Shot 2021-06-11 at 11 50 36 AM" src="https://user-images.githubusercontent.com/4661832/121713913-5d643a00-caab-11eb-919c-24ec6fc4a757.png">
<img width="189" alt="Screen Shot 2021-06-11 at 11 50 47 AM" src="https://user-images.githubusercontent.com/4661832/121713916-5d643a00-caab-11eb-9bcd-2c5f67450ff6.png">
