### PR TITLE
[BH-1091] Verify plugin zip before deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,10 +314,7 @@ jobs:
 
   plugin-test-lint-php:
     working_directory: .
-    docker:
-      - image: php:7.4-apache
-        environment:
-          APP_ENV: test
+    executor: php/default
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,7 +461,7 @@ workflows:
             tags:
               only: /.*/
       - plugin-deploy:
-          name: "Deploy zip to api (staging) atlas-content-modeler"
+          name: "plugin-deploy-staging"
           slug: atlas-content-modeler
           requires:
             - plugin-build-zip
@@ -479,10 +479,10 @@ workflows:
           auth_url: https://auth-staging.wpengine.io/v1/tokens
           upload_url: https://wp-product-info-staging.wpesvc.net/v1/plugins
       - plugin-deploy:
-          name: "Deploy zip to api (production) atlas-content-modeler"
+          name: "plugin-deploy-production"
           slug: atlas-content-modeler
           requires:
-            - "Deploy zip to api (staging) atlas-content-modeler"
+            - "plugin-deploy-staging"
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,7 +461,7 @@ workflows:
       - plugin-build-json:
           slug: atlas-content-modeler
           requires:
-            - plugin-test-unit
+            - plugin-build-composer
           # Run this job on every commit/PR to make sure it's in working order prior to deploying
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,7 @@ jobs:
       - run:
           name: Run Code Sniffer sniffs
           command: vendor/bin/phpcs
+          working_directory: atlas-content-modeler
 
   plugin-test-unit:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,25 @@ jobs:
             npm run lint
           working_directory: <<parameters.slug>>
 
+  plugin-test-lint-php:
+    working_directory: .
+    docker:
+      - image: php:7.4-apache
+        environment:
+          APP_ENV: test
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install system packages
+          command: apt-get update && apt-get -y install git
+      - run:
+          name: Install PHP extensions
+          command: docker-php-ext-install pdo
+      - run:
+          name: Run Code Sniffer sniffs
+          command: vendor/bin/phpcs
+
   plugin-test-unit:
     docker:
       - image: cimg/php:7.4
@@ -443,6 +462,13 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - plugin-test-lint-php:
+          requires:
+            - plugin-build-zip
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
       - plugin-test-jest:
           slug: atlas-content-modeler
           requires:
@@ -454,6 +480,7 @@ workflows:
       - plugin-test-e2e:
           requires:
             - plugin-test-lint-js
+            - plugin-test-lint-php
             - plugin-test-jest
             - plugin-test-unit
           # run this job for any build, any branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
           paths:
             - .
 
-  plugin-bundle-pot:
+  plugin-build-pot:
     docker:
       - image: circleci/php:7.4-node-browsers
     steps:
@@ -437,12 +437,14 @@ workflows:
               only: /.*/
       - plugin-test-e2e:
           requires:
+            - plugin-test-lint
             - plugin-test-jest
+            - plugin-test-unit
           # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
-      - plugin-bundle-pot:
+      - plugin-build-pot:
           requires:
             - plugin-build-composer
           # Run this job on every commit/PR so the plugin is available as a build artifact
@@ -453,7 +455,10 @@ workflows:
           slug: atlas-content-modeler
           requires:
             - plugin-build-npm
-            - plugin-bundle-pot
+            - plugin-build-pot
+            - plugin-test-lint
+            - plugin-test-jest
+            - plugin-test-unit
           # Run this job on every commit/PR so the plugin is available as a build artifact
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,10 +257,6 @@ jobs:
           command: |
             npm run test-no-watch
           working_directory: <<parameters.slug>>
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
 
   plugin-test-e2e:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
           name: "Bundle plugin files into a zip"
           command: |
             zip --verbose -x@<<parameters.slug>>/.zipignore -x *.wpe/* */build/ -r "build/<<parameters.slug>>.$BUILD_VERSION.zip" <<parameters.slug>>
+            echo "<<parameters.slug>>.$BUILD_VERSION.zip" >> build/file.txt
       - store_artifacts:
           path: build
       - persist_to_workspace:
@@ -319,7 +320,7 @@ jobs:
       - run:
           name: Activate atlas-content-modeler plugin
           command: |
-            ./wp-cli.phar plugin install --activate --path=/tmp/wordpress build/atlas-content-modeler.$BUILD_VERSION.zip
+            ./wp-cli.phar plugin install --activate --path=/tmp/wordpress build/$(cat build/file.txt)
 
       - run:
           name: Install WPGraphQL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,12 +321,6 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run:
-          name: Install system packages
-          command: apt-get update && apt-get -y install git
-      - run:
-          name: Install PHP extensions
-          command: docker-php-ext-install pdo
       - php/install-composer
       - run:
           name: Run Code Sniffer sniffs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,10 +486,7 @@ workflows:
               only: /.*/
       - plugin-test-e2e:
           requires:
-            - plugin-test-lint-js
-            - plugin-test-lint-php
-            - plugin-test-jest
-            - plugin-test-unit
+            - plugin-build-zip
           # run this job for any build, any branch
           filters:
             tags:
@@ -501,6 +498,10 @@ workflows:
             - plugin-build-zip
             - plugin-build-json
             - plugin-test-e2e
+            - plugin-test-lint-js
+            - plugin-test-lint-php
+            - plugin-test-jest
+            - plugin-test-unit
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,114 +149,6 @@ jobs:
           paths:
             - build
 
-  plugin-test-jest:
-    executor:
-      name: node/default
-      tag: lts
-    parameters:
-      slug:
-        type: string
-    working_directory: .
-    steps:
-      - attach_workspace:
-          at: .
-      - node/install-packages:
-          app-dir: <<parameters.slug>>
-      - run:
-          name: Run Jest tests
-          command: |
-            npm run test-no-watch
-          working_directory: <<parameters.slug>>
-
-  plugin-test-lint-js:
-    executor:
-      name: node/default
-      tag: lts
-    parameters:
-      slug:
-        type: string
-    working_directory: .
-    steps:
-      - attach_workspace:
-          at: .
-      - node/install-packages:
-          app-dir: <<parameters.slug>>
-      - run:
-          name: NPM style
-          command: |
-            npm run style
-          working_directory: <<parameters.slug>>
-      - run:
-          name: NPM eslint
-          command: |
-            npm run lint
-          working_directory: <<parameters.slug>>
-
-  plugin-test-lint-php:
-    working_directory: .
-    docker:
-      - image: php:7.4-apache
-        environment:
-          APP_ENV: test
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Install system packages
-          command: apt-get update && apt-get -y install git
-      - run:
-          name: Install PHP extensions
-          command: docker-php-ext-install pdo
-      - run:
-          name: Install Composer
-          command: |
-            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-            php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            php composer-setup.php
-            php -r "unlink('composer-setup.php');"
-      - run:
-          name: Run Code Sniffer sniffs
-          command: php ../composer.phar lint
-          working_directory: atlas-content-modeler
-
-  plugin-test-unit:
-    docker:
-      - image: cimg/php:7.4
-      - image: circleci/mysql:5.7
-        environment:
-          MYSQL_DATABASE: wp_database
-          MYSQL_USER: wp_user
-          MYSQL_PASSWORD: wp_pass
-          MYSQL_ROOT_PASSWORD: password
-    parameters:
-      slug:
-        type: string
-    steps:
-      - attach_workspace:
-          at: .
-      - php/install-composer
-      - php/install-packages:
-          app-dir: <<parameters.slug>>
-      - run:
-          name: Remove composer setup file
-          command: |
-            rm -v composer-setup.php
-      - run:
-          name: Install Subversion package
-          command: |
-            sudo apt-get update -yq
-            sudo apt-get install subversion -yq
-      - run:
-          name: Setup WordPress testing framework
-          command: |
-            /bin/bash tests/install-wp-tests.sh wp_database wp_user wp_pass 127.0.0.1 latest true
-          working_directory: <<parameters.slug>>
-      - run:
-          name: Run testing suite
-          command: |
-            composer test
-          working_directory: <<parameters.slug>>
-
   plugin-test-e2e:
     docker:
       - image: circleci/php:7.4-node-browsers
@@ -377,6 +269,114 @@ jobs:
       - store_artifacts:
           path: atlas-content-modeler/tests/_output
 
+  plugin-test-jest:
+    executor:
+      name: node/default
+      tag: lts
+    parameters:
+      slug:
+        type: string
+    working_directory: .
+    steps:
+      - attach_workspace:
+          at: .
+      - node/install-packages:
+          app-dir: <<parameters.slug>>
+      - run:
+          name: Run Jest tests
+          command: |
+            npm run test-no-watch
+          working_directory: <<parameters.slug>>
+
+  plugin-test-lint-js:
+    executor:
+      name: node/default
+      tag: lts
+    parameters:
+      slug:
+        type: string
+    working_directory: .
+    steps:
+      - attach_workspace:
+          at: .
+      - node/install-packages:
+          app-dir: <<parameters.slug>>
+      - run:
+          name: NPM style
+          command: |
+            npm run style
+          working_directory: <<parameters.slug>>
+      - run:
+          name: NPM eslint
+          command: |
+            npm run lint
+          working_directory: <<parameters.slug>>
+
+  plugin-test-lint-php:
+    working_directory: .
+    docker:
+      - image: php:7.4-apache
+        environment:
+          APP_ENV: test
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install system packages
+          command: apt-get update && apt-get -y install git
+      - run:
+          name: Install PHP extensions
+          command: docker-php-ext-install pdo
+      - run:
+          name: Install Composer
+          command: |
+            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+            php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
+            php composer-setup.php
+            php -r "unlink('composer-setup.php');"
+      - run:
+          name: Run Code Sniffer sniffs
+          command: php ../composer.phar lint
+          working_directory: atlas-content-modeler
+
+  plugin-test-unit:
+    docker:
+      - image: cimg/php:7.4
+      - image: circleci/mysql:5.7
+        environment:
+          MYSQL_DATABASE: wp_database
+          MYSQL_USER: wp_user
+          MYSQL_PASSWORD: wp_pass
+          MYSQL_ROOT_PASSWORD: password
+    parameters:
+      slug:
+        type: string
+    steps:
+      - attach_workspace:
+          at: .
+      - php/install-composer
+      - php/install-packages:
+          app-dir: <<parameters.slug>>
+      - run:
+          name: Remove composer setup file
+          command: |
+            rm -v composer-setup.php
+      - run:
+          name: Install Subversion package
+          command: |
+            sudo apt-get update -yq
+            sudo apt-get install subversion -yq
+      - run:
+          name: Setup WordPress testing framework
+          command: |
+            /bin/bash tests/install-wp-tests.sh wp_database wp_user wp_pass 127.0.0.1 latest true
+          working_directory: <<parameters.slug>>
+      - run:
+          name: Run testing suite
+          command: |
+            composer test
+          working_directory: <<parameters.slug>>
+
   plugin-deploy:
     executor: wp-product-orb/authenticate
     environment:
@@ -430,18 +430,18 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - plugin-build-pot:
-          requires:
-            - plugin-build-composer
-          # Run this job on every commit/PR so the plugin is available as a build artifact
-          filters:
-            tags:
-              only: /.*/
       - plugin-build-json:
           slug: atlas-content-modeler
           requires:
             - plugin-build-composer
           # Run this job on every commit/PR to make sure it's in working order prior to deploying
+          filters:
+            tags:
+              only: /.*/
+      - plugin-build-pot:
+          requires:
+            - plugin-build-composer
+          # Run this job on every commit/PR so the plugin is available as a build artifact
           filters:
             tags:
               only: /.*/
@@ -454,7 +454,14 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - plugin-test-unit:
+      - plugin-test-e2e:
+          requires:
+            - plugin-build-zip
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
+      - plugin-test-jest:
           slug: atlas-content-modeler
           requires:
             - plugin-build-zip
@@ -477,15 +484,8 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - plugin-test-jest:
+      - plugin-test-unit:
           slug: atlas-content-modeler
-          requires:
-            - plugin-build-zip
-          # run this job for any build, any branch
-          filters:
-            tags:
-              only: /.*/
-      - plugin-test-e2e:
           requires:
             - plugin-build-zip
           # run this job for any build, any branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,30 +9,6 @@ orbs:
   node: circleci/node@4.1.0
 
 jobs:
-  plugin-test-lint:
-    executor:
-      name: node/default
-      tag: lts
-    parameters:
-      slug:
-        type: string
-    working_directory: .
-    steps:
-      - attach_workspace:
-          at: .
-      - node/install-packages:
-          app-dir: <<parameters.slug>>
-      - run:
-          name: NPM style
-          command: |
-            npm run style
-          working_directory: <<parameters.slug>>
-      - run:
-          name: NPM eslint
-          command: |
-            npm run lint
-          working_directory: <<parameters.slug>>
-
   plugin-checkout:
     executor: wp-product-orb/default
     environment:
@@ -85,6 +61,136 @@ jobs:
           paths:
             - atlas-content-modeler/vendor
 
+  plugin-build-npm:
+    executor:
+      name: node/default
+      tag: lts
+    parameters:
+      slug:
+        type: string
+    working_directory: .
+    steps:
+      - attach_workspace:
+          at: .
+      - node/install-packages:
+          app-dir: <<parameters.slug>>
+      - run:
+          name: NPM build
+          command: |
+            npm run build
+          working_directory: <<parameters.slug>>
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  plugin-build-json:
+    executor: wp-product-orb/parser
+    environment:
+      WPE_SESSION_DIR: ./.wpe
+    parameters:
+      slug:
+        type: string
+    steps:
+      - attach_workspace:
+          at: .
+      - wp-product-orb/variable-load
+      - wp-product-orb/parse-wp-readme:
+          infile: <<parameters.slug>>/readme.txt
+          outfile: build/<<parameters.slug>>.$BUILD_VERSION.json
+      - store_artifacts:
+          path: build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build
+
+  plugin-build-pot:
+    docker:
+      - image: circleci/php:7.4-node-browsers
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install WP-CLI
+          command: |
+            curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+            chmod +x wp-cli.phar
+            ./wp-cli.phar --info
+      - run:
+          name: Build .pot file
+          command: |
+            ./wp-cli.phar i18n make-pot ~/project/atlas-content-modeler
+      - persist_to_workspace:
+            root: .
+            paths:
+              - atlas-content-modeler/languages
+
+  plugin-build-zip:
+    executor: wp-product-orb/default
+    environment:
+      WPE_SESSION_DIR: ./.wpe
+    parameters:
+      slug:
+        type: string
+    steps:
+      - attach_workspace:
+          at: .
+      - wp-product-orb/variable-load
+      - run:
+          name: "Bundle plugin files into a zip"
+          command: |
+            zip --verbose -x@<<parameters.slug>>/.zipignore -x *.wpe/* */build/ -r "build/<<parameters.slug>>.$BUILD_VERSION.zip" <<parameters.slug>>
+      - store_artifacts:
+          path: build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build
+
+  plugin-test-jest:
+    executor:
+      name: node/default
+      tag: lts
+    parameters:
+      slug:
+        type: string
+    working_directory: .
+    steps:
+      - attach_workspace:
+          at: .
+      - node/install-packages:
+          app-dir: <<parameters.slug>>
+      - run:
+          name: Run Jest tests
+          command: |
+            npm run test-no-watch
+          working_directory: <<parameters.slug>>
+
+  plugin-test-lint:
+    executor:
+      name: node/default
+      tag: lts
+    parameters:
+      slug:
+        type: string
+    working_directory: .
+    steps:
+      - attach_workspace:
+          at: .
+      - node/install-packages:
+          app-dir: <<parameters.slug>>
+      - run:
+          name: NPM style
+          command: |
+            npm run style
+          working_directory: <<parameters.slug>>
+      - run:
+          name: NPM eslint
+          command: |
+            npm run lint
+          working_directory: <<parameters.slug>>
+
   plugin-test-unit:
     docker:
       - image: cimg/php:7.4
@@ -121,137 +227,6 @@ jobs:
           name: Run testing suite
           command: |
             composer test
-          working_directory: <<parameters.slug>>
-
-  plugin-build-zip:
-    executor: wp-product-orb/default
-    environment:
-      WPE_SESSION_DIR: ./.wpe
-    parameters:
-      slug:
-        type: string
-    steps:
-      - attach_workspace:
-          at: .
-      - wp-product-orb/variable-load
-      - run:
-          name: "Bundle plugin files into a zip"
-          command: |
-            zip --verbose -x@<<parameters.slug>>/.zipignore -x *.wpe/* */build/ -r "build/<<parameters.slug>>.$BUILD_VERSION.zip" <<parameters.slug>>
-      - store_artifacts:
-          path: build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build
-
-  plugin-build-json:
-    executor: wp-product-orb/parser
-    environment:
-      WPE_SESSION_DIR: ./.wpe
-    parameters:
-      slug:
-        type: string
-    steps:
-      - attach_workspace:
-          at: .
-      - wp-product-orb/variable-load
-      - wp-product-orb/parse-wp-readme:
-          infile: <<parameters.slug>>/readme.txt
-          outfile: build/<<parameters.slug>>.$BUILD_VERSION.json
-      - store_artifacts:
-          path: build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build
-
-  plugin-deploy:
-    executor: wp-product-orb/authenticate
-    environment:
-      WPE_SESSION_DIR: ./.wpe
-    parameters:
-      auth_url:
-        type: string
-      upload_url:
-        type: string
-      slug:
-        type: string
-    steps:
-      - attach_workspace:
-          at: .
-      - wp-product-orb/variable-load
-      - wp-product-orb/authenticate:
-          user: WPE_LDAP_USER
-          pass: WPE_LDAP_PASS
-          url: <<parameters.auth_url>>
-      - wp-product-orb/post-zip:
-          url: <<parameters.upload_url>>/<<parameters.slug>>
-          zip: build/<<parameters.slug>>.$BUILD_VERSION.zip
-          json: build/<<parameters.slug>>.$BUILD_VERSION.json
-          version: $BUILD_VERSION
-
-  plugin-build-npm:
-    executor:
-      name: node/default
-      tag: lts
-    parameters:
-      slug:
-        type: string
-    working_directory: .
-    steps:
-      - attach_workspace:
-          at: .
-      - node/install-packages:
-          app-dir: <<parameters.slug>>
-      - run:
-          name: NPM build
-          command: |
-            npm run build
-          working_directory: <<parameters.slug>>
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-
-  plugin-build-pot:
-    docker:
-      - image: circleci/php:7.4-node-browsers
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Install WP-CLI
-          command: |
-            curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-            chmod +x wp-cli.phar
-            ./wp-cli.phar --info
-      - run:
-          name: Build .pot file
-          command: |
-            ./wp-cli.phar i18n make-pot ~/project/atlas-content-modeler
-      - persist_to_workspace:
-            root: .
-            paths:
-              - atlas-content-modeler/languages
-
-  plugin-test-jest:
-    executor:
-      name: node/default
-      tag: lts
-    parameters:
-      slug:
-        type: string
-    working_directory: .
-    steps:
-      - attach_workspace:
-          at: .
-      - node/install-packages:
-          app-dir: <<parameters.slug>>
-      - run:
-          name: Run Jest tests
-          command: |
-            npm run test-no-watch
           working_directory: <<parameters.slug>>
 
   plugin-test-e2e:
@@ -374,6 +349,31 @@ jobs:
 
       - store_artifacts:
           path: atlas-content-modeler/tests/_output
+
+  plugin-deploy:
+    executor: wp-product-orb/authenticate
+    environment:
+      WPE_SESSION_DIR: ./.wpe
+    parameters:
+      auth_url:
+        type: string
+      upload_url:
+        type: string
+      slug:
+        type: string
+    steps:
+      - attach_workspace:
+          at: .
+      - wp-product-orb/variable-load
+      - wp-product-orb/authenticate:
+          user: WPE_LDAP_USER
+          pass: WPE_LDAP_PASS
+          url: <<parameters.auth_url>>
+      - wp-product-orb/post-zip:
+          url: <<parameters.upload_url>>/<<parameters.slug>>
+          zip: build/<<parameters.slug>>.$BUILD_VERSION.zip
+          json: build/<<parameters.slug>>.$BUILD_VERSION.json
+          version: $BUILD_VERSION
 
 workflows:
   # Workflows defined for each package and plugin.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,13 +327,7 @@ jobs:
       - run:
           name: Install PHP extensions
           command: docker-php-ext-install pdo
-      - run:
-          name: Install Composer
-          command: |
-            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-            php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            php composer-setup.php
-            php -r "unlink('composer-setup.php');"
+      - php/install-composer
       - run:
           name: Run Code Sniffer sniffs
           command: php ../composer.phar lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,6 @@ workflows:
               only:
                 - main
                 - canary
-                - chriswiegman/BH-1091
             tags:
               only: /.*/
           context: wpe-ldap-creds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,7 @@ workflows:
       - plugin-build-npm:
           slug: atlas-content-modeler
           requires:
-            - plugin-test-lint
+            - plugin-checkout
           # run this job for any build, any branch
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,43 +403,10 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - plugin-test-unit:
-          slug: atlas-content-modeler
-          requires:
-            - plugin-build-composer
-          # run this job for any build, any branch
-          filters:
-            tags:
-              only: /.*/
-      - plugin-test-lint:
-          slug: atlas-content-modeler
-          requires:
-            - plugin-test-unit
-          # run this job for any build, any branch
-          filters:
-            tags:
-              only: /.*/
       - plugin-build-npm:
           slug: atlas-content-modeler
           requires:
             - plugin-checkout
-          # run this job for any build, any branch
-          filters:
-            tags:
-              only: /.*/
-      - plugin-test-jest:
-          slug: atlas-content-modeler
-          requires:
-            - plugin-build-npm
-          # run this job for any build, any branch
-          filters:
-            tags:
-              only: /.*/
-      - plugin-test-e2e:
-          requires:
-            - plugin-test-lint
-            - plugin-test-jest
-            - plugin-test-unit
           # run this job for any build, any branch
           filters:
             tags:
@@ -451,23 +418,53 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - plugin-build-zip:
-          slug: atlas-content-modeler
-          requires:
-            - plugin-build-npm
-            - plugin-build-pot
-            - plugin-test-lint
-            - plugin-test-jest
-            - plugin-test-unit
-          # Run this job on every commit/PR so the plugin is available as a build artifact
-          filters:
-            tags:
-              only: /.*/
       - plugin-build-json:
           slug: atlas-content-modeler
           requires:
             - plugin-build-composer
           # Run this job on every commit/PR to make sure it's in working order prior to deploying
+          filters:
+            tags:
+              only: /.*/
+      - plugin-build-zip:
+          slug: atlas-content-modeler
+          requires:
+            - plugin-build-npm
+            - plugin-build-pot
+          # Run this job on every commit/PR so the plugin is available as a build artifact
+          filters:
+            tags:
+              only: /.*/
+      - plugin-test-unit:
+          slug: atlas-content-modeler
+          requires:
+            - plugin-build-zip
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
+      - plugin-test-lint:
+          slug: atlas-content-modeler
+          requires:
+            - plugin-test-zip
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
+      - plugin-test-jest:
+          slug: atlas-content-modeler
+          requires:
+            - plugin-build-zip
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
+      - plugin-test-e2e:
+          requires:
+            - plugin-test-lint
+            - plugin-test-jest
+            - plugin-test-unit
+          # run this job for any build, any branch
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
             npm run test-no-watch
           working_directory: <<parameters.slug>>
 
-  plugin-test-lint:
+  plugin-test-lint-js:
     executor:
       name: node/default
       tag: lts
@@ -435,7 +435,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - plugin-test-lint:
+      - plugin-test-lint-js:
           slug: atlas-content-modeler
           requires:
             - plugin-build-zip
@@ -453,7 +453,7 @@ workflows:
               only: /.*/
       - plugin-test-e2e:
           requires:
-            - plugin-test-lint
+            - plugin-test-lint-js
             - plugin-test-jest
             - plugin-test-unit
           # run this job for any build, any branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,6 @@ jobs:
           command: |
             npm run lint
           working_directory: <<parameters.slug>>
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
 
   plugin-checkout:
     executor: wp-product-orb/default
@@ -87,7 +83,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - .
+            - atlas-content-modeler/vendor
 
   plugin-test-unit:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,6 @@ jobs:
           name: Remove composer setup file
           command: |
             rm -v composer-setup.php
-      - run:
-          name: Composer PHP lint and code sniffer
-          command: |
-            /usr/local/bin/composer lint && /usr/local/bin/composer phpcs
-          working_directory: <<parameters.slug>>
       - persist_to_workspace:
           root: .
           paths:
@@ -321,7 +316,7 @@ jobs:
       - php/install-composer
       - run:
           name: Run Code Sniffer sniffs
-          command: php ../composer.phar lint
+          command: /usr/local/bin/composer lint && /usr/local/bin/composer phpcs
           working_directory: atlas-content-modeler
 
   plugin-test-unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
   node: circleci/node@4.1.0
 
 jobs:
-  lint:
+  plugin-test-lint:
     executor:
       name: node/default
       tag: lts
@@ -37,19 +37,6 @@ jobs:
           paths:
             - .
 
-  checkout:
-    executor: wp-product-orb/default
-    parameters:
-      slug:
-        type: string
-    steps:
-      - checkout:
-          path: <<parameters.slug>>
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-
   plugin-checkout:
     executor: wp-product-orb/default
     environment:
@@ -60,8 +47,8 @@ jobs:
       filename:
         type: string
     steps:
-      - attach_workspace:
-          at: .
+      - checkout:
+          path: <<parameters.slug>>
       - run:
           name: Make artifacts build directory
           command: |
@@ -77,7 +64,7 @@ jobs:
           paths:
             - .
 
-  plugin-composer:
+  plugin-build-composer:
     executor: php/default
     parameters:
       slug:
@@ -102,7 +89,7 @@ jobs:
           paths:
             - .
 
-  plugin-test:
+  plugin-test-unit:
     docker:
       - image: cimg/php:7.4
       - image: circleci/mysql:5.7
@@ -140,7 +127,7 @@ jobs:
             composer test
           working_directory: <<parameters.slug>>
 
-  plugin-bundle-zip:
+  plugin-build-zip:
     executor: wp-product-orb/default
     environment:
       WPE_SESSION_DIR: ./.wpe
@@ -162,7 +149,7 @@ jobs:
           paths:
             - build
 
-  plugin-bundle-json:
+  plugin-build-json:
     executor: wp-product-orb/parser
     environment:
       WPE_SESSION_DIR: ./.wpe
@@ -208,7 +195,7 @@ jobs:
           json: build/<<parameters.slug>>.$BUILD_VERSION.json
           version: $BUILD_VERSION
 
-  plugin-npm-build:
+  plugin-build-npm:
     executor:
       name: node/default
       tag: lts
@@ -252,7 +239,7 @@ jobs:
             paths:
               - atlas-content-modeler/languages
 
-  plugin-jest:
+  plugin-test-jest:
     executor:
       name: node/default
       tag: lts
@@ -275,7 +262,7 @@ jobs:
           paths:
             - .
 
-  plugin-e2e-test:
+  plugin-test-e2e:
     docker:
       - image: circleci/php:7.4-node-browsers
       - image: circleci/mysql:5.7-ram
@@ -401,21 +388,14 @@ workflows:
   # tag example for deploying an update for atlas-content-modeler: 1.0.0
   plugin:
     jobs:
-      - checkout:
-          slug: atlas-content-modeler
-          filters:
-            tags:
-              only: /.*/
       - plugin-checkout:
           slug: atlas-content-modeler
           filename: atlas-content-modeler.php
-          requires:
-            - checkout
           # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
-      - plugin-composer:
+      - plugin-build-composer:
           slug: atlas-content-modeler
           requires:
             - plugin-checkout
@@ -423,65 +403,65 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - plugin-test:
+      - plugin-test-unit:
           slug: atlas-content-modeler
           requires:
-            - plugin-composer
+            - plugin-build-composer
           # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
-      - lint:
+      - plugin-test-lint:
           slug: atlas-content-modeler
           requires:
-            - plugin-test
+            - plugin-test-unit
           # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
-      - plugin-npm-build:
+      - plugin-build-npm:
           slug: atlas-content-modeler
           requires:
-            - lint
+            - plugin-test-lint
           # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
-      - plugin-jest:
+      - plugin-test-jest:
           slug: atlas-content-modeler
           requires:
-            - plugin-npm-build
+            - plugin-build-npm
           # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
-      - plugin-e2e-test:
+      - plugin-test-e2e:
           requires:
-            - plugin-jest
+            - plugin-test-jest
           # run this job for any build, any branch
           filters:
             tags:
               only: /.*/
       - plugin-bundle-pot:
           requires:
-            - plugin-composer
+            - plugin-build-composer
           # Run this job on every commit/PR so the plugin is available as a build artifact
           filters:
             tags:
               only: /.*/
-      - plugin-bundle-zip:
+      - plugin-build-zip:
           slug: atlas-content-modeler
           requires:
-            - plugin-npm-build
+            - plugin-build-npm
             - plugin-bundle-pot
           # Run this job on every commit/PR so the plugin is available as a build artifact
           filters:
             tags:
               only: /.*/
-      - plugin-bundle-json:
+      - plugin-build-json:
           slug: atlas-content-modeler
           requires:
-            - plugin-test
+            - plugin-test-unit
           # Run this job on every commit/PR to make sure it's in working order prior to deploying
           filters:
             tags:
@@ -490,14 +470,15 @@ workflows:
           name: "Deploy zip to api (staging) atlas-content-modeler"
           slug: atlas-content-modeler
           requires:
-            - plugin-bundle-zip
-            - plugin-bundle-json
-            - plugin-e2e-test
+            - plugin-build-zip
+            - plugin-build-json
+            - plugin-test-e2e
           filters:
             branches:
               only:
                 - main
                 - canary
+                - chriswiegman/BH-1091
             tags:
               only: /.*/
           context: wpe-ldap-creds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,8 +101,7 @@ jobs:
             - build
 
   plugin-build-pot:
-    docker:
-      - image: circleci/php:7.4-node-browsers
+    executor: php/default
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,8 +319,7 @@ jobs:
       - run:
           name: Activate atlas-content-modeler plugin
           command: |
-            ln -s ~/project/atlas-content-modeler /tmp/wordpress/wp-content/plugins/atlas-content-modeler
-            ./wp-cli.phar plugin activate --path=/tmp/wordpress atlas-content-modeler
+            ./wp-cli.phar plugin install --activate --path=/tmp/wordpress build/atlas-content-modeler.$BUILD_VERSION.zip
 
       - run:
           name: Install WPGraphQL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ workflows:
       - plugin-bundle-zip:
           slug: atlas-content-modeler
           requires:
-            - plugin-e2e-test
+            - plugin-npm-build
             - plugin-bundle-pot
           # Run this job on every commit/PR so the plugin is available as a build artifact
           filters:
@@ -492,6 +492,7 @@ workflows:
           requires:
             - plugin-bundle-zip
             - plugin-bundle-json
+            - plugin-e2e-test
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,7 +446,7 @@ workflows:
       - plugin-test-lint:
           slug: atlas-content-modeler
           requires:
-            - plugin-test-zip
+            - plugin-build-zip
           # run this job for any build, any branch
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,8 +207,15 @@ jobs:
           name: Install PHP extensions
           command: docker-php-ext-install pdo
       - run:
+          name: Install Composer
+          command: |
+            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+            php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
+            php composer-setup.php
+            php -r "unlink('composer-setup.php');"
+      - run:
           name: Run Code Sniffer sniffs
-          command: vendor/bin/phpcs
+          command: php ../composer.phar lint
           working_directory: atlas-content-modeler
 
   plugin-test-unit:


### PR DESCRIPTION
This PR significantly refactors our CircleCI build in order to allow us to run e2e tests based on the built zip that will then be uploaded for distribution. This will ensure the code were testing is the very code our users will be running and will prevent issues that may arise due to obsolete lines in .zipignore or for any other failure during zip creation.

To get to this point is what took so much refactoring. Here's how it all breaks down:
1. The zip has to be available before the e2e testing. This was a significant departure from previous builds as the way we had been persisting assets would break previously. Now tests do not persist assets and other jobs only persist what they need to. This allows us to build the zip earlier and to run more jobs in parallel which cut off about 2-3 minutes of total build time
2. To sort out which steps were doing what I renamed jobs and re-ordered them to make finding and working with a job a little bit easier. This is the bulk of the refactor

Attached below is both the last build output as well as its associated zip artifact for verification

![Screen Shot 2021-06-24 at 11 30 05 AM](https://user-images.githubusercontent.com/394675/123290889-9f47a400-d4df-11eb-9322-4a4043c102f9.png)

[atlas-content-modeler.0.4.1.zip](https://github.com/wpengine/atlas-content-modeler/files/6710442/atlas-content-modeler.0.4.1.zip)

edited to reflect that I had missed php linting in the original build. It has now been refactored into its own job to better reflect failure when it occurs
