### PR TITLE
style: prevent menu item using light background

### DIFF
--- a/includes/settings/scss/_base.scss
+++ b/includes/settings/scss/_base.scss
@@ -1,6 +1,6 @@
 @import "variables";
 
-.toplevel_page_atlas-content-modeler {
+body.toplevel_page_atlas-content-modeler {
 	background: #f3f7fa;
 	font-family: $font-family;
 	font-size: 15px;


### PR DESCRIPTION
Addresses an issue where the Content Modeler menu list item in the WordPress admin would sometimes display a `#f3f7fa` background color, making it hard to read:

<img width="231" alt="Screenshot 2021-06-22 at 10 30 28" src="https://user-images.githubusercontent.com/647669/122896261-30d0dd80-d349-11eb-834d-05228fa1f0fe.png">

This is due to the body and menu list item sharing a `toplevel_page_atlas-content-modeler` class. This PR fixes it by scoping styles to the body element.

The glitch occurs intermittently so is hard to reproduce, but @mindctrl also reported it at one point.

## To test
1. From the repo root, run `rm -rf .parcel-cache && npm run build`.
2. Clear your browser cache.
3. Visit `/wp-admin/admin.php?page=atlas-content-modeler` and refresh a few times.
4. Visit any other admin page and refresh a few times.

You should not see the white-on-gray “Content Modeler” menu item displayed above. It should always be legible.