### PR TITLE
BH-1162: Add ADR and docs on REST conventions for relationship fields

### DIFF
--- a/docs/adr/0002-taxonomy-definition-schema.md
+++ b/docs/adr/0002-taxonomy-definition-schema.md
@@ -1,4 +1,4 @@
-1: Add schema for storing user-provided taxonomy definitions
+2: Add schema for storing user-provided taxonomy definitions
 =====================================================
 
 Date: 2021-06-23

--- a/docs/adr/0003-rest-api-relationship-field.md
+++ b/docs/adr/0003-rest-api-relationship-field.md
@@ -1,0 +1,104 @@
+3: Allow access to relationship field information via the REST API
+==================================================================
+
+Date: 2021-08-09
+
+Context
+-------
+
+- Relationship fields store relationships between a model entry and one or more other model entries.
+- This plugin already exposes entry metadata (stored field values) in REST responses via the top-level `acm_fields` object.
+- Relationship field metadata will appear in the `acm_fields` object as a reference (such as the ID) by default.
+- We wish to offer the option to retrieve detailed information about related entries (such as the related post title and not just its ID) without additional REST requests.
+
+Decision
+--------
+
+By default, REST requests for an entry with a relationship field will return the related entry ID in `acm_fields`, as well as a link to the related resource in the `_links` top-level object under a `related` key:
+
+```sh
+curl https://example.com/wp-json/wp/v2/rabbits/123 | jq
+
+{
+  "id": 123,
+  …
+  "acm_fields": {
+    "owner": 456
+  },
+  "_links": {
+    "related": [
+      {
+        "href": "https://example.com/wp-json/wp/v2/owners/456",
+        "embeddable": true
+      }
+    ],
+    "self": [
+      {
+        "href": "https://example.com/wp-json/wp/v2/rabbits/123"
+      }
+    ],
+    …
+  }
+}
+```
+
+REST requests for the same resource with an added `_embed` query parameter will return all embeddable `_links` expanded in an `_embedded` top-level object.
+
+```sh
+curl https://example.com/wp-json/wp/v2/rabbits/123?_embed | jq
+
+{
+  "id": 123,
+  …
+  "acm_fields": {
+    "owner": 456
+  },
+  "_links": {
+    "related": [
+      {
+        "href": "https://example.com/wp-json/wp/v2/owners/456",
+        "embeddable": true
+      }
+    ],
+    "self": [
+      {
+        "href": "https://example.com/wp-json/wp/v2/rabbits/123"
+      }
+    ],
+    …
+  },
+  "_embedded": {
+    "related": {
+      456: {
+        "id": 456,
+        "title": "Isabella",
+        "acm_fields": {
+          "pets": [ 123 ],
+		  "field2": "field 2 value"
+        }
+      }
+    …
+    }
+  }
+  …
+}
+```
+
+Embedded entries with relationship meta should not add those entries to the `_links` or `_embedded` objects. This is to keep top-level `_links` and `_embedded` values scoped to the current resource and to avoid cyclical references and performance issues from deep-nested relationships.
+
+Consequences
+------------
+
+- This decision aligns with the existing WordPress core REST mechanism for [linked and embedded items](https://developer.wordpress.org/rest-api/using-the-rest-api/linking-and-embedding/).
+- Clients that need information about deep-nested structures may still need to infer resource URLs from the context and make more than one request.
+
+Alternatives
+------------
+
+These alternatives were evaluated and rejected:
+
+- Displaying only the ID of the related entry with no provision for returning more information in the same request. This is the easiest path but it makes it frustrating to work with related entries using the REST API.
+- Returning the related entry URI instead of the entry ID as the related field value. This eases further lookups but still requires additional requests.
+- Adopting an “expandable object” API such as [the REST API used by Stripe](https://stripe.com/docs/api/expanding_objects). Extending the example above, passing `expand[]="acm_fields.owner"` would return an object of expanded owner data inline and in place of the related owner ID, instead of in a separate `_embedded` object. This is an elegant idea that we may consider adopting later. We rejected it for now because:
+    - It goes against the model currently used by WordPress. If users are already passing `_embed`, they do not have to learn anything new. If users are not already passing `_embed`, they can add it and interact with our API the same way as the WordPress core API. By following WordPress conventions instead of inventing our own REST query API, we reduce the chance of updates to WordPress breaking REST request handling.
+    - Developers who prefer this API may be better served by using GraphQL via [WPGraphQL](https://www.wpgraphql.com/), which offers a powerful query system to request nested data already.

--- a/docs/adr/0003-rest-api-relationship-field.md
+++ b/docs/adr/0003-rest-api-relationship-field.md
@@ -69,7 +69,7 @@ curl https://example.com/wp-json/wp/v2/rabbits/123?_embed | jq
   },
   "_embedded": {
     "related": {
-      456: {
+      "456": {
         "id": 456,
         "title": "Isabella",
         "acm_fields": {

--- a/docs/adr/0003-rest-api-relationship-field.md
+++ b/docs/adr/0003-rest-api-relationship-field.md
@@ -45,7 +45,7 @@ curl https://example.com/wp-json/wp/v2/rabbits/123 | jq
 REST requests for the same resource with an added `_embed` query parameter will return all embeddable `_links` expanded in an `_embedded` top-level object.
 
 ```sh
-curl https://example.com/wp-json/wp/v2/rabbits/123?_embed | jq
+curl "https://example.com/wp-json/wp/v2/rabbits/123?_embed" | jq
 
 {
   "id": 123,

--- a/docs/dev/REST-API.md
+++ b/docs/dev/REST-API.md
@@ -131,7 +131,7 @@ In keeping with [WordPress Core REST conventions](https://developer.wordpress.or
 
 Send additional requests to fetch data about related resources.
 
-Alternatively, fetch data about related entries in your first request by passing the `_embed` query string in the request URI:
+Alternatively, fetch data about related entries in your first request by passing the `_embed` query parameter in the request URI:
 
 `wp-json/wp/v2/[model-plural-name]/[entry-id]?_embed`
 

--- a/docs/dev/REST-API.md
+++ b/docs/dev/REST-API.md
@@ -1,0 +1,161 @@
+# Fetching Atlas Content Modeler Entries with the WordPress REST API
+
+Atlas Content Modeler uses the [WordPress Core REST API](https://developer.wordpress.org/rest-api/) to expose model entries and field data.
+
+## Private vs Public models
+
+Models have private API visibility by default. You must authenticate with a plugin such as [Basic Auth](https://github.com/WP-API/Basic-Auth) to see REST responses for private model data.
+
+To expose model data without authentication, edit the model at Content Modeler → Content Models and change its API Visibility to public.
+
+## Fetch model collections
+
+Fetch a list of model entries using the model's collection endpoint at `wp-json/wp/v2/[model-plural-name]`.
+
+The response includes an array of model entries with Atlas Content Modeler field data in an `acm_fields` object.
+
+For example, with a public “Rabbits” model that has a plural name of “rabbits”:
+
+```sh
+curl https://example.com/wp-json/wp/v2/rabbits
+
+[
+  {
+    "id": 57719,
+    "date": "2021-08-09T15:29:42",
+    "date_gmt": "2021-08-09T15:29:42",
+    "guid": {
+      "rendered": "https://example.com/?post_type=rabbit&#038;p=57719"
+    },
+    "modified": "2021-08-09T15:29:42",
+    "modified_gmt": "2021-08-09T15:29:42",
+    "slug": "57719",
+    "status": "publish",
+    "type": "rabbit",
+    "link": "https://example.com/rabbit/57719/",
+    "template": "",
+    "acm_fields": {
+      "name": "Thumper"
+    },
+    "_links": {
+      …
+    }
+  },
+  {
+    "id": 57716,
+    "date": "2021-08-09T15:28:35",
+    "date_gmt": "2021-08-09T15:28:35",
+    "guid": {
+      "rendered": "https://example.com/?post_type=rabbit&#038;p=57716"
+    },
+    "modified": "2021-08-09T15:28:35",
+    "modified_gmt": "2021-08-09T15:28:35",
+    "slug": "57716",
+    "status": "publish",
+    "type": "rabbit",
+    "link": "https://example.com/rabbit/57716/",
+    "template": "",
+    "acm_fields": {
+      "name": "Roger"
+    },
+    "_links": {
+      …
+    }
+  }
+]
+```
+
+## Fetch a single model entry
+
+Request a single model entry at `wp-json/wp/v2/[model-plural-name]/[entry-id]`.
+
+```sh
+curl https://example.com/wp-json/wp/v2/rabbits/57719
+
+{
+  "id": 57719,
+  "date": "2021-08-09T15:29:42",
+  "date_gmt": "2021-08-09T15:29:42",
+  "guid": {
+    "rendered": "https://example.com/?post_type=rabbit&#038;p=57719"
+  },
+  "modified": "2021-08-09T15:29:42",
+  "modified_gmt": "2021-08-09T15:29:42",
+  "slug": "57719",
+  "status": "publish",
+  "type": "rabbit",
+  "link": "https://example.com/rabbit/57719/",
+  "template": "",
+  "acm_fields": {
+    "name": "Thumper"
+  },
+  "_links": {
+    …
+  }
+}
+```
+
+### Relationship fields
+
+Relationship fields display the ID of the related entry by default.
+
+A request for `wp-json/wp/v2/[model-plural-name]/[entry-id]` for a model with a one-to-many relationship field titled “friends” might give:
+
+```json
+{
+  "acm_fields": {
+    "name": "Thumper",
+    "friends": [ 123, 124 ]
+  },
+}
+```
+
+In keeping with [WordPress Core REST conventions](https://developer.wordpress.org/rest-api/using-the-rest-api/linking-and-embedding/), responses for entries containing relationship fields also include a `_links` object with related resources and their URIs:
+
+```json
+{
+  "_links": {
+    "related": [
+      {
+        "href": "https://example.com/wp-json/wp/v2/deer/123",
+        "embeddable": true
+      },
+      {
+        "href": "https://example.com/wp-json/wp/v2/rabbits/124",
+        "embeddable": true
+      }
+    ],
+  },
+}
+```
+
+Send additional requests to fetch data about related resources.
+
+Alternatively, fetch data about related entries in your first request by passing the `_embed` query string in the request URI:
+
+`wp-json/wp/v2/[model-plural-name]/[entry-id]?_embed`
+
+You will see embeddable resources from `_links` expanded in an `_embedded` object at the top level of the response, without having to make additional requests:
+
+```json
+{
+  "_embedded": {
+    "related": {
+      "123": {
+        "id": 123,
+        "title": "Bambi",
+        "acm_fields": {
+          "field": "field value"
+        }
+      },
+      "124": {
+        "id": 124,
+        "title": "Blossom",
+        "acm_fields": {
+          "field": "field value"
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
## Description

- Proposes a method to return related field data in response to a single REST request for an entry with related entries. (See `docs/adr/0003-rest-api-relationship-field.md`.)
- Documents how developers would use the REST API to get information about a related field. (See `docs/dev/REST-API.md`.)
- Targets the `relationship` branch. These docs will only be relevant when the relationship feature is complete and that branch is merged to main.

https://wpengine.atlassian.net/browse/BH-1162

## Testing

No code changes. This documents proposed changes and suggests a direction for [BH-1138](https://wpengine.atlassian.net/browse/BH-1138).

Review the added ADR and docs and feel free to leave suggestions for improvement or comments about the approach.

I have based responses on WordPress core documentation, because our relationship field and REST logic do not exist yet. Docs may need to be adjusted when the feature is complete and we can test the REST response.