### PR TITLE
[NO JIRA] Ensure relationship fields can be updated

### DIFF
--- a/includes/settings/js/src/components/fields/RelationshipFields.jsx
+++ b/includes/settings/js/src/components/fields/RelationshipFields.jsx
@@ -50,6 +50,14 @@ const RelationshipFields = ({ register, data, editing, watch, errors }) => {
 							);
 						})}
 					</select>
+					{editing && (
+						<input
+							type="hidden"
+							ref={register()}
+							name="reference"
+							value={data?.reference}
+						/>
+					)}
 					<p className="field-messages">
 						{errors.reference &&
 							errors.reference.type === "required" && (

--- a/tests/acceptance/CreateContentModelRelationFieldCest.php
+++ b/tests/acceptance/CreateContentModelRelationFieldCest.php
@@ -48,4 +48,21 @@ class CreateContentModelRelationFieldCest
 		$I->assertEquals('true', $reference_disabled_state);
 		$I->assertEquals('true', $cardinality_disabled_state);
 	}
+
+	public function i_can_update_an_existing_relationship_field(AcceptanceTester $I)
+	{
+		$this->i_can_create_a_relation_field($I);
+		// Offsets from the center are used here to prevent “other element would
+		// receive the click” due to the “add field” button overlapping the edit
+		// button in the center.
+		$I->clickWithLeftButton('.field-list button.edit', -5, -5);
+		$I->wait(1);
+
+		$I->fillField(['name' => 'name'], 'Updated Name');
+
+		$I->click('.open-field button.primary');
+		$I->wait(1);
+
+		$I->see('Updated Name', '.field-list div.widest');
+	}
 }

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -35,6 +35,13 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		/**
+		 * Reset the WPGraphQL schema before each test.
+		 * Lazy loading types only loads part of the schema,
+		 * so we refresh for each test.
+		 */
+		WPGraphQL::clear_schema();
+
 		update_registered_content_types( $this->mock_post_types() );
 
 		// @todo why is this not running automatically?


### PR DESCRIPTION
Prevents a 400 error when attempting to update an existing relationship field.

When editing the relationship field, the disabled 'reference' select field value would not be sent during updates. The 400 error occurred due to this logic on the backend, which expects a non-empty reference value during field creation or update:

https://github.com/wpengine/atlas-content-modeler/blob/9a25f7f95becf4508b873dc260fd5b397a107a1e/includes/rest-api/rest-api-endpoint-registration.php#L209-L215

This fix creates a hidden input field to send the reference value if the relationship field is being edited, so that the 'reference' value is always passed even if the select field it relates to is disabled.

Also includes a cherry-pick of 13759cbf176d048ba2436613bbbe3509825b4ccf to ensure that tests pass here.

## Testing

Includes e2e tests to update a relationship field.

### To test manually
1. Create a relationship field.
2. Edit the relationship field, change its name and confirm you can save the field.
3. Refresh to ensure the updated name persists.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

n/a