### PR TITLE
Fixes banner and bootstrap issues

### DIFF
--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -212,7 +212,7 @@ final class FormEditingExperience {
 		}
 
 		wp_nonce_field( 'atlas-content-modeler-pubex-nonce', 'atlas-content-modeler-pubex-nonce' );
-		echo '<div id="atlas-content-modeler-fields-app" class="wpe"></div>';
+		echo '<div id="atlas-content-modeler-fields-app" class="wpe atlas-content-modeler"></div>';
 	}
 
 	/**

--- a/includes/shared-assets/js/feedback-banner.js
+++ b/includes/shared-assets/js/feedback-banner.js
@@ -15,19 +15,13 @@ function feedbackTrigger() {
 
 // bind to feedback banner buttons to trigger API call
 window.addEventListener("DOMContentLoaded", (event) => {
+	const feedbackDismissBtnClass = "notice-dismiss";
 	const feedbackBtn = document.querySelector("#feedbackFormBtn");
-	const feedbackBanner = document.querySelector("#feedbackBanner");
-	let feedbackDismissBtn = null;
-	if (feedbackBanner) {
-		feedbackDismissBtn = feedbackBanner.getElementsByClassName(
-			"notice-dismiss"
-		);
-	}
 
 	document.addEventListener("click", (event) => {
 		if (
-			event.target === feedbackBtn ||
-			(feedbackDismissBtn && feedbackDismissBtn.length)
+			event.target.id === feedbackBtn.id ||
+			event.target.className === feedbackDismissBtnClass
 		) {
 			feedbackTrigger();
 		}


### PR DESCRIPTION
Bootstrap was not being activated since the atlas-content-modeler class was put on the id and removed from the class. I added it back onto the class.

The banner was triggering the banner js trigger everytime you clicked the page. Now it only happens on the close button or the bannerBtn.