### PR TITLE
Pass full field settings array for handling REST responses

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -62,7 +62,7 @@ function register_meta_types( string $post_type_slug, array $fields ): void {
 						continue;
 					}
 
-					$acm_fields[ $field['slug'] ] = handle_content_fields_for_rest_api( $post['id'], $field, $request );
+					$acm_fields[ $field['slug'] ] = handle_content_fields_for_rest_api( $post['id'], $field );
 				}
 
 				return $acm_fields;


### PR DESCRIPTION
Follows #157 

Given that we may want to shape the REST response for other field types, it could be useful to have access to the full field settings array. For example, we might want to cast number fields to `int` or `float` based on the `numberType` setting.