### PR TITLE
[BH-1148] Remove ACM taxonomy associations when deleting a content model

### DIFF
--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -686,7 +686,7 @@ function delete_model( string $post_type_slug ) {
 		if ( $type_index !== false ) {
 			$has_taxonomy_update = true;
 			unset( $taxonomy['types'][ $type_index ] );
-			$taxonomies[ $tax_slug ] = $taxonomy;
+			$taxonomies[ $tax_slug ]['types'] = array_values( $taxonomy['types'] );
 		}
 	}
 

--- a/includes/settings/js/src/components/ContentModelDropdown.jsx
+++ b/includes/settings/js/src/components/ContentModelDropdown.jsx
@@ -37,7 +37,7 @@ function deleteModel(name = "") {
 
 export const ContentModelDropdown = ({ model }) => {
 	const { plural, slug } = model;
-	const { models, dispatch } = useContext(ModelsContext);
+	const { models, dispatch, taxonomiesDispatch } = useContext(ModelsContext);
 	const history = useHistory();
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [modalIsOpen, setModalIsOpen] = useState(false);
@@ -180,11 +180,20 @@ export const ContentModelDropdown = ({ model }) => {
 				<button
 					className="first warning"
 					onClick={async () => {
+						// Optimistically remove the model from the UI.
+						dispatch({ type: "removeModel", slug });
 						// delete model and remove related menu sidebar item
 						await deleteModel(slug)
 							.then((res) => {
 								if (res.success) {
 									removeSidebarMenuItem(slug);
+									taxonomiesDispatch({
+										type: "removeModel",
+										slug,
+									});
+								} else {
+									// Restore the model in the UI since deletion failed.
+									dispatch({ type: "addModel", data: model });
 								}
 							})
 							.catch(() => {
@@ -197,11 +206,12 @@ export const ContentModelDropdown = ({ model }) => {
 										slug
 									)
 								);
+								// Restore the model in the UI since deletion failed.
+								dispatch({ type: "addModel", data: model });
 							});
 
 						setModalIsOpen(false);
 						history.push(atlasContentModeler.appPath);
-						dispatch({ type: "removeModel", slug });
 					}}
 				>
 					Delete

--- a/includes/settings/js/src/taxonomiesReducer.js
+++ b/includes/settings/js/src/taxonomiesReducer.js
@@ -12,6 +12,14 @@ export function taxonomiesReducer(state, action) {
 		case "removeTaxonomy":
 			const { [action.slug]: deleted, ...otherTaxonomies } = state;
 			return otherTaxonomies;
+		case "removeModel":
+			Object.values(state).forEach((taxonomy) => {
+				state[taxonomy.slug].types = taxonomy.types.filter(
+					(type) => type !== action.slug
+				);
+			});
+
+			return state;
 		default:
 			throw new Error(`${action.type} not found`);
 	}

--- a/tests/acceptance/DeleteContentModelCest.php
+++ b/tests/acceptance/DeleteContentModelCest.php
@@ -1,0 +1,68 @@
+<?php
+
+class DeleteContentModelCest
+{
+	public function _before(\AcceptanceTester $I)
+	{
+		$I->maximizeWindow();
+		$I->loginAsAdmin();
+		$I->wait(1);
+		$I->haveContentModel('Goose', 'Geese');
+		$I->wait(1);
+	}
+
+	/**
+	 * Ensure a user can delete models.
+	 */
+	public function i_can_delete_a_model(AcceptanceTester $I)
+	{
+		$I->amOnWPEngineContentModelPage();
+		$I->wait(1);
+
+		$I->click('.model-list button.options');
+		$I->see('Delete', '.dropdown-content');
+        $I->click('Delete', '.model-list .dropdown-content');
+
+		$I->see("Are you sure you want to delete");
+		$I->click('Delete', '.atlas-content-modeler-delete-model-modal-container');
+		$I->wait(1);
+		$I->see("You currently have no Content Models.");
+	}
+
+	/**
+	 * Ensure that any taxonomies associated with a deleted model are updated properly.
+	 *
+	 * We expect that the deleted model's post type slug will be removed from the 'types'
+	 * array of any taxonomies it is associated with.
+	 */
+	public function i_see_that_associated_taxonomies_are_updated_when_model_is_deleted(AcceptanceTester $I)
+	{
+		$I->haveContentModel('Moose', 'Moose');
+		$I->wait(1);
+		$I->haveTaxonomy('Breed', 'Breeds', [ 'goose', 'moose' ]);
+		$I->wait(1);
+
+		$I->amOnWPEngineContentModelPage();
+		$I->click('.model-list button.options');
+        $I->click('Delete', '.model-list .dropdown-content');
+		$I->click('Delete', '.atlas-content-modeler-delete-model-modal-container');
+
+		$I->dontSee('Goose', '.model-list');
+		$I->wait(1);
+
+		// Test that React state was updated without reloading the page.
+		$I->click('button.taxonomies');
+		$I->see('moose', '.taxonomy-list');
+		$I->dontSee('goose', '.taxonomy-list');
+
+		/**
+		 * We have tested the React state update above, but we
+		 * should also test a fresh copy of the data from the
+		 * server.
+		 */
+		$I->reloadPage();
+
+		$I->see('moose', '.taxonomy-list');
+		$I->dontSee('goose', '.taxonomy-list');
+	}
+}


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

- The `delete_model()` function has been refactored a bit for this work. It didn't appear to be used anywhere, so I thought it made sense to update and align it with how we use `create_model()` and `update_model()`. A side effect of this refactoring is improved error messaging, which allowed for better error handling on the front-end.
- I've allowed a content model's association with a taxonomy to be removed _even if it's the last model associated to that taxonomy_. This bypasses the front-end requirement that forces users to choose at least one model for every taxonomy, but I didn't see any good alternatives (i.e. preventing the model deletion or deleting the whole taxonomy if this was the last model). I wonder if dropping the front-end requirement might be the way to go?
     - **Another consequence of this decision:** After deleting all of your models, taxonomies might still exist in the DB but remain inaccessible from the UI due to the fact that we only show the "View Taxonomies" button when you have at least one model. How we address this depends on what we do with the front-end requirement.

Related to the second point above, I started to feel like I was stretching the limits of our data structures here. What we have still works for now, but I wanted to go ahead and bring it up and start collecting thoughts in case others run into the same limitations. Feel free to chime in on [BH-1150](https://wpengine.atlassian.net/browse/BH-1150).

<!--
Provide a link to the JIRA ticket (if any) for issue tracking purposes
-->

https://wpengine.atlassian.net/browse/BH-1148

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

Unit and e2e tests are included. Manual steps:

1. Create Restaurant and Recipe models.
2. Create a Cuisines taxonomy and assign it to both Restaurants and Recipes.
3. Delete the Recipe model.
4. Click "View Taxonomies" to view the taxonomy list.
5. See that "restaurant" is the only model listed for Cuisines in the taxonomies table.