### PR TITLE
[BH-1109] fix: handle lowercased model labels in graphiQL query generator

### DIFF
--- a/includes/settings/js/src/utils.js
+++ b/includes/settings/js/src/utils.js
@@ -101,8 +101,11 @@ export const maybeCloseDropdown = (setDropdownOpen, timer) => {
  * @return {string} The GraphiQL URL with query param prefilled.
  */
 export const getGraphiQLLink = (modelData) => {
-	const modelSingular = modelData.singular.replace(/\s/g, "");
-	const fragmentName = `${modelSingular}Fields`;
+	const graphQLType = toValidApiId(modelData.singular).replace(
+		/^[a-z]/g,
+		(match) => match.toUpperCase() // GraphQL's "Types" are all capitalized
+	);
+	const fragmentName = `${graphQLType}Fields`;
 	const pluralSlug = toValidApiId(modelData.plural);
 
 	const fields = sanitizeFields(modelData?.fields);
@@ -148,7 +151,7 @@ ${fields[id]?.slug} {
   }
 }
 
-fragment ${fragmentName} on ${modelSingular} {
+fragment ${fragmentName} on ${graphQLType} {
   ${fieldSlugs.join("\n  ")}
 }
 `;

--- a/includes/settings/js/src/utils.js
+++ b/includes/settings/js/src/utils.js
@@ -103,7 +103,7 @@ export const maybeCloseDropdown = (setDropdownOpen, timer) => {
 export const getGraphiQLLink = (modelData) => {
 	const graphQLType = toValidApiId(modelData.singular).replace(
 		/^[a-z]/g,
-		(match) => match.toUpperCase() // GraphQL's "Types" are all capitalized
+		(match) => match.toUpperCase() // GraphQL's "Types" are all capitalized.
 	);
 	const fragmentName = `${graphQLType}Fields`;
 	const rootToTypeConnectionFieldName =

--- a/includes/settings/js/src/utils.js
+++ b/includes/settings/js/src/utils.js
@@ -139,7 +139,7 @@ ${fields[id]?.slug} {
 	});
 
 	if (fieldSlugs.length === 0) {
-		fieldSlugs.push("title");
+		fieldSlugs.push("databaseId");
 	}
 
 	const query = `

--- a/includes/settings/js/src/utils.js
+++ b/includes/settings/js/src/utils.js
@@ -106,7 +106,10 @@ export const getGraphiQLLink = (modelData) => {
 		(match) => match.toUpperCase() // GraphQL's "Types" are all capitalized
 	);
 	const fragmentName = `${graphQLType}Fields`;
-	const pluralSlug = toValidApiId(modelData.plural);
+	const rootToTypeConnectionFieldName =
+		modelData.singular !== modelData.plural
+			? toValidApiId(modelData.plural)
+			: "all" + graphQLType;
 
 	const fields = sanitizeFields(modelData?.fields);
 	const fieldSlugs = getFieldOrder(fields).map((id) => {
@@ -144,7 +147,7 @@ ${fields[id]?.slug} {
 
 	const query = `
 {
-  ${pluralSlug}(first: 10) {
+  ${rootToTypeConnectionFieldName}(first: 10) {
     nodes {
       ...${fragmentName}
     }

--- a/tests/acceptance/OpenInGraphiQLCest.php
+++ b/tests/acceptance/OpenInGraphiQLCest.php
@@ -2,12 +2,36 @@
 
 class OpenInGraphiQLCest
 {
-	/**
-	 * Ensure the “Open in GraphiQL” model option opens GraphiQL with a pre-filled query.
-	 */
-	public function i_can_open_my_model_in_graphiql(AcceptanceTester $I)
+	public function _before(\AcceptanceTester $I)
 	{
 		$I->loginAsAdmin();
+	}
+
+	/**
+	 * Ensure the “Open in GraphiQL” model option opens GraphiQL with a valid pre-filled
+	 * query when the model has no fields.
+	 */
+	public function i_can_open_model_with_no_fields_in_graphiql(AcceptanceTester $I)
+	{
+		$I->haveContentModel('Dog', 'Dogs');
+		$I->wait(1);
+
+		$I->click('.heading .options'); // Model options button.
+		$I->click('.show-in-graphiql');
+		$I->switchToNextTab(); // GraphiQL opens in a new tab.
+		$I->wait(2); // Give GraphiQL time for linting.
+
+		$I->see('Dog', '#graphiql');
+		// Check for query errors marked by GraphiQL linter.
+		$I->dontSeeElementInDOM('#graphiql .CodeMirror-lint-mark-error');
+	}
+
+	/**
+	 * Ensure the “Open in GraphiQL” model option opens GraphiQL with a valid pre-filled
+	 * query, including the model's fields.
+	 */
+	public function i_can_open_a_model_with_fields_in_graphiql(AcceptanceTester $I)
+	{
 		$I->haveContentModel('Dog', 'Dogs');
 		$I->wait(1);
 
@@ -20,8 +44,48 @@ class OpenInGraphiQLCest
 		$I->click('.heading .options'); // Model options button.
 		$I->click('.show-in-graphiql');
 		$I->switchToNextTab(); // GraphiQL opens in a new tab.
-		$I->wait(1);
+		$I->wait(2); // Give GraphiQL time for linting.
 
 		$I->see('wagsPerMinute', '#graphiql');
+		// Check for query errors marked by GraphiQL linter.
+		$I->dontSeeElementInDOM('#graphiql .CodeMirror-lint-mark-error');
+	}
+
+	/**
+	 * Ensure the “Open in GraphiQL” model option opens GraphiQL with a valid pre-filled
+	 * query when the model singular and plural names are not capitalized.
+	 */
+	public function i_can_open_model_with_lowercased_model_names_in_graphiql(AcceptanceTester $I)
+	{
+		$I->haveContentModel('cat', 'cats');
+		$I->wait(1);
+
+		$I->click('.heading .options'); // Model options button.
+		$I->click('.show-in-graphiql');
+		$I->switchToNextTab(); // GraphiQL opens in a new tab.
+		$I->wait(2); // Give GraphiQL time for linting.
+
+		$I->see('Cat', '#graphiql');
+		// Check for query errors marked by GraphiQL linter.
+		$I->dontSeeElementInDOM('#graphiql .CodeMirror-lint-mark-error');
+	}
+
+	/**
+	 * Ensure the “Open in GraphiQL” model option opens GraphiQL with a valid pre-filled
+	 * query when the model singular and plural names are identical.
+	 */
+	public function i_can_open_model_with_same_singular_and_plural_name_in_graphiql(AcceptanceTester $I)
+	{
+		$I->haveContentModel('deer', 'deer');
+		$I->wait(1);
+
+		$I->click('.heading .options'); // Model options button.
+		$I->click('.show-in-graphiql');
+		$I->switchToNextTab(); // GraphiQL opens in a new tab.
+		$I->wait(2); // Give GraphiQL time for linting.
+
+		$I->see('Deer', '#graphiql');
+		// Check for query errors marked by GraphiQL linter.
+		$I->dontSeeElementInDOM('#graphiql .CodeMirror-lint-mark-error');
 	}
 }


### PR DESCRIPTION
## Description
<!--
Include a summary of the change and some contextual information.
-->

- Fixes invalid GraphiQL queries generated from models that use lowercased names
- Fixes invalid GraphiQL queries generated on models that have no fields
- Adapts to new WPGraphQL convention of prepending the singular name with `all` to generate the plural field name when singular and plural names are identical

We'll want to circle back to this before we start adding pre-generated queries in too many other places, but this should patch things for now. I looked into using GraphQL introspection queries to look up the exact format of the schema as it is registered in WPGraphQL and while definitely possible, it's going to be a much bigger task.

<!--
Provide a link to the JIRA ticket (if any) for issue tracking purposes
-->

https://wpengine.atlassian.net/browse/BH-1109

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->
To test models with lowercased names and no fields:

1. Create a model using lowercased 'cat' and 'cats' as the singular and plural names, respectively (case sensitive)
2. In the model's "..." options menu, click "Open in GraphiQL".
3. See that there are no linting errors and the query runs successfully.

To test models with same singular and plural names:

1. Make sure you're running at least WPGraphQL v1.5.0.
2. Create a model using lowercased 'deer' and 'deer' as the singular and plural names, respectively
3. In the model's "..." options menu, click "Open in GraphiQL".
4. See that there are no linting errors, the query includes `allDeer`, and the query runs successfully. 
