### PR TITLE
fix: correct classname conflict for failing REST tests

### DIFF
--- a/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
+++ b/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * Class TestRestTaxonomyEndpoint
+ *
+ * Verifies plugin REST endpoints for CRUD operations on ACM taxonomies.
+ */
 class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 	protected $server;
 

--- a/tests/integration/content-registration/test-rest-wp-taxonomy.php
+++ b/tests/integration/content-registration/test-rest-wp-taxonomy.php
@@ -2,7 +2,12 @@
 
 use function WPE\AtlasContentModeler\ContentRegistration\Taxonomies\register;
 
-class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
+/**
+ * Class TestRestWPTaxonomy
+ *
+ * Checks ACM taxonomies are available via WP core endpoints under `/wp/v2/`.
+ */
+class TestRestWPTaxonomy extends WP_UnitTestCase {
 	/**
 	 * @var WP_REST_Server Server instance to send requests from.
 	 */


### PR DESCRIPTION
## Description
Fixes a [failing test](https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/1193/workflows/7af2f645-b02e-4885-b79a-1d965439e7f7/jobs/9547) after recent merges to the taxonomies branch due to a duplicated classname.

Targets the taxonomies branch. Main is unaffected.

[No Jira ticket.]

## Testing
Verify that tests pass in Circle.

## Screenshots
`composer test` fail from Circle:

```
PHP Fatal error:  Cannot declare class TestRestTaxonomyEndpoint, because the name is already in use in /home/circleci/project/atlas-content-modeler/tests/integration/content-registration/test-rest-taxonomy.php on line 5

Fatal error: Cannot declare class TestRestTaxonomyEndpoint, because the name is already in use in /home/circleci/project/atlas-content-modeler/tests/integration/content-registration/test-rest-taxonomy.php on line 5
Script phpunit handling the test event returned with error code 255

Exited with code exit status 255
```

## Documentation Changes

n/a

## Dependant PRs

n/a