### PR TITLE
[NO JIRA] Fix test failure by clearing WPGraphQL schema on setup

### DIFF
--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -35,6 +35,13 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		/**
+		 * Reset the WPGraphQL schema before each test.
+		 * Lazy loading types only loads part of the schema,
+		 * so we refresh for each test.
+		 */
+		WPGraphQL::clear_schema();
+
 		update_registered_content_types( $this->mock_post_types() );
 
 		// @todo why is this not running automatically?


### PR DESCRIPTION
Fixes a test failure in `tests/integration/content-registration/test-custom-post-type-registration.php` using the advice from @jasonbahl in the related [Slack thread](https://wpengine.slack.com/archives/C020RTG8Y0L/p1627662933002900).

## Testing

Confirm that `PostTypeRegistrationTestCases::test_graphql_query_result_has_custom_fields_data` tests pass in the `plugin-test-unit` CircleCI workflow.

Example of previous test failure:

```
PostTypeRegistrationTestCases::test_graphql_query_result_has_custom_fields_data
PHPUnit\Runner\Exception: test_graphql_query_result_has_custom_fields_data failed with exception: Undefined index: data
```

https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/1322/workflows/b0155d57-9dc4-4ab5-a168-21ef30429387/jobs/11055

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

n/a