### PR TITLE
[BH-1079, BH-1080] Reflect taxonomy updates in admin sidebar

### DIFF
--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import { useHistory } from "react-router-dom";
 import { __, sprintf } from "@wordpress/i18n";
 import { useLocationSearch } from "../utils";
@@ -12,6 +12,79 @@ export default function Taxonomies() {
 	const query = useLocationSearch();
 	const editing = query.get("editing");
 	const editingTaxonomy = editing ? taxonomies[editing] : null;
+
+	const prevTaxonomiesRef = useRef();
+	useEffect(() => {
+		prevTaxonomiesRef.current = taxonomies;
+	});
+	const prevTaxonomies = prevTaxonomiesRef.current;
+
+	useEffect(() => {
+		if (!taxonomies || !prevTaxonomies) {
+			// If no prevTaxonomies, then nothing has been changed.
+			return;
+		}
+
+		const getTaxonomyEditHref = (slug, type) =>
+			`edit-tags.php?taxonomy=${slug}&post_type=${type}`;
+
+		// Remove taxonomies that no longer exists or are not associated with a specific model.
+		Object.values(prevTaxonomies).forEach(({ slug, types }) => {
+			types.forEach((type) => {
+				if (
+					!taxonomies.hasOwnProperty(slug) ||
+					!taxonomies[slug].types.includes(type)
+				) {
+					const href = getTaxonomyEditHref(slug, type);
+					const taxLink = document.querySelector(
+						`#adminmenu a[href="${href}"]`
+					);
+
+					if (!taxLink) {
+						// This model for this "type" must have been deleted.
+						return;
+					}
+
+					// Just hide the list item so we can preserve order if this type is re-assigned.
+					taxLink.parentElement.style.display = "none";
+				}
+			});
+		});
+
+		// Add or update all current taxonomies.
+		Object.values(taxonomies).forEach(({ slug, plural, types }) => {
+			types.forEach((type) => {
+				const href = getTaxonomyEditHref(slug, type);
+				const taxLink = document.querySelector(
+					`#adminmenu a[href="${href}"`
+				);
+
+				// Get or create the list item.
+				let listItem = taxLink
+					? taxLink.parentElement
+					: document.createElement("li");
+
+				// Give the list item an updated edit link.
+				listItem.innerHTML = `<a href="${href}">${plural}</a>`;
+				// Always show taxonomies that are enabled in case we hid them on removal.
+				listItem.style.display = "list-item";
+
+				// If the taxonomy link didn't exist already, we should insert it.
+				if (!taxLink) {
+					const postTypeSubMenu = document.querySelector(
+						`#menu-posts-${type} .wp-submenu`
+					);
+
+					if (!postTypeSubMenu) {
+						// The model for this "type" must have been deleted.
+						return;
+					}
+
+					postTypeSubMenu.appendChild(listItem);
+				}
+			});
+		});
+	}, [taxonomies]);
 
 	const cancelEditing = () => {
 		history.push(atlasContentModeler.appPath + "&view=taxonomies");

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -26,7 +26,7 @@ export default function Taxonomies() {
 		}
 
 		const getTaxonomyEditHref = (slug, type) =>
-			`edit-tags.php?taxonomy=${slug}&post_type=${type}`;
+			`edit-tags.php?taxonomy=${slug}&post_type=${type.toLowerCase()}`;
 
 		// Remove taxonomies that no longer exists or are not associated with a specific model.
 		Object.values(prevTaxonomies).forEach(({ slug, types }) => {
@@ -72,7 +72,7 @@ export default function Taxonomies() {
 				// If the taxonomy link didn't exist already, we should insert it.
 				if (!taxLink) {
 					const postTypeSubMenu = document.querySelector(
-						`#menu-posts-${type} .wp-submenu`
+						`#menu-posts-${type.toLowerCase()} .wp-submenu`
 					);
 
 					if (!postTypeSubMenu) {

--- a/tests/acceptance/SidebarUpdatesCest.php
+++ b/tests/acceptance/SidebarUpdatesCest.php
@@ -38,6 +38,7 @@ class SidebarUpdatesCest
 	{
 		$I->haveContentModel('Moose', 'Moose');
 		$I->haveContentModel('Goose', 'Geese');
+		$I->wait(1);
 
 		$I->seeElementInDOM('#menu-posts-goose');
 		$I->seeElementInDOM('#menu-posts-moose');

--- a/tests/acceptance/SidebarUpdatesCest.php
+++ b/tests/acceptance/SidebarUpdatesCest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Users should see their changes reflected in the WordPress admin sidebar
+ * whenever without having to refresh the page.
+ */
+class SidebarUpdatesCest
+{
+	public function _before(\AcceptanceTester $I)
+	{
+		$I->maximizeWindow();
+		$I->loginAsAdmin();
+	}
+
+	/**
+	 * Ensure the sidebar is updated when a model is added.
+	 */
+	public function the_sidebar_adds_new_post_types_upon_creation(AcceptanceTester $I)
+	{
+		$I->dontSeeElementInDOM('#menu-posts-goose');
+
+		$I->haveContentModel('Goose', 'Geese');
+		$I->wait(1);
+
+		$I->seeElementInDOM('#menu-posts-goose');
+
+		$I->haveContentModel('Moose', 'Moose');
+		$I->wait(1);
+
+		$I->seeElementInDOM('#menu-posts-goose');
+		$I->seeElementInDOM('#menu-posts-moose');
+	}
+
+	/**
+	 * Ensure the sidebar is updated when a model is deleted.
+	 */
+	public function the_sidebar_removes_post_types_upon_deletion(AcceptanceTester $I)
+	{
+		$I->haveContentModel('Moose', 'Moose');
+		$I->haveContentModel('Goose', 'Geese');
+
+		$I->seeElementInDOM('#menu-posts-goose');
+		$I->seeElementInDOM('#menu-posts-moose');
+
+		$I->amOnWPEngineContentModelPage();
+
+		// Delete Moose.
+		$I->click('.model-list button.options');
+		$I->click('.dropdown-content a.delete');
+		$I->click('Delete', '.atlas-content-modeler-delete-model-modal-container');
+		$I->wait(1);
+
+		$I->dontSeeElementInDOM('#menu-posts-moose');
+
+		// Delete Goose.
+		$I->click('.model-list button.options');
+		$I->click('.dropdown-content a.delete');
+		$I->click('Delete', '.atlas-content-modeler-delete-model-modal-container');
+		$I->wait(1);
+
+		$I->dontSeeElementInDOM('#menu-posts-goose');
+	}
+
+	/**
+	 * Ensure the sidebar is updated when taxonomies are added.
+	 */
+	public function the_sidebar_adds_new_taxonomies_upon_creation(AcceptanceTester $I)
+	{
+		$I->haveContentModel('Moose', 'Moose');
+		$I->haveContentModel('Goose', 'Geese');
+		$I->wait(1);
+
+		$I->haveTaxonomy('Breed', 'Breeds', ['goose']);
+		$I->wait(1);
+
+		// The new taxonomy is assigned to Goose.
+		$I->seeElementInDOM('#menu-posts-goose a', ['href' => 'edit-tags.php?taxonomy=breed&post_type=goose']);
+		$I->moveMouseOver(['css' => '#menu-posts-goose']);
+		$I->see('Breeds', ['css' => '#menu-posts-goose a']);
+		// The new taxonomy is not assigned to Moose.
+		$I->dontSeeElementInDOM('#menu-posts-moose a', ['href' => 'edit-tags.php?taxonomy=breed&post_type=moose']);
+
+		$I->haveTaxonomy('Region', 'Regions', ['goose', 'moose']);
+		$I->wait(1);
+
+		// The new taxonomy is added to Goose and existing taxonomies are still present.
+		$I->seeElementInDOM('#menu-posts-goose a', ['href' => 'edit-tags.php?taxonomy=region&post_type=goose']);
+		$I->moveMouseOver(['css' => '#menu-posts-goose']);
+		$I->see('Breeds', ['css' => '#menu-posts-goose a']);
+		$I->see('Region', ['css' => '#menu-posts-goose a']);
+
+		// Only the new taxonomy is present on Moose.
+		$I->seeElementInDOM('#menu-posts-moose a', ['href' => 'edit-tags.php?taxonomy=region&post_type=moose']);
+		$I->moveMouseOver(['css' => '#menu-posts-moose']);
+		$I->dontSee('Breeds', ['css' => '#menu-posts-moose a']);
+		$I->see('Region', ['css' => '#menu-posts-moose a']);
+	}
+
+	/**
+	 * Ensure the sidebar is updated when taxonomies are edited.
+	 */
+	public function the_sidebar_updates_taxonomies_upon_editing(AcceptanceTester $I)
+	{
+		$I->haveContentModel('Moose', 'Moose');
+		$I->haveContentModel('Goose', 'Geese');
+		$I->wait(1);
+
+		$I->haveTaxonomy('Breed', 'Breeds', ['goose']);
+		$I->wait(1);
+
+		$I->moveMouseOver(['css' => '#menu-posts-goose']);
+		$I->see('Breeds', ['css' => '#menu-posts-goose a']);
+		$I->moveMouseOver(['css' => '#menu-posts-moose']);
+		$I->dontSee('Breeds', ['css' => '#menu-posts-moose a']);
+
+		// Make some edits
+		$I->click('.action button.options');
+		$I->click('Edit', '.action .dropdown-content');
+		$I->wait(1);
+		$I->fillField(['name' => 'plural'], "Br33ds");
+		$I->click(".checklist .checkbox input[value=moose]");
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+
+		// The edited taxonomy should be updated on both models.
+		$I->moveMouseOver(['css' => '#menu-posts-goose']);
+		$I->see('Br33ds', ['css' => '#menu-posts-goose a']);
+		$I->moveMouseOver(['css' => '#menu-posts-moose']);
+		$I->see('Br33ds', ['css' => '#menu-posts-moose a']);
+
+		// Make edits to test "type" removal.
+		$I->click('.action button.options');
+		$I->click('Edit', '.action .dropdown-content');
+		$I->wait(1);
+		$I->click(".checklist .checkbox input[value=goose]"); // Remove from goose
+		$I->click('.card-content button.primary');
+		$I->wait(1);
+
+		$I->moveMouseOver(['css' => '#menu-posts-goose']);
+		$I->dontSee('Br33ds', ['css' => '#menu-posts-goose a']);
+		$I->moveMouseOver(['css' => '#menu-posts-moose']);
+		$I->see('Br33ds', ['css' => '#menu-posts-moose a']);
+	}
+
+	/**
+	 * Ensure the sidebar is updated when taxonomies are deleted.
+	 */
+	public function the_sidebar_removes_taxonomies_upon_deletion(AcceptanceTester $I)
+	{
+		$I->haveContentModel('Moose', 'Moose');
+		$I->haveContentModel('Goose', 'Geese');
+		$I->wait(1);
+
+		$I->haveTaxonomy('Breed', 'Breeds', ['goose', 'moose']);
+		$I->wait(1);
+
+		$I->moveMouseOver(['css' => '#menu-posts-goose']);
+		$I->see('Breeds', ['css' => '#menu-posts-goose a']);
+		$I->moveMouseOver(['css' => '#menu-posts-moose']);
+		$I->See('Breeds', ['css' => '#menu-posts-moose a']);
+
+		// Delete the Breeds taxonomy.
+		$I->click('.action button.options');
+		$I->see('Delete', '.dropdown-content');
+		$I->click('Delete', '.action .dropdown-content');
+		$I->click('Delete', '.atlas-content-modeler-delete-field-modal-container');
+
+		// The edited taxonomy should be removed from both models.
+		$I->moveMouseOver(['css' => '#menu-posts-goose']);
+		$I->dontSee('Breeds', ['css' => '#menu-posts-goose a']);
+		$I->moveMouseOver(['css' => '#menu-posts-moose']);
+		$I->dontSee('Breeds', ['css' => '#menu-posts-moose a']);
+	}
+}

--- a/tests/acceptance/SidebarUpdatesCest.php
+++ b/tests/acceptance/SidebarUpdatesCest.php
@@ -2,7 +2,7 @@
 
 /**
  * Users should see their changes reflected in the WordPress admin sidebar
- * whenever without having to refresh the page.
+ * without having to refresh the page.
  */
 class SidebarUpdatesCest
 {


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->
Updates the admin sidebar in response to any changes in taxonomies. I elected to go this route rather than mirroring the approach we use for models because of the nested updates that need to happen on changes to a taxonomy's "types" setting. It seemed cleaner to do the necessary diffing and updating all in one place.

<!--
Provide a link to the JIRA ticket (if any) for issue tracking purposes
-->

https://wpengine.atlassian.net/browse/BH-1079
https://wpengine.atlassian.net/browse/BH-1080

One issue I ran into is deciding what to do with taxonomies that have non-existent types assigned to them. For example:

1. Create Restaurant and Recipe models.
2. Create a Cuisines taxonomy and assign it to both Restaurants and Recipes.
3. Delete the Recipe model.

In this case, we still have 'recipe' defined as a type on Cuisines and it still shows up in the taxonomy list table. I've worked around it in this PR, but it feels like something that warrants more discussion. ~~I'll create a ticket in JIRA with some thoughts to kick it off.~~ Ticket is here: https://wpengine.atlassian.net/browse/BH-1148

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

I've included a set of acceptance tests that cover all taxonomy actions. I also included a couple of tests to cover sidebar updates for model creation/deletion.