### PR TITLE
BH-1078: Add Taxonomy List

### DIFF
--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import Icon from "../../../../components/icons";
 import { useApiIdGenerator } from "./fields/useApiIdGenerator";
 import { showSuccess } from "../toasts";
+import TaxonomiesTable from "./TaxonomiesTable";
 
 const { apiFetch } = wp;
 
@@ -99,7 +100,7 @@ export default function Taxonomies() {
 	}
 
 	return (
-		<div className="app-card">
+		<div className="app-card taxonomies-view">
 			<section className="heading flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
 				<h2>{__("Taxonomies", "atlas-content-modeler")}</h2>
 				<button
@@ -491,13 +492,8 @@ export default function Taxonomies() {
 							</button>
 						</form>
 					</div>
-					<div className="taxonomy-list col-xs-10 col-lg-6 order-0 order-lg-1">
-						{/* TODO: Display taxonomies in a table here. */}
-						{Object.values(taxonomies).map((taxonomy) => {
-							return (
-								<p key={taxonomy?.slug}>{taxonomy?.plural}</p>
-							);
-						})}
+					<div className="taxonomy-list col-xs-10 col-lg-7 order-0 order-lg-1">
+						<TaxonomiesTable taxonomies={taxonomies} />
 					</div>
 				</div>
 			</section>

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -492,7 +492,7 @@ export default function Taxonomies() {
 							</button>
 						</form>
 					</div>
-					<div className="taxonomy-list col-xs-10 col-lg-7 order-0 order-lg-1">
+					<div className="taxonomy-list col-xs-10 col-lg-8 order-0 order-lg-1">
 						<TaxonomiesTable taxonomies={taxonomies} />
 					</div>
 				</div>

--- a/includes/settings/js/src/components/TaxonomiesDropdown.jsx
+++ b/includes/settings/js/src/components/TaxonomiesDropdown.jsx
@@ -1,0 +1,155 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import Icon from "../../../../components/icons";
+import Modal from "react-modal";
+import { maybeCloseDropdown } from "../utils";
+import { sprintf, __ } from "@wordpress/i18n";
+
+export const TaxonomiesDropdown = ({ taxonomy }) => {
+	const [dropdownOpen, setDropdownOpen] = useState(false);
+	const [modalIsOpen, setModalIsOpen] = useState(false);
+	const timer = useRef(null);
+
+	const customStyles = {
+		overlay: {
+			backgroundColor: "rgba(0, 40, 56, 0.7)",
+		},
+		content: {
+			top: "50%",
+			left: "50%",
+			right: "auto",
+			bottom: "auto",
+			marginRight: "-50%",
+			transform: "translate(-50%, -50%)",
+			border: "none",
+			padding: "40px",
+		},
+	};
+
+	const handleKeyPress = useCallback(
+		(e) => {
+			if (e.key === "Escape") {
+				setDropdownOpen(false);
+			}
+		},
+		[setDropdownOpen]
+	);
+
+	useEffect(() => {
+		if (dropdownOpen) {
+			document.addEventListener("keydown", handleKeyPress);
+		} else {
+			document.removeEventListener("keydown", handleKeyPress);
+		}
+
+		return () => document.removeEventListener("keydown", handleKeyPress);
+	}, [dropdownOpen, handleKeyPress]);
+
+	useEffect(() => {
+		return () => clearTimeout(timer.current);
+	}, [timer]);
+
+	return (
+		<span className="dropdown">
+			<button
+				className="options py-sm-0 py-2"
+				onBlur={() => maybeCloseDropdown(setDropdownOpen, timer)}
+				onClick={() => setDropdownOpen(!dropdownOpen)}
+				aria-label={sprintf(
+					__("Options for the %s taxonomy.", "atlas-content-modeler"),
+					taxonomy.plural
+				)}
+			>
+				<Icon type="options" />
+			</button>
+			<div className={`dropdown-content ${dropdownOpen ? "" : "hidden"}`}>
+				<a
+					href="#"
+					aria-label={sprintf(
+						__("Edit the %s taxonomy.", "atlas-content-modeler"),
+						taxonomy.plural
+					)}
+					onBlur={() => maybeCloseDropdown(setDropdownOpen, timer)}
+					onClick={(event) => {
+						event.preventDefault();
+						// TODO: implement editing here.
+						alert("TODO: Implement editing here.");
+						setDropdownOpen(false);
+					}}
+				>
+					{__("Edit", "atlas-content-modeler")}
+				</a>
+				<a
+					className="delete"
+					href="#"
+					aria-label={sprintf(
+						__("Delete the %s taxonomy.", "atlas-content-modeler"),
+						taxonomy.plural
+					)}
+					onBlur={() => maybeCloseDropdown(setDropdownOpen, timer)}
+					onClick={(event) => {
+						event.preventDefault();
+						setDropdownOpen(false);
+						setModalIsOpen(true);
+					}}
+				>
+					{__("Delete", "atlas-content-modeler")}
+				</a>
+			</div>
+			<Modal
+				isOpen={modalIsOpen}
+				contentLabel={sprintf(
+					__("Delete the %s taxonomy?", "atlas-content-modeler"),
+					taxonomy.plural
+				)}
+				portalClassName="atlas-content-modeler-delete-field-modal-container"
+				onRequestClose={() => {
+					setModalIsOpen(false);
+				}}
+				// taxonomy={taxonomy}
+				style={customStyles}
+			>
+				<h2>
+					{sprintf(
+						__("Delete the %s taxonomy?", "atlas-content-modeler"),
+						taxonomy.plural
+					)}
+				</h2>
+				<p>
+					{__(
+						"This will delete the taxonomy and related data.",
+						"atlas-content-modeler"
+					)}
+				</p>
+				<p>
+					{sprintf(
+						__(
+							"Are you sure you want to delete the %s taxonomy? ",
+							"atlas-content-modeler"
+						),
+						taxonomy.plural
+					)}
+				</p>
+				<button
+					type="submit"
+					form={taxonomy.slug}
+					className="first warning"
+					onClick={() => {
+						// TODO: implement deletion here. See FieldOptionsDropdown.jsx.
+						alert("TODO: implement deletion here.");
+						setModalIsOpen(false);
+					}}
+				>
+					{__("Delete", "atlas-content-modeler")}
+				</button>
+				<button
+					className="tertiary"
+					onClick={() => {
+						setModalIsOpen(false);
+					}}
+				>
+					{__("Cancel", "atlas-content-modeler")}
+				</button>
+			</Modal>
+		</span>
+	);
+};

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { __, sprintf } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 import { TaxonomiesDropdown } from "./TaxonomiesDropdown";
 
 const TaxonomiesTable = ({ taxonomies = {} }) => {

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -47,7 +47,7 @@ const TaxonomiesTable = ({ taxonomies = {} }) => {
 								<td>{taxonomy?.plural}</td>
 								<td>{taxonomy?.slug}</td>
 								<td>{taxonomy?.types?.join(", ")}</td>
-								<td className="action">
+								<td className="action right">
 									<div className="neg-margin-wrapper">
 										<TaxonomiesDropdown
 											taxonomy={taxonomy}

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -10,7 +10,14 @@ const TaxonomiesTable = ({ taxonomies = {} }) => {
 				<thead>
 					<tr>
 						<th className="checkbox">
-							<input type="checkbox" className="check-all" />
+							<input
+								type="checkbox"
+								className="check-all"
+								aria-label={__(
+									"Toggle selection of all taxonomies to apply a bulk action",
+									"atlas-content-modeler"
+								)}
+							/>
 						</th>
 						<th>{__("Name", "atlas-content-modeler")}</th>
 						<th>{__("Slug", "atlas-content-modeler")}</th>
@@ -28,6 +35,13 @@ const TaxonomiesTable = ({ taxonomies = {} }) => {
 									<input
 										type="checkbox"
 										className="check-all"
+										aria-label={sprintf(
+											__(
+												"Toggle selection of the %s taxonomy.",
+												"atlas-content-modeler"
+											),
+											taxonomy.plural
+										)}
 									/>
 								</td>
 								<td>{taxonomy?.plural}</td>

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -5,11 +5,13 @@ import { TaxonomiesDropdown } from "./TaxonomiesDropdown";
 const TaxonomiesTable = ({ taxonomies = {} }) => {
 	return (
 		<>
-			<select name="bulk-action">
-				<option value="-1">Bulk actions</option>
-				<option value="delete">Delete</option>
-			</select>
-			<button className="button action">Apply</button>
+			<div className="bulk-actions">
+				<select name="bulk-action">
+					<option value="-1">Bulk action</option>
+					<option value="delete">Delete</option>
+				</select>
+				<button className="tertiary">Apply</button>
+			</div>
 			<table className="table table-striped">
 				<thead>
 					<tr>

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -3,6 +3,17 @@ import { __ } from "@wordpress/i18n";
 import { TaxonomiesDropdown } from "./TaxonomiesDropdown";
 
 const TaxonomiesTable = ({ taxonomies = {} }) => {
+	if (Object.values(taxonomies).length < 1) {
+		return (
+			<p>
+				{__(
+					"You currently have no taxonomies.",
+					"atlas-content-modeler"
+				)}
+			</p>
+		);
+	}
+
 	return (
 		<>
 			<table className="table table-striped">

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
+import { TaxonomiesDropdown } from "./TaxonomiesDropdown";
 
 const TaxonomiesTable = ({ taxonomies = {} }) => {
 	return (
@@ -33,7 +34,11 @@ const TaxonomiesTable = ({ taxonomies = {} }) => {
 								<td>{taxonomy?.slug}</td>
 								<td>{taxonomy?.types?.join(", ")}</td>
 								<td className="action">
-									<button>...</button>
+									<div className="neg-margin-wrapper">
+										<TaxonomiesDropdown
+											taxonomy={taxonomy}
+										/>
+									</div>
 								</td>
 							</tr>
 						);

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -5,26 +5,9 @@ import { TaxonomiesDropdown } from "./TaxonomiesDropdown";
 const TaxonomiesTable = ({ taxonomies = {} }) => {
 	return (
 		<>
-			<div className="bulk-actions">
-				<select name="bulk-action">
-					<option value="-1">Bulk action</option>
-					<option value="delete">Delete</option>
-				</select>
-				<button className="tertiary">Apply</button>
-			</div>
 			<table className="table table-striped">
 				<thead>
 					<tr>
-						<th className="checkbox">
-							<input
-								type="checkbox"
-								className="check-all"
-								aria-label={__(
-									"Toggle selection of all taxonomies to apply a bulk action",
-									"atlas-content-modeler"
-								)}
-							/>
-						</th>
 						<th>{__("Name", "atlas-content-modeler")}</th>
 						<th>{__("Slug", "atlas-content-modeler")}</th>
 						<th>{__("Models", "atlas-content-modeler")}</th>
@@ -37,19 +20,6 @@ const TaxonomiesTable = ({ taxonomies = {} }) => {
 					{Object.values(taxonomies).map((taxonomy) => {
 						return (
 							<tr key={taxonomy?.slug}>
-								<td className="checkbox">
-									<input
-										type="checkbox"
-										className="check-all"
-										aria-label={sprintf(
-											__(
-												"Toggle selection of the %s taxonomy.",
-												"atlas-content-modeler"
-											),
-											taxonomy.plural
-										)}
-									/>
-								</td>
 								<td>{taxonomy?.plural}</td>
 								<td>{taxonomy?.slug}</td>
 								<td>{taxonomy?.types?.join(", ")}</td>

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { __ } from "@wordpress/i18n";
+
+const TaxonomiesTable = ({ taxonomies = {} }) => {
+	return (
+		<>
+			<p>TODO: add Bulk Action here</p>
+			<table className="table table-striped">
+				<thead>
+					<tr>
+						<th className="checkbox">
+							<input type="checkbox" className="check-all" />
+						</th>
+						<th>{__("Name", "atlas-content-modeler")}</th>
+						<th>{__("Slug", "atlas-content-modeler")}</th>
+						<th>{__("Models", "atlas-content-modeler")}</th>
+						<th className="action">
+							{__("Action", "atlas-content-modeler")}
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{Object.values(taxonomies).map((taxonomy) => {
+						return (
+							<tr key={taxonomy?.slug}>
+								<td className="checkbox">
+									<input
+										type="checkbox"
+										className="check-all"
+									/>
+								</td>
+								<td>{taxonomy?.plural}</td>
+								<td>{taxonomy?.slug}</td>
+								<td>{taxonomy?.types?.join(", ")}</td>
+								<td className="action">
+									<button>...</button>
+								</td>
+							</tr>
+						);
+					})}
+				</tbody>
+			</table>
+		</>
+	);
+};
+
+export default TaxonomiesTable;

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -5,7 +5,11 @@ import { TaxonomiesDropdown } from "./TaxonomiesDropdown";
 const TaxonomiesTable = ({ taxonomies = {} }) => {
 	return (
 		<>
-			<p>TODO: add Bulk Action here</p>
+			<select name="bulk-action">
+				<option value="-1">Bulk actions</option>
+				<option value="delete">Delete</option>
+			</select>
+			<button className="button action">Apply</button>
 			<table className="table table-striped">
 				<thead>
 					<tr>

--- a/includes/settings/scss/_buttons.scss
+++ b/includes/settings/scss/_buttons.scss
@@ -155,7 +155,7 @@ button.options svg {
 }
 
 button.options {
-	background-color: $color-white;
+	background-color: transparent;
 	border: none;
 	color: $color-text;
 	height: 100%;

--- a/includes/settings/scss/_buttons.scss
+++ b/includes/settings/scss/_buttons.scss
@@ -15,9 +15,9 @@ button {
 
 button:disabled,
 button:disabled:hover {
-	background: $color-gray-disabled-background !important;
-	border-color: $color-gray-disabled-border !important;
-	color: $color-gray-disabled-text !important;
+	background: $color-secondary-light !important;
+	border-color: $color-secondary !important;
+	color: $color-gray !important;
 }
 
 button.first {

--- a/includes/settings/scss/_taxonomies.scss
+++ b/includes/settings/scss/_taxonomies.scss
@@ -28,6 +28,10 @@
 		text-align: right;
 		padding-right: 0;
 	}
+
+	&:first-of-type {
+		padding-left: 1rem;
+	}
 }
 
 .taxonomies-view table button {
@@ -41,15 +45,4 @@
 
 .taxonomies-view table button svg {
 	margin: 0 auto;
-}
-
-.taxonomies-view .bulk-actions {
-	margin-bottom: 18px;
-
-	select {
-		height: 52px;
-		margin-top: -1px;
-		margin-right: 18px;
-		padding: 0 32px 0 20px;
-	}
 }

--- a/includes/settings/scss/_taxonomies.scss
+++ b/includes/settings/scss/_taxonomies.scss
@@ -46,3 +46,7 @@
 .taxonomies-view table button svg {
 	margin: 0 auto;
 }
+
+.atlas-content-modeler .taxonomies-view .row > * {
+	box-sizing: border-box;
+}

--- a/includes/settings/scss/_taxonomies.scss
+++ b/includes/settings/scss/_taxonomies.scss
@@ -28,8 +28,13 @@
 
 .taxonomies-view table button {
 	border: none;
-	height: 55px;
-	width: 55px;
-	line-height: 55px;
+	margin: 2px;
+	height: 51px;
+	width: 51px;
+	line-height: 51px;
 	padding: 0;
+}
+
+.taxonomies-view table button svg {
+	margin: 0 auto;
 }

--- a/includes/settings/scss/_taxonomies.scss
+++ b/includes/settings/scss/_taxonomies.scss
@@ -24,6 +24,10 @@
 		text-align: right;
 		padding-right: 1rem;
 	}
+	&.action.right {
+		text-align: right;
+		padding-right: 0;
+	}
 }
 
 .taxonomies-view table button {

--- a/includes/settings/scss/_taxonomies.scss
+++ b/includes/settings/scss/_taxonomies.scss
@@ -42,3 +42,14 @@
 .taxonomies-view table button svg {
 	margin: 0 auto;
 }
+
+.taxonomies-view .bulk-actions {
+	margin-bottom: 18px;
+
+	select {
+		height: 52px;
+		margin-top: -1px;
+		margin-right: 18px;
+		padding: 0 32px 0 20px;
+	}
+}

--- a/includes/settings/scss/_taxonomies.scss
+++ b/includes/settings/scss/_taxonomies.scss
@@ -1,0 +1,35 @@
+@import "variables";
+
+.taxonomies-view table {
+	border-collapse: collapse;
+}
+
+.taxonomies-view table thead {
+	background: $color-secondary;
+	text-transform: uppercase;
+}
+
+.atlas-content-modeler .taxonomies-view table td {
+	vertical-align: middle;
+	padding: 0 0.5rem;
+}
+
+.atlas-content-modeler .taxonomies-view table th,
+.atlas-content-modeler .taxonomies-view table td {
+	text-align: left;
+	&.checkbox {
+		text-align: center;
+	}
+	&.action {
+		text-align: right;
+		padding-right: 1rem;
+	}
+}
+
+.taxonomies-view table button {
+	border: none;
+	height: 55px;
+	width: 55px;
+	line-height: 55px;
+	padding: 0;
+}

--- a/includes/settings/scss/_variables.scss
+++ b/includes/settings/scss/_variables.scss
@@ -1,11 +1,10 @@
 $color-white: #fff;
 $color-text: #002838;
+$color-secondary: #cfdde9;
+$color-secondary-light: #f4f7fa;
 $color-gray: #59767f;
 $color-gray-mid: #405e6a;
 $color-gray-light: #9db7d1;
-$color-gray-disabled-background: #f4f7fa;
-$color-gray-disabled-border: #cfdde9;
-$color-gray-disabled-text: #59767f;
 $color-primary: #7e5cef;
 $color-primary-hover: #5c43ae;
 $color-highlight: #0ecad4;

--- a/includes/settings/scss/index.scss
+++ b/includes/settings/scss/index.scss
@@ -1,4 +1,7 @@
-/* import bootstrap dependencies for grid and utilities only */
+@import "variables";
+
+// Bootstrap color overrides.
+$table-striped-bg: $color-secondary-light;
 
 .atlas-content-modeler {
 	@import "../../../node_modules/bootstrap/scss/_functions";
@@ -9,6 +12,7 @@
 	@import "../../../node_modules/bootstrap/scss/_grid";
 	@import "../../../node_modules/bootstrap/scss/_helpers";
 	@import "../../../node_modules/bootstrap/scss/_utilities";
+	@import "../../../node_modules/bootstrap/scss/_tables";
 	@import "../../../node_modules/bootstrap/scss/utilities/_api";
 
 	@import "../../../node_modules/bootstrap/scss/_buttons";

--- a/includes/settings/scss/index.scss
+++ b/includes/settings/scss/index.scss
@@ -29,6 +29,7 @@ $breakpoint-tablet: 850px;
 @import "model-list";
 @import "field-list";
 @import "open-field";
+@import "taxonomies";
 @import "toast";
 @import "flex";
 @import "bootstrap-overrides";

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -32,6 +32,7 @@ class CreateTaxonomyCest
 		$I->wait(1);
 		$I->see('taxonomy was created', '#success');
 		$I->see('Breeds', '.taxonomy-list');
+		$I->see('goose', '.taxonomy-list');
 
 		// Form fields should reset when a submission was successful.
 		$I->seeInField("#singular", "");

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -20,6 +20,12 @@ class CreateTaxonomyCest
 		$I->see('Taxonomies', 'section.heading h2');
 	}
 
+	public function i_can_see_the_no_taxonomies_message_if_none_exist(AcceptanceTester $I)
+	{
+		$I->amOnTaxonomyListingsPage();
+		$I->see('You currently have no taxonomies', '.taxonomy-list' );
+	}
+
 	public function i_can_create_a_taxonomy(AcceptanceTester $I)
 	{
 		$I->amOnTaxonomyListingsPage();


### PR DESCRIPTION
- Implements the taxonomy table on the taxonomies developer app view.
- Adds the taxonomy options button and drop down.
- Adds “Edit” and “Delete” options to the drop down. 

### Notes
- Edit and Delete options are wired up to work but will show a TODO alert for now. (This targets the 'taxonomies' branch, so we won't release it until this is fixed in separate PRs.)
- We decided in Slack to remove the Bulk Action option for now.
- I cleared the column heading changes with Mason. (The [Figma mockup](https://www.figma.com/file/6b3kxG7r2OTv2A024CQiUU/Taxonomy) has different headings.)

### To test
1. Click “View Taxonomies from the main model page or visit `/wp-admin/?page=atlas-content-modeler&view=taxonomies` or 
2. Add one or more taxonomies, which should appear in the table.
3. Try the “Edit” or “Delete” actions, which should present you with an alert.

### Before
<img width="1229" alt="Screenshot 2021-07-01 at 18 51 23" src="https://user-images.githubusercontent.com/647669/124161175-612d2000-da9d-11eb-8145-7c9e609a832b.png">

### After
<img width="1207" alt="Screenshot 2021-07-01 at 18 04 52" src="https://user-images.githubusercontent.com/647669/124155566-e7923380-da96-11eb-86ce-30db4746c294.png">
