### PR TITLE
[BH-1054] Add CodeClimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,32 @@
+version: "2"         # required to adjust maintainability checks
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    config:
+      threshold: 250
+  method-complexity:
+    config:
+      threshold: 5
+  method-count:
+    config:
+      threshold: 20
+  method-lines:
+    config:
+      threshold: 25
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+  identical-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,7 +8,7 @@ checks:
       threshold: 4
   file-lines:
     config:
-      threshold: 250
+      threshold: 500
   method-complexity:
     config:
       threshold: 5
@@ -30,6 +30,8 @@ checks:
   identical-code:
     config:
       threshold: # language-specific defaults. an override will affect all languages.
+  exclude_patterns:
+    - "*.jsx"
   plugins:
     eslint:
       enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,8 +30,6 @@ checks:
   identical-code:
     config:
       threshold: # language-specific defaults. an override will affect all languages.
-  exclude_patterns:
-  - "*.jsx"
   plugins:
     eslint:
       enabled: true
@@ -48,3 +46,5 @@ checks:
       enabled: true
     fixme:
       enabled: true
+  exclude_patterns:
+  - "**/*.jsx"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -46,5 +46,5 @@ checks:
       enabled: true
     fixme:
       enabled: true
-  exclude_patterns:
-    - "**/*.jsx"
+exclude_patterns:
+  - "**/*.jsx"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -48,3 +48,4 @@ checks:
       enabled: true
 exclude_patterns:
   - "**/*.jsx"
+  - "tests/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,3 +30,12 @@ checks:
   identical-code:
     config:
       threshold: # language-specific defaults. an override will affect all languages.
+  plugins:
+    rubocop:
+      enabled: true
+    eslint:
+      enabled: true
+    phpmd:
+      enabled: true
+    duplication:
+      enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -31,7 +31,7 @@ checks:
     config:
       threshold: # language-specific defaults. an override will affect all languages.
   exclude_patterns:
-    - "*.jsx"
+  - "*.jsx"
   plugins:
     eslint:
       enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -33,7 +33,16 @@ checks:
   plugins:
     eslint:
       enabled: true
+      config:
+        config: .eslintrc
+        extensions:
+          - .js
+          - .jsx
     phpmd:
       enabled: true
     duplication:
+      enabled: true
+    sonar-php:
+      enabled: true
+    fixme:
       enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -46,3 +46,5 @@ checks:
       enabled: true
     fixme:
       enabled: true
+  exclude_patterns:
+    - "**/*.jsx"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -46,5 +46,3 @@ checks:
       enabled: true
     fixme:
       enabled: true
-  exclude_patterns:
-  - "**/*.jsx"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -31,8 +31,6 @@ checks:
     config:
       threshold: # language-specific defaults. an override will affect all languages.
   plugins:
-    rubocop:
-      enabled: true
     eslint:
       enabled: true
     phpmd:


### PR DESCRIPTION
This adds a very basic codeclimate config along with 5 of their plugins:

* phpmd
* eslint (probably isn't needed but doesn't hurt anything)
* duplication 
* sonar-php
* fixme

(see https://docs.codeclimate.com/docs/list-of-engines)

Note this is configured to get us started. The complexity checks do require a different way of looking at code, from experience with them. We can tune further as we learn what works best for us. In addition, I've excluded jsx for now as the logic for the complexity checks simply throws too many false positives with it.