### PR TITLE
BH-1087: Adjust styling for the relationship field (DevEx)

### DIFF
--- a/includes/settings/js/src/components/fields/RelationshipFields.jsx
+++ b/includes/settings/js/src/components/fields/RelationshipFields.jsx
@@ -1,7 +1,7 @@
 /**
  * Additional form fields for the Relationship field type.
  */
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { sprintf, __ } from "@wordpress/i18n";
 import { ModelsContext } from "../../ModelsContext";
 import { useLocationSearch } from "../../utils";
@@ -14,6 +14,10 @@ const RelationshipFields = ({ register, data, editing, watch, errors }) => {
 	);
 	const modelId = useLocationSearch().get("id");
 	const selectedReference = watch("reference");
+	const [descriptionCount, setDescriptionCount] = useState(
+		data?.description?.length || 0
+	);
+	const descriptionMaxLength = 250;
 
 	return (
 		<>
@@ -180,10 +184,27 @@ const RelationshipFields = ({ register, data, editing, watch, errors }) => {
 				</p>
 				<textarea
 					name="description"
-					ref={register()}
+					ref={register({ maxLength: descriptionMaxLength })}
 					id="description"
 					className="two-columns"
+					onChange={(e) => setDescriptionCount(e.target.value.length)}
 				/>
+				<p className="field-messages two-columns">
+					{errors.description &&
+						errors.description.type === "maxLength" && (
+							<span className="error">
+								<Icon type="error" />
+								<span role="alert">
+									{__(
+										"Exceeds max length.",
+										"atlas-content-modeler"
+									)}
+								</span>
+							</span>
+						)}
+					<span>&nbsp;</span>
+					<span className="count">{`${descriptionCount}/${descriptionMaxLength}`}</span>
+				</p>
 			</div>
 		</>
 	);

--- a/includes/settings/js/src/components/fields/RelationshipFields.jsx
+++ b/includes/settings/js/src/components/fields/RelationshipFields.jsx
@@ -174,6 +174,7 @@ const RelationshipFields = ({ register, data, editing, watch, errors }) => {
 					name="description"
 					ref={register()}
 					id="description"
+					className="two-columns"
 				/>
 			</div>
 		</>

--- a/includes/settings/scss/_forms.scss
+++ b/includes/settings/scss/_forms.scss
@@ -186,7 +186,7 @@ input[type="radio"] {
 
 .atlas-content-modeler-admin-page .radio-row {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	margin-bottom: 10px;
 }
 .atlas-content-modeler-admin-page .field a {
@@ -215,7 +215,7 @@ input[type="radio"] {
 }
 
 .atlas-content-modeler-admin-page .radio-row input[type="radio"] {
-	margin-right: 20px;
+	margin: 5px 8px 0 0;
 }
 
 .atlas-content-modeler-admin-page .radio-row label span {

--- a/includes/settings/scss/_forms.scss
+++ b/includes/settings/scss/_forms.scss
@@ -131,6 +131,12 @@
 	text-align: right;
 }
 
+@media screen and (min-width: 782px) {
+	.atlas-content-modeler-admin-page .field-messages.two-columns {
+		max-width: 570px;
+	}
+}
+
 .atlas-content-modeler-admin-page .field-messages .error {
 	align-items: center;
 	display: flex;

--- a/includes/settings/scss/_forms.scss
+++ b/includes/settings/scss/_forms.scss
@@ -42,6 +42,11 @@
 		select {
 			width: 260px !important;
 		}
+
+		textarea.two-columns {
+			max-width: none;
+			width: 570px !important;
+		}
 	}
 }
 

--- a/tests/acceptance/CreateContentModelRelationFieldCest.php
+++ b/tests/acceptance/CreateContentModelRelationFieldCest.php
@@ -1,4 +1,5 @@
 <?php
+use Codeception\Util\Locator;
 
 class CreateContentModelRelationFieldCest
 {
@@ -64,5 +65,32 @@ class CreateContentModelRelationFieldCest
 		$I->wait(1);
 
 		$I->see('Updated Name', '.field-list div.widest');
+	}
+
+	public function i_can_set_a_relationship_field_description_shorter_than_the_character_limit(AcceptanceTester $I)
+	{
+		$I->selectOption('#reference', 'Employees');
+		$I->click('#one-to-many');
+
+		// The field cannot be submitted with a description exceeding the maximum length.
+		$I->fillField(['name' => 'description'], str_repeat('a', 251));
+		$I->see('251/250', Locator::lastElement('span.count'));
+		$I->click('.open-field button.primary');
+		$I->wait(1);
+		$I->see('Exceeds max length');
+
+		// The description saves when corrected.
+		$I->fillField(['name' => 'description'], 'This text is under the character limit.');
+		$I->see('39/250', Locator::lastElement('span.count'));
+		$I->click('.open-field button.primary');
+		$I->wait(1);
+		$I->see('Relationship', '.field-list div.type');
+		$I->see('Company Employees', '.field-list div.widest');
+
+		// The description and count are correct when reopening the field.
+		$I->clickWithLeftButton('.field-list button.edit', -5, -5);
+		$I->seeInField('description', 'This text is under the character limit.');
+		$I->see('39/250', Locator::lastElement('span.count'));
+		$I->wait(1);
 	}
 }


### PR DESCRIPTION
## Description

Implements changes from design review feedback at https://wpengine.atlassian.net/browse/BH-1087.

- Aligns radio buttons with main labels.
- Uses two columns for the relationship field description.
- Adds a maximum character limit of 250 to the description field, with counter and error message.

## Testing

Includes an e2e test for the new description field character limit.

To test manually:

- Confirm design changes look ok.
- Confirm relationship field description count behaves as expected.

## Screenshots

| Before  | After |
| ------------- | ------------- |
|  <img width="975" alt="Screenshot 2021-08-04 at 12 19 25" src="https://user-images.githubusercontent.com/647669/128164991-03cf3baa-827e-4cec-9a3c-59dce73ae13e.png"> |  <img width="944" alt="Screenshot 2021-08-04 at 12 18 43" src="https://user-images.githubusercontent.com/647669/128165016-e5fdc3b0-44ec-4c3e-944d-5f6e3e3deac7.png"> |

## Documentation Changes

n/a

## Dependant PRs

n/a