### PR TITLE
[NO JIRA] Apply slug sanitization updates to taxonomies

### DIFF
--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -797,7 +797,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 	if ( in_array( $params['slug'], $non_acm_taxonomies, true ) ) {
 		return new WP_Error(
 			'atlas_content_modeler_taxonomy_exists',
-			esc_html__( 'A taxonomy with this API Identifier already exists.', 'atlas-content-modeler' ),
+			esc_html__( 'A taxonomy with this Taxonomy ID already exists.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -806,7 +806,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 	if ( ! $is_update && array_key_exists( $params['slug'], $acm_taxonomies ) ) {
 		return new WP_Error(
 			'atlas_content_modeler_taxonomy_exists',
-			esc_html__( 'A taxonomy with this API Identifier already exists.', 'atlas-content-modeler' ),
+			esc_html__( 'A taxonomy with this Taxonomy ID already exists.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}

--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -781,10 +781,10 @@ function content_model_multi_option_exists( array $names, string $current_choice
  * @since 0.6.0
  */
 function save_taxonomy( array $params, bool $is_update ) {
-	if ( empty( $params['slug'] ) ) {
+	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {
 		return new WP_Error(
 			'atlas_content_modeler_invalid_id',
-			esc_html__( 'Please provide a valid API Identifier.', 'atlas-content-modeler' ),
+			esc_html__( 'Taxonomy slug must be between 1 and 32 characters in length.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}

--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -782,6 +782,10 @@ function content_model_multi_option_exists( array $names, string $current_choice
  * @since 0.6.0
  */
 function save_taxonomy( string $taxonomy_slug, array $params, bool $is_update ) {
+	// Sanitize key allows hyphens, but it's close enough to register_taxonomy() requirements.
+	$taxonomy_slug  = sanitize_key( $taxonomy_slug );
+	$params['slug'] = $taxonomy_slug;
+
 	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {
 		return new WP_Error(
 			'atlas_content_modeler_invalid_id',

--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -592,7 +592,7 @@ function dispatch_update_taxonomy( WP_REST_Request $request ) {
 	unset( $params['_locale'] ); // Sent by wp.apiFetch but not needed.
 
 	$is_update = $request->get_method() === 'PUT';
-	$taxonomy  = save_taxonomy( $params['slug'], $params, $is_update );
+	$taxonomy  = save_taxonomy( $params, $is_update );
 
 	if ( is_wp_error( $taxonomy ) ) {
 		return new WP_Error(
@@ -775,16 +775,14 @@ function content_model_multi_option_exists( array $names, string $current_choice
 /**
  * Saves a taxonomy.
  *
- * @param string $taxonomy_slug The taxonomy slug.
- * @param array  $params Parameters passed from the taxonomy form.
- * @param bool   $is_update True if `$params` came from a PUT request.
+ * @param array $params Parameters passed from the taxonomy form.
+ * @param bool  $is_update True if `$params` came from a PUT request.
  * @return array|WP_Error
  * @since 0.6.0
  */
-function save_taxonomy( string $taxonomy_slug, array $params, bool $is_update ) {
+function save_taxonomy( array $params, bool $is_update ) {
 	// Sanitize key allows hyphens, but it's close enough to register_taxonomy() requirements.
-	$taxonomy_slug  = sanitize_key( $taxonomy_slug );
-	$params['slug'] = $taxonomy_slug;
+	$params['slug'] = isset( $params['slug'] ) ? sanitize_key( $params['slug'] ) : '';
 
 	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {
 		return new WP_Error(

--- a/includes/rest-api/rest-api-endpoint-registration.php
+++ b/includes/rest-api/rest-api-endpoint-registration.php
@@ -592,7 +592,7 @@ function dispatch_update_taxonomy( WP_REST_Request $request ) {
 	unset( $params['_locale'] ); // Sent by wp.apiFetch but not needed.
 
 	$is_update = $request->get_method() === 'PUT';
-	$taxonomy  = save_taxonomy( $params, $is_update );
+	$taxonomy  = save_taxonomy( $params['slug'], $params, $is_update );
 
 	if ( is_wp_error( $taxonomy ) ) {
 		return new WP_Error(
@@ -775,12 +775,13 @@ function content_model_multi_option_exists( array $names, string $current_choice
 /**
  * Saves a taxonomy.
  *
- * @param array $params Parameters passed from the taxonomy form.
- * @param bool  $is_update True if `$params` came from a PUT request.
+ * @param string $taxonomy_slug The taxonomy slug.
+ * @param array  $params Parameters passed from the taxonomy form.
+ * @param bool   $is_update True if `$params` came from a PUT request.
  * @return array|WP_Error
  * @since 0.6.0
  */
-function save_taxonomy( array $params, bool $is_update ) {
+function save_taxonomy( string $taxonomy_slug, array $params, bool $is_update ) {
 	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {
 		return new WP_Error(
 			'atlas_content_modeler_invalid_id',

--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -26,7 +26,7 @@ export default function Taxonomies() {
 		}
 
 		const getTaxonomyEditHref = (slug, type) =>
-			`edit-tags.php?taxonomy=${slug}&post_type=${type.toLowerCase()}`;
+			`edit-tags.php?taxonomy=${slug}&post_type=${type}`;
 
 		// Remove taxonomies that no longer exists or are not associated with a specific model.
 		Object.values(prevTaxonomies).forEach(({ slug, types }) => {
@@ -72,7 +72,7 @@ export default function Taxonomies() {
 				// If the taxonomy link didn't exist already, we should insert it.
 				if (!taxLink) {
 					const postTypeSubMenu = document.querySelector(
-						`#menu-posts-${type.toLowerCase()} .wp-submenu`
+						`#menu-posts-${type} .wp-submenu`
 					);
 
 					if (!postTypeSubMenu) {

--- a/includes/settings/js/src/components/TaxonomiesForm.jsx
+++ b/includes/settings/js/src/components/TaxonomiesForm.jsx
@@ -4,7 +4,8 @@ import { __, sprintf } from "@wordpress/i18n";
 import { ModelsContext } from "../ModelsContext";
 import Icon from "../../../../components/icons";
 import { showSuccess } from "../toasts";
-import { useApiIdGenerator } from "./fields/useApiIdGenerator";
+import { useInputGenerator } from "../hooks";
+import { toPostTypeSlug as toSanitizedKey } from "../formats";
 
 const { apiFetch } = wp;
 const { isEqual, pick } = lodash;
@@ -28,12 +29,12 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 	});
 
 	const {
-		setApiIdGeneratorInput,
-		apiIdFieldAttributes,
 		setFieldsAreLinked,
-	} = useApiIdGenerator({
-		apiFieldId: "slug",
-		setValue,
+		setInputGeneratorSourceValue,
+		onChangeGeneratedValue,
+	} = useInputGenerator({
+		setGeneratedValue: (value) => setValue("slug", value),
+		format: toSanitizedKey,
 	});
 
 	const successMessage = editingTaxonomy
@@ -56,7 +57,7 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 	 */
 	const resetForm = () => {
 		reset();
-		setApiIdGeneratorInput("");
+		setInputGeneratorSourceValue("");
 		setSingularCount(0);
 		setPluralCount(0);
 		setFieldsAreLinked(true);
@@ -176,7 +177,7 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 						maxLength: 50,
 					})}
 					onChange={(e) => {
-						setApiIdGeneratorInput(e.target.value);
+						setInputGeneratorSourceValue(e.target.value);
 						setSingularCount(e.target.value.length);
 					}}
 				/>
@@ -282,7 +283,9 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 						required: true,
 						maxLength: 32,
 					})}
-					{...apiIdFieldAttributes}
+					onChange={(e) => {
+						onChangeGeneratedValue(e.target.value);
+					}}
 				/>
 				<p className="field-messages">
 					{errors.slug && errors.slug.type === "required" && (

--- a/includes/settings/js/src/components/TaxonomiesForm.jsx
+++ b/includes/settings/js/src/components/TaxonomiesForm.jsx
@@ -262,15 +262,15 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 				</p>
 			</div>
 
-			{/* API Identifier / Slug */}
+			{/* Taxonomy ID / Slug */}
 			<div className={errors.slug ? "field has-error" : "field"}>
 				<label htmlFor="slug">
-					{__("API Identifier", "atlas-content-modeler")}
+					{__("Taxonomy ID", "atlas-content-modeler")}
 				</label>
 				<br />
 				<p className="help">
 					{__(
-						"Auto-generated from the singular name and used for API requests.",
+						"Auto-generated and used internally for WordPress to identify the taxonomy.",
 						"atlas-content-modeler"
 					)}
 				</p>

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -103,7 +103,7 @@ class CreateTaxonomyCest
 		$I->click('.card-content button.primary');
 		$I->wait(1);
 
-		$I->see('A taxonomy with this API Identifier already exists');
+		$I->see('A taxonomy with this Taxonomy ID already exists');
 	}
 
 	public function i_can_see_a_generated_slug_when_creating_a_second_taxonomy_after_editing_the_slug_in_the_first(AcceptanceTester $I)
@@ -121,7 +121,7 @@ class CreateTaxonomyCest
 		$I->see('taxonomy was created', '#success');
 		$I->see('Firsts', '.taxonomy-list');
 
-		// A successful submission should relink the Singular and API ID fields
+		// A successful submission should relink the Singular and Taxonomy ID fields
 		// so they are linked for the next entry. Confirm the fields were
 		// relinked: filling "singular" should auto-generate a slug.
 		$I->fillField(['name' => 'singular'], 'Second');

--- a/tests/acceptance/EditTaxonomyCest.php
+++ b/tests/acceptance/EditTaxonomyCest.php
@@ -8,6 +8,7 @@ class EditTaxonomyCest
 		$I->loginAsAdmin();
 		$I->wait(1);
 		$I->haveContentModel('Goose', 'Geese');
+		$I->wait(1);
 		$I->haveTaxonomy('Breed', 'Breeds', ['goose']);
 		$I->wait(1);
 		$I->amOnTaxonomyListingsPage();


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->
Accounting for the merge of #214:

- Replaces the `useApiIDGenerator` hook with `useInputGenerator`.
- Sanitizes taxonomy slugs server-side.
- Enforces slug length restrictions server-side.
- Changes API Identifier label to Taxonomy ID (following pattern from #200)
- Changes formatting of Taxonomy ID to match `sanitize_key()` behavior.
    - WordPress doesn't do this sanitization automatically on registration of taxonomies like they do for post types, so we wouldn't technically run into any mismatch between stored and registered taxonomy slug values. However, sanitizing still seems like a good thing for us to do. The taxonomy slug is used as an array key, so sanitize_key() still seemed like a good choice.

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->
Existing tests should provide sufficient coverage for these changes.
