### PR TITLE
BH-1075 Allow creation of taxonomies in the developer app

### DIFF
--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -742,10 +742,12 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
-	$acm_taxonomies = get_option( 'atlas_content_modeler_taxonomies', array() );
-	$wp_taxonomies  = get_taxonomies();
+	$acm_taxonomies     = get_option( 'atlas_content_modeler_taxonomies', array() );
+	$wp_taxonomies      = get_taxonomies();
+	$non_acm_taxonomies = array_diff( array_keys( $wp_taxonomies ), array_keys( $acm_taxonomies ) );
 
-	if ( array_key_exists( $params['slug'], $wp_taxonomies ) ) {
+	// Prevents creation of a taxonomy if one with the same slug exists that was not created in ACM.
+	if ( in_array( $params['slug'], $non_acm_taxonomies, true ) ) {
 		return new WP_Error(
 			'atlas_content_modeler_taxonomy_exists',
 			esc_html__( 'A taxonomy with this API Identifier already exists.', 'atlas-content-modeler' ),
@@ -753,6 +755,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
+	// Allows updates of existing ACM taxonomies, but prevents creation of ACM taxonomies with identical slugs.
 	if ( ! $is_update && array_key_exists( $params['slug'], $acm_taxonomies ) ) {
 		return new WP_Error(
 			'atlas_content_modeler_taxonomy_exists',

--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -742,9 +742,18 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
-	$taxonomies = get_option( 'atlas_content_modeler_taxonomies', array() );
+	$acm_taxonomies = get_option( 'atlas_content_modeler_taxonomies', array() );
+	$wp_taxonomies  = get_taxonomies();
 
-	if ( ! $is_update && array_key_exists( $params['slug'], $taxonomies ) ) {
+	if ( array_key_exists( $params['slug'], $wp_taxonomies ) ) {
+		return new WP_Error(
+			'atlas_content_modeler_taxonomy_exists',
+			esc_html__( 'A taxonomy with this API Identifier already exists.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	if ( ! $is_update && array_key_exists( $params['slug'], $acm_taxonomies ) ) {
 		return new WP_Error(
 			'atlas_content_modeler_taxonomy_exists',
 			esc_html__( 'A taxonomy with this API Identifier already exists.', 'atlas-content-modeler' ),
@@ -768,9 +777,9 @@ function save_taxonomy( array $params, bool $is_update ) {
 		'api_visibility'  => 'private',
 	];
 
-	$taxonomy                        = wp_parse_args( $params, $defaults );
-	$taxonomies[ $taxonomy['slug'] ] = $taxonomy;
-	$created                         = update_option( 'atlas_content_modeler_taxonomies', $taxonomies );
+	$taxonomy                            = wp_parse_args( $params, $defaults );
+	$acm_taxonomies[ $taxonomy['slug'] ] = $taxonomy;
+	$created                             = update_option( 'atlas_content_modeler_taxonomies', $acm_taxonomies );
 
 	if ( ! $created ) {
 		return new WP_Error(

--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -730,7 +730,7 @@ function content_model_multi_option_exists( array $names, string $current_choice
  *
  * @param array $params Parameters passed from the taxonomy form.
  * @param bool  $is_update True if `$params` came from a PUT request.
- * @return object|WP_Error
+ * @return array|WP_Error
  * @since 0.6.0
  */
 function save_taxonomy( array $params, bool $is_update ) {

--- a/includes/settings/js/src/App.jsx
+++ b/includes/settings/js/src/App.jsx
@@ -6,6 +6,7 @@ import "react-toastify/dist/ReactToastify.css";
 import CreateContentModel from "./components/CreateContentModel.jsx";
 import ViewContentModelsList from "./components/ViewContentModelsList";
 import EditContentModel from "./components/EditContentModel";
+import Taxonomies from "./components/Taxonomies";
 import { useLocationSearch } from "./utils";
 import { ModelsContextProvider } from "./ModelsContext";
 
@@ -37,6 +38,10 @@ function ViewTemplate() {
 
 	if (view === "edit-model") {
 		return <EditContentModel />;
+	}
+
+	if (view === "taxonomies") {
+		return <Taxonomies />;
 	}
 
 	return <ViewContentModelsList />;

--- a/includes/settings/js/src/ModelsContext.jsx
+++ b/includes/settings/js/src/ModelsContext.jsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from "react";
 import { reducer } from "./reducer";
+import { taxonomiesReducer } from "./taxonomiesReducer";
 
 export const ModelsContext = React.createContext(null);
 
@@ -17,11 +18,18 @@ export function ModelsContextProvider(props) {
 		atlasContentModeler?.initialState
 	);
 
+	const [taxonomies, taxonomiesDispatch] = useReducer(
+		taxonomiesReducer,
+		atlasContentModeler?.taxonomies
+	);
+
 	return (
 		<ModelsContext.Provider
 			value={{
 				models,
 				dispatch,
+				taxonomies,
+				taxonomiesDispatch,
 			}}
 		>
 			{props.children}

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -335,7 +335,10 @@ export default function Taxonomies() {
 										htmlFor="hierarchical"
 										className="checkbox"
 									>
-										Terms can have parents
+										{__(
+											"Terms can have parent terms",
+											"atlas-content-modeler"
+										)}
 									</label>
 								</p>
 								<p className="help">

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -293,7 +293,7 @@ export default function Taxonomies() {
 												<Icon type="error" />
 												<span role="alert">
 													{__(
-														"Exceeds max length of 20.",
+														"Exceeds max length of 32",
 														"atlas-content-modeler"
 													)}
 												</span>

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -270,7 +270,7 @@ export default function Taxonomies() {
 									className="w-100"
 									ref={register({
 										required: true,
-										maxLength: 20,
+										maxLength: 32,
 									})}
 									{...apiIdFieldAttributes}
 								/>

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -33,8 +33,8 @@ export default function Taxonomies() {
 	});
 
 	function apiCreateTaxonomy(data) {
-		if (data?.type.length < 1) {
-			setError("type", {
+		if (data.types.length < 1) {
+			setError("types", {
 				type: "noModelSet",
 			});
 			return false;
@@ -260,7 +260,7 @@ export default function Taxonomies() {
 							{/* Models / Types */}
 							<div
 								className={
-									errors.type ? "field has-error" : "field"
+									errors.types ? "field has-error" : "field"
 								}
 							>
 								<fieldset>
@@ -283,7 +283,7 @@ export default function Taxonomies() {
 													<input
 														type="checkbox"
 														value={model.slug}
-														name="type"
+														name="types"
 														ref={register}
 													/>
 													{model.plural}
@@ -294,8 +294,8 @@ export default function Taxonomies() {
 									})}
 								</fieldset>
 								<p className="field-messages">
-									{errors.type &&
-										errors.type.type === "noModelSet" && (
+									{errors.types &&
+										errors.types.type === "noModelSet" && (
 											<span className="error">
 												<Icon type="error" />
 												<span role="alert">

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -72,7 +72,9 @@ export default function Taxonomies() {
 					});
 					window.scrollTo(0, 0);
 					reset();
-					setApiIdGeneratorInput(""); // Resets the API ID field.
+					setApiIdGeneratorInput("");
+					setSingularCount(0);
+					setPluralCount(0);
 					setFieldsAreLinked(true);
 					showSuccess(
 						sprintf(

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -6,7 +6,6 @@ import { useForm } from "react-hook-form";
 import Icon from "../../../../components/icons";
 import { useApiIdGenerator } from "./fields/useApiIdGenerator";
 import { showSuccess } from "../toasts";
-import { toValidApiId } from "./fields/toValidApiId";
 
 const { apiFetch } = wp;
 

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import Icon from "../../../../components/icons";
 import { useApiIdGenerator } from "./fields/useApiIdGenerator";
 import { showSuccess } from "../toasts";
+import { toValidApiId } from "./fields/toValidApiId";
 
 const { apiFetch } = wp;
 
@@ -27,7 +28,6 @@ export default function Taxonomies() {
 		defaultValues: {
 			api_visibility: "private",
 			hierarchical: false,
-			slug: "",
 		},
 	});
 
@@ -60,6 +60,7 @@ export default function Taxonomies() {
 					});
 					window.scrollTo(0, 0);
 					reset();
+					setApiIdGeneratorInput(""); // Resets the API ID field.
 					showSuccess(
 						sprintf(
 							__(

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -33,7 +33,11 @@ export default function Taxonomies() {
 
 	const [singularCount, setSingularCount] = useState(0);
 	const [pluralCount, setPluralCount] = useState(0);
-	const { setApiIdGeneratorInput, apiIdFieldAttributes } = useApiIdGenerator({
+	const {
+		setApiIdGeneratorInput,
+		apiIdFieldAttributes,
+		setFieldsAreLinked,
+	} = useApiIdGenerator({
 		apiFieldId: "slug",
 		setValue,
 	});
@@ -70,6 +74,7 @@ export default function Taxonomies() {
 					window.scrollTo(0, 0);
 					reset();
 					setApiIdGeneratorInput(""); // Resets the API ID field.
+					setFieldsAreLinked(true);
 					showSuccess(
 						sprintf(
 							__(

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -1,16 +1,51 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { __ } from "@wordpress/i18n";
 import { ModelsContext } from "../ModelsContext";
+import { useForm } from "react-hook-form";
+import Icon from "../../../../components/icons";
+import { useApiIdGenerator } from "./fields/useApiIdGenerator";
 
 export default function Taxonomies() {
-	const { taxonomies, taxonomiesDispatch } = useContext(ModelsContext);
+	const { models, taxonomies, taxonomiesDispatch } = useContext(
+		ModelsContext
+	);
 	const history = useHistory();
+	const {
+		register,
+		handleSubmit,
+		errors,
+		setValue,
+		setError,
+		formState: { isSubmitting },
+	} = useForm({
+		defaultValues: {
+			api_visibility: "private",
+			hierarchical: false,
+		},
+	});
+
+	const [singularCount, setSingularCount] = useState(0);
+	const [pluralCount, setPluralCount] = useState(0);
+	const { setApiIdGeneratorInput, apiIdFieldAttributes } = useApiIdGenerator({
+		apiFieldId: "slug",
+		setValue,
+	});
+
+	function apiCreateTaxonomy(data) {
+		if (data?.type.length < 1) {
+			setError("type", {
+				type: "noModelSet",
+			});
+			return false;
+		}
+		console.log(data);
+	}
 
 	return (
 		<div className="app-card">
 			<section className="heading flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
-				<h2>Taxonomies</h2>
+				<h2>{__("Taxonomies", "atlas-content-modeler")}</h2>
 				<button
 					className="tertiary"
 					onClick={() => history.push(atlasContentModeler.appPath)}
@@ -21,9 +56,381 @@ export default function Taxonomies() {
 			<section className="card-content">
 				<div className="row">
 					<div className="col-xs-10 col-lg-4 order-1 order-lg-0">
-						Form goes here.
+						<h3>{__("Add New", "atlas-content-modeler")}</h3>
+						<form onSubmit={handleSubmit(apiCreateTaxonomy)}>
+							{/* Singular Name */}
+							<div
+								className={
+									errors.singular
+										? "field has-error"
+										: "field"
+								}
+							>
+								<label htmlFor="singular">
+									{__(
+										"Singular Name",
+										"atlas-content-modeler"
+									)}
+								</label>
+								<br />
+								<p className="help">
+									{__(
+										'Singular display name for your taxonomy, e.g. "Ingredient"',
+										"atlas-content-modeler"
+									)}
+									.
+								</p>
+								<input
+									id="singular"
+									name="singular"
+									placeholder="Ingredient"
+									className="w-100"
+									ref={register({
+										required: true,
+										maxLength: 50,
+									})}
+									onChange={(e) => {
+										setApiIdGeneratorInput(e.target.value);
+										setSingularCount(e.target.value.length);
+									}}
+								/>
+								<p className="field-messages">
+									{errors.singular &&
+										errors.singular.type === "required" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{__(
+														"This field is required",
+														"atlas-content-modeler"
+													)}
+												</span>
+											</span>
+										)}
+									{errors.singular &&
+										errors.singular.type ===
+											"maxLength" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{__(
+														"Exceeds max length.",
+														"atlas-content-modeler"
+													)}
+												</span>
+											</span>
+										)}
+									<span>&nbsp;</span>
+									<span className="count">
+										{singularCount}/50
+									</span>
+								</p>
+							</div>
+
+							{/* Plural Name */}
+							<div
+								className={
+									errors.plural ? "field has-error" : "field"
+								}
+							>
+								<label htmlFor="plural">
+									{__("Plural Name", "atlas-content-modeler")}
+								</label>
+								<br />
+								<p className="help">
+									{__(
+										'Plural display name for your taxonomy, e.g. "Ingredients".',
+										"atlas-content-modeler"
+									)}
+								</p>
+								<input
+									id="plural"
+									name="plural"
+									placeholder="Ingredients"
+									className="w-100"
+									ref={register({
+										required: true,
+										maxLength: 50,
+									})}
+									onChange={(event) => {
+										setPluralCount(
+											event.target.value.length
+										);
+									}}
+								/>
+								<p className="field-messages">
+									{errors.plural &&
+										errors.plural.type === "required" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{__(
+														"This field is required",
+														"atlas-content-modeler"
+													)}
+												</span>
+											</span>
+										)}
+									{errors.plural &&
+										errors.plural.type === "maxLength" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{__(
+														"Exceeds max length.",
+														"atlas-content-modeler"
+													)}
+												</span>
+											</span>
+										)}
+									<span>&nbsp;</span>
+									<span className="count">
+										{pluralCount}/50
+									</span>
+								</p>
+							</div>
+
+							{/* API Identifier / Slug */}
+							<div
+								className={
+									errors.slug ? "field has-error" : "field"
+								}
+							>
+								<label htmlFor="slug">
+									{__(
+										"API Identifier",
+										"atlas-content-modeler"
+									)}
+								</label>
+								<br />
+								<p className="help">
+									{__(
+										"Auto-generated from the singular name and used for API requests.",
+										"atlas-content-modeler"
+									)}
+								</p>
+								<input
+									id="slug"
+									name="slug"
+									className="w-100"
+									ref={register({
+										required: true,
+										maxLength: 20,
+									})}
+									{...apiIdFieldAttributes}
+								/>
+								<p className="field-messages">
+									{errors.slug &&
+										errors.slug.type === "required" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{__(
+														"This field is required",
+														"atlas-content-modeler"
+													)}
+												</span>
+											</span>
+										)}
+									{errors.slug &&
+										errors.slug.type === "maxLength" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{__(
+														"Exceeds max length of 20.",
+														"atlas-content-modeler"
+													)}
+												</span>
+											</span>
+										)}
+									{errors.slug &&
+										errors.slug.type === "idExists" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{errors.slug.message}
+												</span>
+											</span>
+										)}
+									<span>&nbsp;</span>
+								</p>
+							</div>
+
+							{/* Models / Types */}
+							<div
+								className={
+									errors.type ? "field has-error" : "field"
+								}
+							>
+								<fieldset>
+									<legend>
+										{__("Models", "atlas-content-modeler")}
+									</legend>
+									<p className="help">
+										{__(
+											"The models to make this taxonomy available on.",
+											"atlas-content-modeler"
+										)}
+									</p>
+									{Object.values(models).map((model) => {
+										return (
+											<div
+												className="checklist"
+												key={model.slug}
+											>
+												<label className="checkbox">
+													<input
+														type="checkbox"
+														value={model.slug}
+														name="type"
+														ref={register}
+													/>
+													{model.plural}
+												</label>
+												<br />
+											</div>
+										);
+									})}
+								</fieldset>
+								<p className="field-messages">
+									{errors.type &&
+										errors.type.type === "noModelSet" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{__(
+														"Please choose at least one model.",
+														"atlas-content-modeler"
+													)}
+												</span>
+											</span>
+										)}
+								</p>
+							</div>
+
+							{/* Hierarchical */}
+							<div
+								className={
+									errors.hierarchical
+										? "field has-error"
+										: "field"
+								}
+							>
+								<label htmlFor="hierarchical">
+									{__(
+										"Hierarchical",
+										"atlas-content-modeler"
+									)}
+								</label>
+								<br />
+								<p>
+									<input
+										name="hierarchical"
+										id="hierarchical"
+										type="checkbox"
+										ref={register()}
+									/>
+									<label
+										htmlFor="hierarchical"
+										className="checkbox"
+									>
+										Terms can have parents
+									</label>
+								</p>
+								<p className="help">
+									{__(
+										"Enable to allow taxonomy terms to have parents, like WordPress categories. Disable if terms will not have parents, like WordPress tags.",
+										"atlas-content-modeler"
+									)}
+								</p>
+							</div>
+
+							{/* API Visibility */}
+							<div
+								className={
+									errors.api_visibility
+										? "field has-error"
+										: "field"
+								}
+							>
+								<label htmlFor="api_visibility">
+									{__(
+										"API Visibility",
+										"atlas-content-modeler"
+									)}
+								</label>
+								<br />
+								<p className="help">
+									{__(
+										"Whether or not this taxonomy requires authentication to be accessed via REST and GraphQL APIs.",
+										"atlas-content-modeler"
+									)}
+								</p>
+
+								<input
+									id="api_visibility_public"
+									name="api_visibility"
+									type="radio"
+									value="public"
+									ref={register({ required: true })}
+								/>
+								<label htmlFor="api_visibility_public">
+									{__("Public", "atlas-content-modeler")}
+								</label>
+								<p className="help">
+									{__(
+										"No authentication is needed for REST and GraphQL.",
+										"atlas-content-modeler"
+									)}
+								</p>
+
+								<input
+									id="api_visibility_private"
+									name="api_visibility"
+									type="radio"
+									value="private"
+									ref={register({ required: true })}
+								/>
+								<label htmlFor="api_visibility_private">
+									{__("Private", "atlas-content-modeler")}
+								</label>
+								<p className="help">
+									{__(
+										"REST and GraphQL requests require authentication.",
+										"atlas-content-modeler"
+									)}
+								</p>
+
+								<p className="field-messages">
+									{errors.api_visibility &&
+										errors.api_visibility.type ===
+											"required" && (
+											<span className="error">
+												<Icon type="error" />
+												<span role="alert">
+													{__(
+														"This field is required",
+														"atlas-content-modeler"
+													)}
+												</span>
+											</span>
+										)}
+									<span>&nbsp;</span>
+								</p>
+							</div>
+
+							<button
+								type="submit"
+								disabled={isSubmitting}
+								className="primary first"
+							>
+								{__("Create", "atlas-content-modeler")}
+							</button>
+						</form>
 					</div>
 					<div className="col-xs-10 col-lg-6 order-0 order-lg-1">
+						{/* TODO: Display taxonomies in a table here. */}
 						{Object.values(taxonomies).map((taxonomy) => {
 							return (
 								<p key={taxonomy?.slug}>{taxonomy?.plural}</p>

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -39,7 +39,16 @@ export default function Taxonomies() {
 	});
 
 	function apiCreateTaxonomy(data) {
-		if (data.types.length < 1) {
+		// Wrap single models as an array.
+		if (typeof data.types === "string") {
+			data.types = [data.types];
+		}
+
+		// Check that at least one model was ticked.
+		if (
+			typeof data.types === "boolean" ||
+			(typeof data.types === "object" && data.types.length < 1)
+		) {
 			setError("types", {
 				type: "noModelSet",
 			});
@@ -476,7 +485,7 @@ export default function Taxonomies() {
 							</button>
 						</form>
 					</div>
-					<div className="col-xs-10 col-lg-6 order-0 order-lg-1">
+					<div className="taxonomy-list col-xs-10 col-lg-6 order-0 order-lg-1">
 						{/* TODO: Display taxonomies in a table here. */}
 						{Object.values(taxonomies).map((taxonomy) => {
 							return (

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -1,0 +1,37 @@
+import React, { useContext } from "react";
+import { useHistory } from "react-router-dom";
+import { __ } from "@wordpress/i18n";
+import { ModelsContext } from "../ModelsContext";
+
+export default function Taxonomies() {
+	const { taxonomies, taxonomiesDispatch } = useContext(ModelsContext);
+	const history = useHistory();
+
+	return (
+		<div className="app-card">
+			<section className="heading flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
+				<h2>Taxonomies</h2>
+				<button
+					className="tertiary"
+					onClick={() => history.push(atlasContentModeler.appPath)}
+				>
+					{__("View Content Models", "atlas-content-modeler")}
+				</button>
+			</section>
+			<section className="card-content">
+				<div className="row">
+					<div className="col-xs-10 col-lg-4 order-1 order-lg-0">
+						Form goes here.
+					</div>
+					<div className="col-xs-10 col-lg-6 order-0 order-lg-1">
+						{Object.values(taxonomies).map((taxonomy) => {
+							return (
+								<p key={taxonomy?.slug}>{taxonomy?.plural}</p>
+							);
+						})}
+					</div>
+				</div>
+			</section>
+		</div>
+	);
+}

--- a/includes/settings/js/src/components/ViewContentModelsList.jsx
+++ b/includes/settings/js/src/components/ViewContentModelsList.jsx
@@ -11,15 +11,28 @@ function Header({ showButton = true }) {
 		<section className="heading flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
 			<h2>Content Models</h2>
 			{showButton && (
-				<button
-					onClick={() =>
-						history.push(
-							atlasContentModeler.appPath + "&view=create-model"
-						)
-					}
-				>
-					{__("Add New", "atlas-content-modeler")}
-				</button>
+				<>
+					<button
+						className="tertiary taxonomies"
+						onClick={() =>
+							history.push(
+								atlasContentModeler.appPath + "&view=taxonomies"
+							)
+						}
+					>
+						{__("View Taxonomies", "atlas-content-modeler")}
+					</button>
+					<button
+						onClick={() =>
+							history.push(
+								atlasContentModeler.appPath +
+									"&view=create-model"
+							)
+						}
+					>
+						{__("New Model", "atlas-content-modeler")}
+					</button>
+				</>
 			)}
 		</section>
 	);

--- a/includes/settings/js/src/components/ViewContentModelsList.jsx
+++ b/includes/settings/js/src/components/ViewContentModelsList.jsx
@@ -5,12 +5,12 @@ import { sanitizeFields } from "../queries";
 import { ContentModelDropdown } from "./ContentModelDropdown";
 import { sprintf, __ } from "@wordpress/i18n";
 
-function Header({ showButton = true }) {
+function Header({ showButtons = true }) {
 	let history = useHistory();
 	return (
 		<section className="heading flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
 			<h2>Content Models</h2>
-			{showButton && (
+			{showButtons && (
 				<>
 					<button
 						className="tertiary taxonomies"
@@ -45,7 +45,7 @@ export default function ViewContentModelsList() {
 
 	return (
 		<div className="app-card">
-			<Header showButton={hasModels} />
+			<Header showButtons={hasModels} />
 			<section className="card-content">
 				{hasModels ? (
 					<ul className="model-list">

--- a/includes/settings/js/src/components/fields/useApiIdGenerator.js
+++ b/includes/settings/js/src/components/fields/useApiIdGenerator.js
@@ -42,6 +42,7 @@ export function useApiIdGenerator({
 	}
 
 	return {
+		setFieldsAreLinked,
 		setApiIdGeneratorInput,
 		apiIdFieldAttributes: {
 			onChange: (event) => {

--- a/includes/settings/js/src/taxonomiesReducer.js
+++ b/includes/settings/js/src/taxonomiesReducer.js
@@ -1,0 +1,10 @@
+/**
+ * Actions to update global taxonomy state.
+ */
+
+export function taxonomiesReducer(state, action) {
+	switch (action.type) {
+		default:
+			throw new Error(`${action.type} not found`);
+	}
+}

--- a/includes/settings/js/src/taxonomiesReducer.js
+++ b/includes/settings/js/src/taxonomiesReducer.js
@@ -4,6 +4,11 @@
 
 export function taxonomiesReducer(state, action) {
 	switch (action.type) {
+		case "addTaxonomy":
+			return {
+				...state,
+				[action.data.slug]: action.data,
+			};
 		default:
 			throw new Error(`${action.type} not found`);
 	}

--- a/includes/settings/scss/_app-card.scss
+++ b/includes/settings/scss/_app-card.scss
@@ -25,6 +25,11 @@
 	color: $color-primary-hover;
 }
 
+.app-card h3 {
+	font-size: 21px;
+	font-weight: bold;
+}
+
 .app-card .heading {
 	display: flex;
 	justify-content: space-between;

--- a/includes/settings/scss/_buttons.scss
+++ b/includes/settings/scss/_buttons.scss
@@ -61,6 +61,11 @@ button.tertiary:hover {
 	border: 1px solid $color-primary;
 }
 
+button.taxonomies {
+	margin-left: auto;
+	margin-right: 14px;
+}
+
 button.add-option {
 	border: 1px solid transparent;
 	padding: 14px 4px 14px 0;

--- a/includes/settings/scss/_forms.scss
+++ b/includes/settings/scss/_forms.scss
@@ -97,7 +97,7 @@
 	margin-top: 14px;
 }
 
-.atlas-content-modeler-admin-page legend {
+.atlas-content-modeler-admin-page .field-form legend {
 	margin-bottom: 19px;
 }
 
@@ -108,6 +108,13 @@
 
 .field-description {
 	margin-bottom: 21px;
+}
+
+.checklist {
+	margin-bottom: 14px;
+	&:last-of-type {
+		margin-bottom: 0;
+	}
 }
 
 .atlas-content-modeler-admin-page .field-messages {

--- a/includes/settings/settings-callbacks.php
+++ b/includes/settings/settings-callbacks.php
@@ -72,6 +72,7 @@ function enqueue_settings_assets( $hook ) {
 		'atlasContentModeler',
 		array(
 			'appPath'             => $admin_path . '?page=atlas-content-modeler',
+			'taxonomies'          => get_option( 'atlas_content_modeler_taxonomies', array() ),
 			'initialState'        => get_registered_content_types(),
 			'isGraphiQLAvailable' => is_plugin_active( 'wp-graphql/wp-graphql.php' )
 				&& function_exists( 'get_graphql_setting' )

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -54,10 +54,26 @@ class AcceptanceTester extends \Codeception\Actor
         $this->amOnPage($path);
     }
 
-    /**
-     * Create a Content Model.
-     *
-     * @param string $singular    Singular content model name.
+	/**
+	 * Visit the Taxonomy page.
+	 *
+	 * @param string $params Optional query parameter string.
+	 */
+	public function amOnTaxonomyListingsPage($params = '')
+	{
+		$path = '/wp-admin/admin.php?page=atlas-content-modeler&view=taxonomies';
+
+		if ( $params ) {
+			$path .= $params;
+		}
+
+		$this->amOnPage($path);
+	}
+
+	/**
+	 * Create a Content Model.
+	 *
+	 * @param string $singular    Singular content model name.
      * @param string $plural      Plural content model name.
      * @param string $description Content model description.
      */

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -1,0 +1,120 @@
+<?php
+
+class CreateTaxonomyCest
+{
+	public function _before(\AcceptanceTester $I)
+	{
+		$I->maximizeWindow();
+		$I->loginAsAdmin();
+		$I->haveContentModel('goose', 'geese');
+		$I->wait(1);
+	}
+
+	public function i_can_navigate_to_the_taxonomies_page(AcceptanceTester $I)
+	{
+		$I->amOnWPEngineContentModelPage();
+		$I->wait(1);
+		$I->see('View Taxonomies', 'button.taxonomies');
+		$I->click('button.taxonomies');
+		$I->wait(1);
+		$I->see('Taxonomies', 'section.heading h2');
+	}
+
+	public function i_can_create_a_taxonomy(AcceptanceTester $I)
+	{
+		$I->amOnTaxonomyListingsPage();
+		$I->wait(1);
+
+		$I->fillField(['name' => 'singular'], 'Breed');
+		$I->fillField(['name' => 'plural'], 'Breeds');
+		$I->click('.checklist .checkbox'); // The “goose” model.
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+		$I->see('taxonomy was created', '#success');
+		$I->see('Breeds', '.taxonomy-list');
+
+		// Form fields should reset when a submission was successful.
+		$I->seeInField("#singular", "");
+		$I->seeInField("#plural", "");
+		$I->seeInField("#slug", "");
+	}
+
+	public function i_can_not_create_a_taxonomy_without_ticking_a_model(AcceptanceTester $I)
+	{
+		$I->amOnTaxonomyListingsPage();
+		$I->wait(1);
+
+		$I->fillField(['name' => 'singular'], 'Breed');
+		$I->fillField(['name' => 'plural'], 'Breeds');
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+		$I->see('Please choose at least one model');
+	}
+
+	public function i_can_not_create_a_taxonomy_without_filling_the_singular_name(AcceptanceTester $I)
+	{
+		$I->amOnTaxonomyListingsPage();
+		$I->wait(1);
+
+		$I->fillField(['name' => 'plural'], 'Breeds');
+		$I->click('.checklist .checkbox'); // The “goose” model.
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+		$I->see('This field is required');
+	}
+
+	public function i_can_not_create_a_taxonomy_without_filling_the_plural_name(AcceptanceTester $I)
+	{
+		$I->amOnTaxonomyListingsPage();
+		$I->wait(1);
+
+		$I->fillField(['name' => 'singular'], 'Breed');
+		$I->click('.checklist .checkbox'); // The “goose” model.
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+		$I->see('This field is required');
+	}
+
+	public function i_can_not_create_a_taxonomy_if_the_slug_already_exists(AcceptanceTester $I)
+	{
+		$I->amOnTaxonomyListingsPage();
+		$I->wait(1);
+
+		$I->fillField(['name' => 'singular'], 'Breed');
+		$I->fillField(['name' => 'plural'], 'Breeds');
+		$I->click('.checklist .checkbox'); // The “goose” model.
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+
+		// Create another taxonomy with the same info.
+		$I->fillField(['name' => 'singular'], 'Breed');
+		$I->fillField(['name' => 'plural'], 'Breeds');
+		$I->click('.checklist .checkbox');
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+
+		$I->see('A taxonomy with this API Identifier already exists');
+	}
+
+	public function i_can_see_a_generated_slug_when_creating_a_second_taxonomy_after_editing_the_slug_in_the_first(AcceptanceTester $I)
+	{
+		$I->amOnTaxonomyListingsPage();
+		$I->wait(1);
+
+		$I->fillField(['name' => 'singular'], 'First');
+		$I->fillField(['name' => 'plural'], 'Firsts');
+		// Edit the slug manually to break the “link” with the singular field.
+		$I->fillField(['name' => 'slug'], 'myFirst');
+		$I->click('.checklist .checkbox'); // The “goose” model.
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+		$I->see('taxonomy was created', '#success');
+		$I->see('Firsts', '.taxonomy-list');
+
+		// A successful submission should relink the Singular and API ID fields
+		// so they are linked for the next entry. Confirm the fields were
+		// relinked: filling "singular" should auto-generate a slug.
+		$I->fillField(['name' => 'singular'], 'Second');
+		$I->seeInField('#slug', 'second');
+	}
+}

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -37,6 +37,9 @@ class CreateTaxonomyCest
 		$I->seeInField("#singular", "");
 		$I->seeInField("#plural", "");
 		$I->seeInField("#slug", "");
+
+		// Character counts should reset.
+		$I->see('0/50', '.field .count');
 	}
 
 	public function i_can_not_create_a_taxonomy_without_ticking_a_model(AcceptanceTester $I)

--- a/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
+++ b/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
@@ -1,0 +1,141 @@
+<?php
+class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
+	protected $server;
+
+	protected $namespace = 'wpe';
+
+	protected $route = 'atlas/taxonomy';
+
+	protected $taxonomy_option = 'atlas_content_modeler_taxonomies';
+
+	/**
+	 * @var array Taxonomies installed during setup.
+	 */
+	protected $starting_taxonomies = [
+		'ingredient' => [
+			'slug'     => 'ingredient',
+			'singular' => 'Ingredient',
+			'plural'   => 'Ingredients',
+		],
+	];
+
+	/**
+	 * @var array Taxonomies used in tests.
+	 */
+	protected $test_taxonomies = [
+		'ingredient' => [
+			'slug'     => 'ingredient',
+			'singular' => 'Test Changing Singular Name',
+			'plural'   => 'Test Changing Plural Name',
+		],
+		'new' => [
+			'slug'     => 'new',
+			'singular' => 'New',
+			'plural'   => 'News',
+		],
+		'missingSlug' => [
+			'singular' => 'Missing Slug',
+			'plural'   => 'Missing Slugs',
+		],
+		'missingSingular' => [
+			'slug'     => 'missingSingular',
+			'plural'   => 'Missing Singulars',
+		],
+		'missingPlural' => [
+			'slug'     => 'missingPlural',
+			'singular' => 'Missing Plural',
+		],
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new \WP_REST_Server;
+		update_option( $this->taxonomy_option, $this->starting_taxonomies );
+		do_action( 'rest_api_init' );
+	}
+
+	public function test_taxonomy_route_is_registered(): void {
+		$routes = $this->server->get_routes( 'wpe' );
+		self::assertArrayHasKey( "/{$this->namespace}/{$this->route}", $routes );
+	}
+
+	public function test_can_create_new_taxonomy(): void {
+		wp_set_current_user( 1 );
+
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $this->test_taxonomies['new'] ) );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 200, $response->get_status() );
+		self::assertSame( true, $response->data['success'] );
+	}
+
+	public function test_cannot_create_taxonomy_when_slug_conflicts_with_existing_taxonomy(): void {
+		wp_set_current_user( 1 );
+
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $this->test_taxonomies['ingredient'] ) );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'atlas_content_modeler_taxonomy_exists', $response->data['code'] );
+	}
+
+	public function test_cannot_create_taxonomy_without_slug(): void {
+		wp_set_current_user( 1 );
+
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $this->test_taxonomies['missingSlug'] ) );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'atlas_content_modeler_invalid_id', $response->data['code'] );
+	}
+
+	public function test_cannot_create_taxonomy_without_singular_name(): void {
+		wp_set_current_user( 1 );
+
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $this->test_taxonomies['missingSingular'] ) );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'atlas_content_modeler_invalid_labels', $response->data['code'] );
+	}
+
+	public function test_cannot_create_taxonomy_without_plural_name(): void {
+		wp_set_current_user( 1 );
+
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $this->test_taxonomies['missingPlural'] ) );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'atlas_content_modeler_invalid_labels', $response->data['code'] );
+	}
+
+	public function test_can_update_taxonomy_with_put_request(): void {
+		wp_set_current_user( 1 );
+
+		$request = new WP_REST_Request( 'PUT', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $this->test_taxonomies['ingredient'] ) );
+		$response = $this->server->dispatch( $request );
+		$taxonomies = get_option( $this->taxonomy_option );
+
+		self::assertSame( 200, $response->get_status() );
+		self::assertSame( 'Test Changing Singular Name', $taxonomies['ingredient']['singular'] );
+		self::assertSame( 'Test Changing Plural Name', $taxonomies['ingredient']['plural'] );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		delete_option( $this->taxonomy_option );
+	}
+}

--- a/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
+++ b/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
@@ -23,6 +23,11 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 	 * @var array Taxonomies used in tests.
 	 */
 	protected $test_taxonomies = [
+		'category' => [
+			'slug'     => 'category',
+			'singular' => 'Test Existing WP Core Taxonomy',
+			'plural'   => 'Test Existing WP Core Taxonomies',
+		],
 		'ingredient' => [
 			'slug'     => 'ingredient',
 			'singular' => 'Test Changing Singular Name',
@@ -72,7 +77,19 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 		self::assertSame( true, $response->data['success'] );
 	}
 
-	public function test_cannot_create_taxonomy_when_slug_conflicts_with_existing_taxonomy(): void {
+	public function test_cannot_create_taxonomy_when_slug_conflicts_with_existing_core_taxonomy(): void {
+		wp_set_current_user( 1 );
+
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $this->test_taxonomies['category'] ) );
+		$response = $this->server->dispatch( $request );
+
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'atlas_content_modeler_taxonomy_exists', $response->data['code'] );
+	}
+
+	public function test_cannot_create_taxonomy_when_slug_conflicts_with_existing_acm_taxonomy(): void {
 		wp_set_current_user( 1 );
 
 		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );


### PR DESCRIPTION
- Adds a new taxonomies view at `/wp-admin/?page=atlas-content-modeler&view=taxonomies`.
- Adds a “View Taxonomies” button on the main model listings page (for now; this may move later).

<img width="1470" alt="Screenshot 2021-06-30 at 11 43 32" src="https://user-images.githubusercontent.com/647669/123939499-78ceb080-d998-11eb-809e-f672ed98d13b.png">

<img width="1452" alt="Screenshot 2021-06-30 at 11 43 21" src="https://user-images.githubusercontent.com/647669/123939512-7c623780-d998-11eb-98eb-f1a500bcc97c.png">

### To test
1. Visit the developer app at `/wp-admin/admin.php?page=atlas-content-modeler`.
2. Click “View Taxonomies”.
3. Try adding taxonomies. You should see them in the list to the right of the taxonomies form.
4. Run `wp option get atlas_content_modeler_taxonomies` or view that row in the WP options table to see the result of your submission as data.
 
### Notes
- We plan to improve the listing of taxonomies in [BH-1078](https://wpengine.atlassian.net/browse/BH-1078) (“List Taxonomies”). I added the listing area to the right of the form as a placeholder for now just to wire up the data.
- Perhaps we could re-use the existing form in [BH-1076](https://wpengine.atlassian.net/browse/BH-1076) (“Edit Taxonomy”)? We could hide the list view in edit mode and present only the form with submit/cancel buttons.
