### PR TITLE
Prevent custom fields from showing in REST when show_in_rest is false

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -58,6 +58,10 @@ function register_meta_types( string $post_type_slug, array $fields ): void {
 				$acm_fields = array();
 
 				foreach ( $fields as $key => $field ) {
+					if ( ! $field['show_in_rest'] ) {
+						continue;
+					}
+
 					$acm_fields[ $field['slug'] ] = handle_content_fields_for_rest_api( $post['id'], $field['type'], $field['slug'] );
 				}
 

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -141,7 +141,7 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 		$request  = new \WP_REST_Request( 'GET', $this->namespace . $this->dog_route . '/' . $this->dog_post_id );
 		$response = $this->server->dispatch( $request );
 		$response_data = $response->get_data();
-		$this->assertFalse( array_key_exists( 'another-dog-test-field', $response_data['meta'] ) );
+		$this->assertFalse( array_key_exists( 'another-dog-test-field', $response_data['acm_fields'] ) );
 	}
 
 	/**


### PR DESCRIPTION
One of our tests snuck by as passing when post meta was reinstated as `acm_fields`. This PR updates the test and adds logic to make sure `show_in_rest` is respected in the REST response for all custom fields.

I'm not sure that `show_in_rest` is configurable in the UI, so it may not be a very pressing issue yet.