### PR TITLE
[BH-1072] Add .pot generation to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,7 +476,6 @@ workflows:
           slug: atlas-content-modeler
           requires:
             - plugin-bundle-pot
-            - plugin-e2e-test
           # Run this job on every commit/PR so the plugin is available as a build artifact
           filters:
             tags:


### PR DESCRIPTION
Generates a .pot file during CircleCI's plugin pipeline and stores it in the plugin zip.

For testing you can view the .pot file in the zip from https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/1026/workflows/17678fcb-3665-4f66-9d7e-dfdf72a74b4f/jobs/7795/artifacts