### PR TITLE
[BH-1060] Fix "Enter" key resetting edit form

### DIFF
--- a/includes/settings/js/src/components/ViewContentModelsList.jsx
+++ b/includes/settings/js/src/components/ViewContentModelsList.jsx
@@ -10,12 +10,15 @@ function Header({ showButton = true }) {
 		<section className="heading flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
 			<h2>Content Models</h2>
 			{showButton && (
-				<a
-					className="page-title-action"
-					href={atlasContentModeler.appPath + "&view=create-model"}
+				<button
+					onClick={() =>
+						history.push(
+							atlasContentModeler.appPath + "&view=create-model"
+						)
+					}
 				>
 					Add New
-				</a>
+				</button>
 			)}
 		</section>
 	);


### PR DESCRIPTION
This implements a simple fix to ignore the enter key on appropriate fields. This prevents the "reset" bug in BH-1060.

Note I'm not overly familiar with either React or this code base so please feel free to suggest an alternate approach if appropriate.

See screencast for validation:


https://user-images.githubusercontent.com/394675/121739364-80054b80-cac9-11eb-847d-26ea8cd43447.mov

