### PR TITLE
[BH-1098] Automate testing and build

### DIFF
--- a/.docker/Dockerfile-node
+++ b/.docker/Dockerfile-node
@@ -1,0 +1,7 @@
+FROM node:lts
+ARG UID=1000
+ARG GID=1000
+
+RUN groupmod -g ${GID} node && usermod -u ${UID} -g ${GID} node
+
+RUN npm -g install npm

--- a/.docker/Dockerfile-phpunit
+++ b/.docker/Dockerfile-phpunit
@@ -1,0 +1,8 @@
+FROM devwithlando/php:7.4-fpm-2
+
+COPY ../tests/install-wp-tests.sh /install-wp-tests.sh
+
+RUN apt-get update; \
+	apt-get install -y subversion; \
+	chmod +x /install-wp-tests.sh; \
+	bash /install-wp-tests.sh wordpress wordpress wordpress phpunitdatabase latest true

--- a/.zipignore
+++ b/.zipignore
@@ -32,3 +32,5 @@ deploy.sh
 *.env.testing*
 *.prettier*
 *.husky/*
+*docker-composer-phpunit.yml
+*Makefile

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test-php-unit: | install-composer ## Run PHPunit tests
 		apt-get update; \
 		apt-get install -y subversion; \
 		chmod +x ./tests/install-wp-tests.sh; \
-		./tests/install-wp-tests.sh wordpress wordpress wordpress phpunitdatabase:3307 latest true; \
+		./tests/install-wp-tests.sh wordpress wordpress wordpress phpunitdatabase latest true; \
 		composer test \
 		"
 	docker-compose -f ./docker-compose-phpunit.yml down

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean-e2e:
 	@echo "Cleaning leftovers from end-to-end tests"
 	find tests/_output/ -type f -not -name '.gitignore' -delete
 	rm -f .env.testing;
-	if [ "$$(docker ps | grep plugin_wordpress)" ]; then \
+	if [ "$$(docker ps | grep atlas-content-modeler_wordpress)" ]; then \
 		docker-compose -f ./docker-compose.yml down; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ ifdef HAS_CHROMEDRIVER
 	@echo "Running End-to-end tests"
 	cp .env.testing.sample .env.testing
 	docker-compose -f ./docker-compose.yml up -d --build
+	sleep 10; \
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/ --user=www-data wordpress wp plugin install wp-graphql --activate
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/ --user=www-data wordpress wp plugin activate atlas-content-modeler
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/wp-content/plugins/atlas-content-modeler --user=www-data wordpress wp db export tests/_data/dump.sql

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build-docker:
 	fi
 
 .PHONY: build-npm
-build-npm:
+build-npm: | install-npm
 	@echo "Building plugin assets"
 	$(DOCKER_RUN) $(NODE_IMAGE) npm run build
 
@@ -53,7 +53,7 @@ install-composer:
 	fi
 
 .PHONY: install-npm
-install-npm: | build-npm
+install-npm: | build-docker
 	if [ ! -d ./node_modules/ ]; then \
 		echo "installing node dependencies for plugin"; \
 		$(DOCKER_RUN) $(NODE_IMAGE) npm install; \
@@ -63,13 +63,13 @@ install-npm: | build-npm
 test: install-npm install-composer test-js-lint test-php-lint test-js-jest test-php-unit ## Build all assets and run all testing except end-to-end testing
 
 .PHONY: test-build
-test: build test-js-lint test-php-lint test-js-jest test-php-unit ## Run all testing except end-to-end testing
+test-build: build test-js-lint test-php-lint test-js-jest test-php-unit ## Run all testing except end-to-end testing
 
 .PHONY: test-all
 test-all: install-npm install-composer test-js-lint test-php-lint test-js-jest test-php-unit test-e2e ## Run all testing
 
 .PHONY: test-all-build
-test-all: build test-js-lint test-php-lint test-js-jest test-php-unit test-e2e ## Build all assets and run all testing
+test-all-build: build test-js-lint test-php-lint test-js-jest test-php-unit test-e2e ## Build all assets and run all testing
 
 .PHONE: test-e2e
 test-e2e: | clean-e2e ## Run end-2-end testing (requires Chrome and Chromedriver)

--- a/Makefile
+++ b/Makefile
@@ -53,20 +53,20 @@ install-composer:
 	fi
 
 .PHONY: install-npm
-install-npm:
+install-npm: | build-npm
 	if [ ! -d ./node_modules/ ]; then \
 		echo "installing node dependencies for plugin"; \
 		$(DOCKER_RUN) $(NODE_IMAGE) npm install; \
 	fi
 
 .PHONY: test
-test: test-js-lint test-php-lint test-js-jest test-php-unit ## Build all assets and run all testing except end-to-end testing
+test: install-npm install-composer test-js-lint test-php-lint test-js-jest test-php-unit ## Build all assets and run all testing except end-to-end testing
 
 .PHONY: test-build
 test: build test-js-lint test-php-lint test-js-jest test-php-unit ## Run all testing except end-to-end testing
 
 .PHONY: test-all
-test-all: test-js-lint test-php-lint test-js-jest test-php-unit test-e2e ## Run all testing
+test-all: install-npm install-composer test-js-lint test-php-lint test-js-jest test-php-unit test-e2e ## Run all testing
 
 .PHONY: test-all-build
 test-all: build test-js-lint test-php-lint test-js-jest test-php-unit test-e2e ## Build all assets and run all testing

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,141 @@
+DOCKER_RUN       := docker run --rm
+COMPOSER_IMAGE   := -v $$(pwd):/app --user $$(id -u):$$(id -g) composer
+NODE_IMAGE       := -w /home/node/app -v $$(pwd):/home/node/app --user node atlascontentmodeler_node_image
+HAS_CHROMEDRIVER := $(shell command -v chromedriver 2> /dev/null)
+CURRENTUSER      := $$(id -u)
+CURRENTGROUP     := $$(id -g)
+
+.PHONY: build
+build:  ## Builds all plugin assets
+	@echo "Setting up Content Modeler plugin"
+	$(MAKE) install-composer
+	$(MAKE) build-docker
+	$(MAKE) install-npm
+	$(MAKE) build-npm
+
+.PHONY: build-docker
+build-docker:
+	if [ ! "$$(docker images | grep atlascontentmodeler_node_image)" ]; then \
+		echo "Building the Node image"; \
+		docker build \
+			-f .docker/Dockerfile-node \
+			--build-arg UID=$(CURRENTUSER) \
+			--build-arg GID=$(CURRENTUSER) \
+			-t atlascontentmodeler_node_image .; \
+	fi
+
+.PHONY: build-npm
+build-npm:
+	@echo "Building plugin assets"
+	$(DOCKER_RUN) $(NODE_IMAGE) npm run build
+
+.PHONY: clean-e2e
+clean-e2e:
+	@echo "Cleaning leftovers from end-to-end tests"
+	find tests/_output/ -type f -not -name '.gitignore' -delete
+	rm -f .env.testing;
+	if [ "$$(docker ps | grep plugin_wordpress)" ]; then \
+		docker-compose -f ./docker-compose.yml down; \
+	fi
+
+.PHONY: help
+help:  ## Display help
+	@awk -F ':|##' \
+		'/^[^\t].+?:.*?##/ {\
+			printf "\033[36m%-30s\033[0m %s\n", $$1, $$NF \
+		}' $(MAKEFILE_LIST) | sort
+
+.PHONY: install-composer
+install-composer:
+	if [ ! -d ./vendor/ ]; then \
+		echo "installing composer dependencies for plugin"; \
+		$(DOCKER_RUN) $(COMPOSER_IMAGE) install --ignore-platform-reqs; \
+	fi
+
+.PHONY: install-npm
+install-npm:
+	if [ ! -d ./node_modules/ ]; then \
+		echo "installing node dependencies for plugin"; \
+		$(DOCKER_RUN) $(NODE_IMAGE) npm install; \
+	fi
+
+.PHONY: test
+test: test-js-lint test-php-lint test-js-jest test-php-unit ## Build all assets and run all testing except end-to-end testing
+
+.PHONY: test-build
+test: build test-js-lint test-php-lint test-js-jest test-php-unit ## Run all testing except end-to-end testing
+
+.PHONY: test-all
+test-all: test-js-lint test-php-lint test-js-jest test-php-unit test-e2e ## Run all testing
+
+.PHONY: test-all-build
+test-all: build test-js-lint test-php-lint test-js-jest test-php-unit test-e2e ## Build all assets and run all testing
+
+.PHONE: test-e2e
+test-e2e: | clean-e2e ## Run end-2-end testing (requires Chrome and Chromedriver)
+ifdef HAS_CHROMEDRIVER
+	@echo "Running End-to-end tests"
+	cp .env.testing.sample .env.testing
+	docker-compose -f ./docker-compose.yml up -d --build
+	sleep 10
+	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/ --user=www-data wordpress wp plugin install wp-graphql --activate
+	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/ --user=www-data wordpress wp plugin activate atlas-content-modeler
+	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/wp-content/plugins/atlas-content-modeler --user=www-data wordpress wp db export tests/_data/dump.sql
+	vendor/bin/codecept run acceptance
+	$(MAKE) clean-e2e
+else
+	@echo "Chromedriver is not available. Please see the readme for installation instructions."
+endif
+
+.PHONY: test-js
+test-js: test-js-lint test-js-jest ## Run all JavaScript testing
+
+.PHONY: test-js-jest
+test-js-jest: | install-npm  ## Run Jest tests
+	$(DOCKER_RUN) \
+		-w /app \
+		$(NODE_IMAGE) \
+		npm run test-no-watch
+
+.PHONY: test-js-lint
+test-js-lint: | install-npm ## Run JavaScript linting
+	$(DOCKER_RUN) \
+		-w /app \
+		$(NODE_IMAGE) \
+		npm run lint
+
+.PHONY: test-lint
+test-lint: test-js-lint test-php-lint ## Run both JavaScript and PHP linting
+
+.PHONY: test-php
+test-php: test-php-lint test-php-unit ## Run all PHP tests
+
+.PHONY: test-php-lint
+test-php-lint: | install-composer ## Run linting only on PHP code
+	$(DOCKER_RUN) \
+		-w /app \
+		-v $$(pwd):/app \
+		devwithlando/php:7.4-fpm-2 \
+		bash -c "\
+		composer lint \
+		"
+
+.PHONY: test-php-unit
+test-php-unit: | install-composer ## Run PHPunit tests
+	if [ "$$(docker ps | grep atlas-content-modeler_docker_phpunitdatabase_1)" ]; then \
+		docker-compose -f ./docker-compose-phpunit.yml down; \
+	fi
+	docker-compose -f ./docker-compose-phpunit.yml up -d
+	docker-compose \
+		-f ./docker-compose-phpunit.yml\
+		exec \
+		-w /app \
+		phpunit \
+		bash -c "\
+		apt-get update; \
+		apt-get install -y subversion; \
+		chmod +x ./tests/install-wp-tests.sh; \
+		./tests/install-wp-tests.sh wordpress wordpress wordpress phpunitdatabase latest true; \
+		composer test \
+		"
+	docker-compose -f ./docker-compose-phpunit.yml down

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,6 @@ ifdef HAS_CHROMEDRIVER
 	else \
 		vendor/bin/codecept run acceptance $(TEST); \
 	fi
-
 	$(MAKE) clean-e2e
 else
 	@echo "Chromedriver is not available. Please see the readme for installation instructions."

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test-php-unit: | install-composer ## Run PHPunit tests
 		apt-get update; \
 		apt-get install -y subversion; \
 		chmod +x ./tests/install-wp-tests.sh; \
-		./tests/install-wp-tests.sh wordpress wordpress wordpress phpunitdatabase latest true; \
+		./tests/install-wp-tests.sh wordpress wordpress wordpress phpunitdatabase:3307 latest true; \
 		composer test \
 		"
 	docker-compose -f ./docker-compose-phpunit.yml down

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,12 @@ ifdef HAS_CHROMEDRIVER
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/ --user=www-data wordpress wp plugin install wp-graphql --activate
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/ --user=www-data wordpress wp plugin activate atlas-content-modeler
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/wp-content/plugins/atlas-content-modeler --user=www-data wordpress wp db export tests/_data/dump.sql
-	vendor/bin/codecept run acceptance
+	if [ -z "$(TEST)" ]; then \
+		vendor/bin/codecept run acceptance; \
+	else \
+		vendor/bin/codecept run acceptance $(TEST); \
+	fi
+
 	$(MAKE) clean-e2e
 else
 	@echo "Chromedriver is not available. Please see the readme for installation instructions."
@@ -154,3 +159,7 @@ test-php-unit: | install-composer build-docker-phpunit ## Run PHPunit tests
 		phpunit \
 		bash -c "composer test"
 	docker-compose -f ./docker-compose-phpunit.yml down
+
+.PHONY: action
+action:
+	@echo $(TEST)

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ ifdef HAS_CHROMEDRIVER
 	@echo "Running End-to-end tests"
 	cp .env.testing.sample .env.testing
 	docker-compose -f ./docker-compose.yml up -d --build
-	sleep 10
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/ --user=www-data wordpress wp plugin install wp-graphql --activate
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/ --user=www-data wordpress wp plugin activate atlas-content-modeler
 	docker-compose -f ./docker-compose.yml exec --workdir=/var/www/html/wp-content/plugins/atlas-content-modeler --user=www-data wordpress wp db export tests/_data/dump.sql

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_RUN       := docker run --rm
-COMPOSER_IMAGE   := -v $$(pwd):/app --user $$(id -u):$$(id -g) composer
-NODE_IMAGE       := -w /home/node/app -v $$(pwd):/home/node/app --user node atlascontentmodeler_node_image
+COMPOSER_IMAGE   := -v "$$(pwd):/app" --user $$(id -u):$$(id -g) composer
+NODE_IMAGE       := -w /home/node/app -v "$$(pwd):/home/node/app" --user node atlascontentmodeler_node_image
 HAS_CHROMEDRIVER := $(shell command -v chromedriver 2> /dev/null)
 CURRENTUSER      := $$(id -u)
 CURRENTGROUP     := $$(id -g)
@@ -139,7 +139,7 @@ test-php: test-php-lint test-php-unit ## Run all PHP tests
 test-php-lint: | install-composer ## Run linting only on PHP code
 	$(DOCKER_RUN) \
 		-w /app \
-		-v $$(pwd):/app \
+		-v "$$(pwd):/app" \
 		devwithlando/php:7.4-fpm-2 \
 		bash -c "\
 		composer lint \

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -8,8 +8,6 @@ services:
 
   phpunitdatabase:
     image: mysql:5.7
-    ports:
-      - 3307:3306
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -8,6 +8,8 @@ services:
 
   phpunitdatabase:
     image: mysql:5.7
+    ports:
+      - 3307:3306
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  phpunit:
+    image: devwithlando/php:7.4-fpm-2
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: phpunitdatabase
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: wordpress
+    volumes:
+        - .:/app
+
+  phpunitdatabase:
+    image: mysql:5.7
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_ROOT_PASSWORD: wordpress

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -3,20 +3,13 @@ version: '3'
 services:
   phpunit:
     image: devwithlando/php:7.4-fpm-2
-    ports:
-      - 8080:80
-    environment:
-      WORDPRESS_DB_HOST: phpunitdatabase
-      WORDPRESS_DB_NAME: wordpress
-      WORDPRESS_DB_USER: root
-      WORDPRESS_DB_PASSWORD: wordpress
     volumes:
         - .:/app
 
   phpunitdatabase:
     image: mysql:5.7
     ports:
-      - 3306:3306
+      - 3307:3306
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -2,7 +2,10 @@ version: '3'
 
 services:
   phpunit:
-    image: devwithlando/php:7.4-fpm-2
+    depends_on:
+      phpunitdatabase:
+        condition: service_healthy
+    image: atlascontentmodeler_phpunit_image
     volumes:
         - .:/app
 
@@ -15,3 +18,8 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
       MYSQL_ROOT_PASSWORD: wordpress
+    healthcheck:
+      test: ["CMD-SHELL", 'mysqladmin ping']
+      interval: 10s
+      timeout: 2s
+      retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   wordpress:
     build:
       context: ./.docker
+    depends_on:
+      db:
+        condition: service_healthy
     restart: always
     ports:
       - 8080:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
       MYSQL_ROOT_PASSWORD: wordpress
     volumes:
       - ./.docker/mysql:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", 'mysqladmin ping']
+      interval: 10s
+      timeout: 2s
+      retries: 10
 
 volumes:
   wordpress:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,6 +12,13 @@
 
 After cloning this repository, you will need to install the required packages.
 
+If you do not have composer or npm installed locally run
+```
+make build
+```
+
+Otherwise, to manually install dependencies, run
+
 Install composer
 ```
 composer install
@@ -22,7 +29,24 @@ Install npm packages
 npm install
 ```
 
-### PHP Linting, code standards, and unit tests
+## Testing
+
+### Automated test setup
+
+The Makefile will allow for most testing without much setup. To run all tests at once run
+```
+make test-all
+```
+
+This will run lints, unit testing, the Jest test suite and all end-to-end testing.
+
+You can also run individual test suites as needed. For a full description of available tests to run see
+```
+make help
+```
+
+### Manual test setup
+#### PHP Linting, code standards, and unit tests
 
 _Before performing any of these commands, you should have run `composer install` during Project Setup._
 
@@ -65,13 +89,13 @@ Or run `phpunit` as a composer command.
 composer test
 ```
 
-### End-2-End Testing
+#### End-2-End Testing
 
 _Before running end-2-end tests, ensure you have ran `composer install` from the Project Setup._
 
 [Codeception](https://codeception.com/) is used for running end-2-end tests in the browser.
 
-#### 1. Environment Setup
+##### 1. Environment Setup
 1. Install [Google Chrome](https://www.google.com/chrome/).
 1. Install [Chromedriver](https://chromedriver.chromium.org/downloads)
     - The major version will need to match your Google Chrome [version](https://www.whatismybrowser.com/detect/what-version-of-chrome-do-i-have). See [Chromedriver Version Selection](https://chromedriver.chromium.org/downloads/version-selection).
@@ -80,7 +104,7 @@ _Before running end-2-end tests, ensure you have ran `composer install` from the
     - In shell, run `chromedriver --version`. _Note: If you are using OS X, it may prevent this program from opening. Open "Security & Privacy" and allow chromedriver_.
     - Run `chromedriver --version` again. _Note: On OS X, you may be prompted for a final time, click "Open"_. When you can see the version, chromedriver is ready.
 
-#### 2. End-2-End Testing Site Setup
+##### 2. End-2-End Testing Site Setup
 A running WordPress test site will be needed to run browser tests against. This test site's database will be reset after each test. Do not use your development site for this.
 
 1. Prepare a test WordPress site.
@@ -95,7 +119,7 @@ A running WordPress test site will be needed to run browser tests against. This 
     - If you are not using the provided Docker build, edit the `.env.testing` file with your test WordPress site information.
 1. Run `vendor/bin/codecept run acceptance` to start the end-2-end tests.
 
-#### Browser testing documentation
+##### Browser testing documentation
 - [Codeception Acceptance Tests](https://codeception.com/docs/03-AcceptanceTests)
     - Base framework for browser testing in php.
 - [WPBrowser](https://wpbrowser.wptestkit.dev/)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -45,6 +45,18 @@ You can also run individual test suites as needed. For a full description of ava
 make help
 ```
 
+#### Running a single end-to-end (acceptance) test
+
+```
+TEST=<test> make test-e2e
+```
+
+example:
+
+```
+TEST=CreateContentModelMediaFieldCest:i_can_add_a_media_field_to_a_content_model make test-e2e
+```
+
 ### Manual test setup
 #### PHP Linting, code standards, and unit tests
 


### PR DESCRIPTION
## Description

This adds Makefile targets to reduce the onboarding and usage costs of our multiple test suites and allows for a standardized build to account for version differences with key tools (where necessary). Note usage of these targets is completely optional. They simply add an easier way for many to run the complex tasks associated with some operations.

For a full list of options run `make help`

To run all testing sans e2e tests run `make test`

To run all testing including e2e tests run `make-test-all`

Individual tests and other options such as building npm on run can also be found in the make file.

https://wpengine.atlassian.net/browse/BH-1098

*Note: this does not change or alter existing processes and commands in any way. It adds what some might consider an easier alternative in an effort to make testing and development easier for all contributors*

## Testing:

1. switch to this branch
2. run `make test-all`
3. Verify output of linting, unit, jest and end-to-end tests




