### PR TITLE
[BH-1122] Update "API Identifer" to "Model ID" with associated description

### DIFF
--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -509,7 +509,7 @@ function create_model( string $post_type_slug, array $args ) {
 	if ( empty( $post_type_slug ) ) {
 		return new WP_Error(
 			'atlas_content_modeler_invalid_id',
-			__( 'Please provide a valid API Identifier.', 'atlas-content-modeler' ),
+			__( 'Please provide a valid Model ID.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -521,7 +521,7 @@ function create_model( string $post_type_slug, array $args ) {
 	if ( ! empty( $content_types[ $post_type_slug ] ) || array_key_exists( $post_type_slug, $existing_content_types ) ) {
 		return new WP_Error(
 			'atlas_content_modeler_already_exists',
-			__( 'A content model with this API Identifier already exists.', 'atlas-content-modeler' ),
+			__( 'A content model with this Model ID already exists.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -198,12 +198,12 @@ export default function CreateContentModel() {
 
 					<div className={errors.slug ? "field has-error" : "field"}>
 						<label htmlFor="slug">
-							{__("API Identifier", "atlas-content-modeler")}
+							{__("Model ID", "atlas-content-modeler")}
 						</label>
 						<br />
 						<p className="help">
 							{__(
-								"Auto-generated from the singular name and used for API requests.",
+								"Auto-generated and used internally for WordPress to identify the model.",
 								"atlas-content-modeler"
 							)}
 						</p>

--- a/includes/settings/js/src/components/EditModelModal.jsx
+++ b/includes/settings/js/src/components/EditModelModal.jsx
@@ -226,10 +226,12 @@ export function EditModelModal({ model, isOpen, setIsOpen }) {
 
 				<div className="row">
 					<div className="field col-sm">
-						<label htmlFor="slug">API Identifier</label>
+						<label htmlFor="slug">
+							{__("Model ID", "atlas-content-modeler")}
+						</label>
 						<p className="help">
 							{__(
-								"Auto-generated and used for API requests.",
+								"Auto-generated and used internally for WordPress to identify the model.",
 								"atlas-content-modeler"
 							)}
 						</p>


### PR DESCRIPTION
## Description

Changes “API Identifier” to “Model ID” and updates the associated description.

<img width="545" alt="Screen Shot 2021-07-21 at 12 45 27 PM" src="https://user-images.githubusercontent.com/394675/126527331-d250a81e-d15e-4f1b-9f63-8388e0253320.png">

<img width="598" alt="Screen Shot 2021-07-21 at 12 45 52 PM" src="https://user-images.githubusercontent.com/394675/126527338-d50746e1-cb79-4b0a-a226-d758e0167b6a.png">

https://wpengine.atlassian.net/browse/BH-1122

This follows the first approach outlined in the Jira ticket above in order to better represent the field and its intended use without confusion in GraphQL or other interfaces.