### PR TITLE
BH-1132: Relationship field server-side validation

### DIFF
--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -11,7 +11,6 @@ namespace WPE\AtlasContentModeler\REST_API;
 
 use WP_Error;
 use WP_REST_Request;
-use function WPE\AtlasContentModeler\ContentRegistration\generate_custom_post_type_args;
 use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_types;
 use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
 

--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -205,6 +205,24 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		);
 	}
 
+	if ( isset( $params['type'] ) && $params['type'] === 'relationship' ) {
+		if ( empty( $params['reference'] ) || empty( $params['cardinality'] ) ) {
+			return new WP_Error(
+				'atlas_content_modeler_missing_field_argument',
+				__( 'The relationship field requires a reference and cardinality argument.', 'atlas-content-modeler' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( empty( $content_types[ $params['reference'] ] ) ) {
+			return new WP_Error(
+				'atlas_content_modeler_invalid_related_content_model',
+				__( 'The related content model no longer exists.', 'atlas-content-modeler' ),
+				array( 'status' => 400 )
+			);
+		}
+	}
+
 	if ( isset( $params['type'] ) && $params['type'] === 'multipleChoice' && ! $params['choices'] ) {
 		return new WP_Error(
 			'wpe_invalid_multi_options',

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -232,6 +232,12 @@ function Form({ id, position, type, editing, storedData }) {
 						)
 					);
 				}
+				if (
+					err.code ===
+					"atlas_content_modeler_invalid_related_content_model"
+				) {
+					setError("reference", { type: "invalidRelatedModel" });
+				}
 			});
 	}
 

--- a/includes/settings/js/src/components/fields/RelationshipFields.jsx
+++ b/includes/settings/js/src/components/fields/RelationshipFields.jsx
@@ -63,6 +63,18 @@ const RelationshipFields = ({ register, data, editing, watch, errors }) => {
 									</span>
 								</span>
 							)}
+						{errors.reference &&
+							errors.reference.type === "invalidRelatedModel" && (
+								<span className="error">
+									<Icon type="error" />
+									<span role="alert">
+										{__(
+											"This model no longer exists.",
+											"atlas-content-modeler"
+										)}
+									</span>
+								</span>
+							)}
 					</p>
 				</div>
 				<div className={editing ? "field read-only editing" : "field"}>

--- a/tests/integration/content-registration/test-rest-field-endpoint.php
+++ b/tests/integration/content-registration/test-rest-field-endpoint.php
@@ -257,6 +257,76 @@ class TestRestFieldEndpoint extends WP_UnitTestCase {
 		self::assertSame( 'wpe_invalid_content_model', $response->get_data()['code'] );
 	}
 
+	public function test_attempt_to_create_relationship_field_without_reference_gives_error() {
+		$relationship_field_missing_reference = [
+			'type'        => 'relationship',
+			'id'          => '111',
+			'model'       => 'rabbits',
+			'position'    => '123',
+			'name'        => 'Related',
+			'slug'        => 'related',
+			'cardinality' => 'one-to-one',
+		];
+
+		wp_set_current_user( 1 );
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $relationship_field_missing_reference ) );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'atlas_content_modeler_missing_field_argument', $data['code'] );
+	}
+
+	public function test_attempt_to_create_relationship_field_without_cardinality_gives_error() {
+		$relationship_field_missing_cardinality = [
+			'type'        => 'relationship',
+			'id'          => '111',
+			'model'       => 'rabbits',
+			'position'    => '123',
+			'name'        => 'Related',
+			'slug'        => 'related',
+			'reference'   => 'rabbits',
+		];
+
+		wp_set_current_user( 1 );
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $relationship_field_missing_cardinality ) );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'atlas_content_modeler_missing_field_argument', $data['code'] );
+	}
+
+	public function test_attempt_to_create_relationship_field_with_missing_reference_model_gives_error() {
+		$relationship_field_missing_cardinality = [
+			'type'        => 'relationship',
+			'id'          => '111',
+			'model'       => 'rabbits',
+			'position'    => '123',
+			'name'        => 'Related',
+			'slug'        => 'related',
+			'cardinality' => 'one-to-one',
+			'reference'   => 'does-not-exist',
+		];
+
+		wp_set_current_user( 1 );
+		$request = new WP_REST_Request( 'POST', "/{$this->namespace}/{$this->route}" );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $relationship_field_missing_cardinality ) );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'atlas_content_modeler_invalid_related_content_model', $data['code'] );
+	}
+
 	public function tearDown() {
 		parent::tearDown();
 		wp_set_current_user( null );


### PR DESCRIPTION
## Description

Checks that the relationship field has a valid `reference` property (the related model is not empty and the model exists) and a non-empty `cardinality` property.

https://wpengine.atlassian.net/browse/BH-1132

## Testing

Includes PHP integration tests for the updated REST endpoint logic.

This isn't easily testable manually because the Relationship field form already checks for empty values, so you can't easily submit the form without filling a model and cardinality.

It's intended as a failsafe to try to prevent accidental submission of incomplete relationship fields, or creation of incomplete fields directly via the REST endpoint.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

Depends on, was forked from, and targets #203.

This branch should be merged into the `relationship` branch if #203 is merged first. (GitHub may automatically adjust this branch's target to `main` if #203 is merged, so this PR's target may need to be manually changed to the `relationship` branch before this PR is merged.)