### PR TITLE
BH-1142: Prepare 0.4.2 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Atlas Content Modeler Changelog
 
-## 0.4.2 - 2021-08-02
+## 0.4.2 - 2021-08-04
 
 ### Added
 - Ability to choose an icon when creating or editing a model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Improve query generation for “Open in GraphiQL” to include lowercase model names and models with the same plural and singular name.
+- Improve sanitization of model slugs. Includes safe migration of existing model slugs.
 - Prevent a PHP warning during title filtering if post info can not be found.
 - Improve number field validation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Atlas Content Modeler Changelog
 
-## Unreleased
+## 0.4.2 - 2021-08-02
+
+### Added
+- Ability to choose an icon when creating or editing a model.
+- Option to restrict file types for the media field.
+- Generate WordPress changelog from the Markdown changelog so that changes are visible from the WordPress changes modal.
+- Plugin developer improvements: GitHub Pull Request template; Code Climate configuration; Makefile for test environments.
+
+### Changed
+- Change “API Identifier” field title on model entry forms to “Model ID” with a new description to better reflect its use.
+- Continuous Integration: the generated plugin zip is now tested and verified before deploying.
 
 ### Fixed
+- Improve query generation for “Open in GraphiQL” to include lowercase model names and models with the same plural and singular name.
 - Prevent a PHP warning during title filtering if post info can not be found.
 
 ## 0.4.1 - 2021-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 - Improve query generation for “Open in GraphiQL” to include lowercase model names and models with the same plural and singular name.
 - Prevent a PHP warning during title filtering if post info can not be found.
+- Improve number field validation.
 
 ## 0.4.1 - 2021-06-24
 ### Added

--- a/atlas-content-modeler.php
+++ b/atlas-content-modeler.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpengine.com/
  * Text Domain: atlas-content-modeler
  * Domain Path: /languages
- * Version: 0.4.1
+ * Version: 0.4.2
  * Requires at least: 5.2
  * Requires PHP: 7.2
  * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Requires at least: 5.3
 Tested up to: 5.7
 Requires PHP: 7.0
-Stable tag: 0.4.1
+Stable tag: 0.4.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Author: WP Engine

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Atlas Content Modeler ===
 Requires at least: 5.3
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 7.0
 Stable tag: 0.4.2
 License: GPLv2 or later


### PR DESCRIPTION
- Preps 0.4.2 for release from the `main` branch.
- Excludes taxonomy and relationships features.
- I was unable to find issues under WordPress 5.8, so I bumped "Tested up to" to 5.8 as suggested by @ChrisWiegman.

https://wpengine.atlassian.net/browse/bh-1142

## Testing

Grab the [zip file artifact](https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/1359/workflows/7527d0a3-6e37-4a48-826b-34be089c9db3/jobs/11490/artifacts) from Circle once built, and confirm all is well locally.

The PHP unit test failure for `PostTypeRegistrationTestCases::test_graphql_query_result_has_custom_fields_data` is being discussed in Slack. I filed a separate PR in https://github.com/wpengine/atlas-content-modeler/pull/212.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

- https://github.com/wpengine/atlas-content-modeler/pull/212 should be merged to main before this is released to prevent CI failures during deployment.