### PR TITLE
fix: Prevent PHP warning during title filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+
+### Fixed
+- Prevent a PHP warning during title filtering if post info can not be found.
+
 ## 0.4.1 - 2021-06-24
 ### Added
 - Generate POT language file for translations.

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -423,6 +423,10 @@ final class FormEditingExperience {
 	public function filter_post_titles( string $title, int $id ) {
 		$post_type = get_post_type( $id );
 
+		if ( ! $post_type ) {
+			return $title;
+		}
+
 		// Only filter titles for post types created with this plugin.
 		if ( ! array_key_exists( $post_type, $this->models ) ) {
 			return $title;

--- a/tests/integration/publisher/test-title-filter.php
+++ b/tests/integration/publisher/test-title-filter.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Tests Title Filtering.
+ *
+ * @package AtlasContentModeler
+ */
+
+/**
+ * Class TestTitleFilter
+ */
+class TestTitleFilter extends WP_UnitTestCase {
+
+	private $form_editing_experience;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->form_editing_experience = new \WPE\AtlasContentModeler\FormEditingExperience();
+	}
+
+	/**
+	 * Ensures the title filter only applies if posts have a known post type.
+	 *
+	 * @covers \WPE\AtlasContentModeler\FormEditingExperience()->filter_post_titles();
+	 */
+	public function test_title_filter_returns_unaltered_title_if_post_has_no_post_type(): void {
+		$original_title = "Original title";
+
+		$filtered_title = $this->form_editing_experience->filter_post_titles(
+			$original_title,
+			123456789 // To test that no filtering takes place if a post cannot be found.
+		);
+
+		$this->assertSame( $original_title, $filtered_title );
+	}
+}

--- a/tests/integration/publisher/test-title-filter.php
+++ b/tests/integration/publisher/test-title-filter.php
@@ -24,11 +24,12 @@ class TestTitleFilter extends WP_UnitTestCase {
 	 * @covers \WPE\AtlasContentModeler\FormEditingExperience()->filter_post_titles();
 	 */
 	public function test_title_filter_returns_unaltered_title_if_post_has_no_post_type(): void {
-		$original_title = "Original title";
+		$original_title  = "Original title";
+		$unknown_post_id = PHP_INT_MAX;
 
 		$filtered_title = $this->form_editing_experience->filter_post_titles(
 			$original_title,
-			123456789 // To test that no filtering takes place if a post cannot be found.
+			$unknown_post_id, // To test that no filtering takes place if a post cannot be found.
 		);
 
 		$this->assertSame( $original_title, $filtered_title );


### PR DESCRIPTION
## Description

Fixes #193 by returning early if no post type is found.

[No related Jira.]

## Testing

This PR adds an integration test to verify that posts with no identifiable post type do not generate this PHP warning as a result of our post title filter:

```
[08-Jul-2021 09:59:38 UTC] PHP Warning:  array_key_exists(): The first argument should be either a string or an integer in /Users/nick/Work/atlas-content-modeler/includes/publisher/class-publisher-form-editing-experience.php on line 427
```

e2e tests to validate title filtering under happy paths already exist in `tests/acceptance/FilterEntryTitlesCest.php`.

You can also test manually by following the reproduction steps in #193 to verify that a warning is no longer logged by PHP.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

n/a