### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+A clear and concise description of the bug goes here.
+
+### To reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots
+Optionally add screenshots to help explain your problem.
+
+### Version information
+- Plugin version: x.x.x
+- WordPress version: x.x.x
+- Operating system:
+- Browser:
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+### Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. For example: I'm always frustrated when [...]
+
+### Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+A clear and concise description of alternative solutions or workarounds you're using.
+
+### Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
To help us collect relevant information and triage public issue reports.

GitHub presents these templates as a choice when someone clicks “new issue” in GitHub, with a less prominent “open a blank issue” link if people want to skip templates. An example from the Genesis repo:

<img width="1288" alt="Screenshot 2021-06-17 at 10 33 18" src="https://user-images.githubusercontent.com/647669/122361422-81b29180-cf57-11eb-8e5d-4770abacb973.png">


