### PR TITLE
BH-1167: Adjust Taxonomies feature based on design review

### DIFF
--- a/includes/settings/js/src/components/Taxonomies.jsx
+++ b/includes/settings/js/src/components/Taxonomies.jsx
@@ -112,26 +112,6 @@ export default function Taxonomies() {
 						__("Taxonomies", "atlas-content-modeler")
 					)}
 				</h2>
-				{editingTaxonomy ? (
-					<button
-						className="tertiary"
-						onClick={(event) => {
-							event.preventDefault();
-							cancelEditing();
-						}}
-					>
-						{__("Cancel Editing", "atlas-content-modeler")}
-					</button>
-				) : (
-					<button
-						className="tertiary"
-						onClick={() =>
-							history.push(atlasContentModeler.appPath)
-						}
-					>
-						{__("View Content Models", "atlas-content-modeler")}
-					</button>
-				)}
 			</section>
 			<section className="card-content">
 				<div className="row">

--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -2,31 +2,44 @@ import React from "react";
 import { __ } from "@wordpress/i18n";
 import { TaxonomiesDropdown } from "./TaxonomiesDropdown";
 
+const TaxonomiesTableHead = () => {
+	return (
+		<thead>
+			<tr>
+				<th>{__("Name", "atlas-content-modeler")}</th>
+				<th>{__("Slug", "atlas-content-modeler")}</th>
+				<th>{__("Models", "atlas-content-modeler")}</th>
+				<th className="action">
+					{__("Action", "atlas-content-modeler")}
+				</th>
+			</tr>
+		</thead>
+	);
+};
+
 const TaxonomiesTable = ({ taxonomies = {} }) => {
 	if (Object.values(taxonomies).length < 1) {
 		return (
-			<p>
-				{__(
-					"You currently have no taxonomies.",
-					"atlas-content-modeler"
-				)}
-			</p>
+			<table className="table table-striped">
+				<TaxonomiesTableHead />
+				<tbody>
+					<tr>
+						<td colSpan="4" className="text-center p-3">
+							{__(
+								"You currently have no taxonomies.",
+								"atlas-content-modeler"
+							)}
+						</td>
+					</tr>
+				</tbody>
+			</table>
 		);
 	}
 
 	return (
 		<>
 			<table className="table table-striped">
-				<thead>
-					<tr>
-						<th>{__("Name", "atlas-content-modeler")}</th>
-						<th>{__("Slug", "atlas-content-modeler")}</th>
-						<th>{__("Models", "atlas-content-modeler")}</th>
-						<th className="action">
-							{__("Action", "atlas-content-modeler")}
-						</th>
-					</tr>
-				</thead>
+				<TaxonomiesTableHead />
 				<tbody>
 					{Object.values(taxonomies).map((taxonomy) => {
 						return (

--- a/includes/settings/js/src/components/ViewContentModelsList.jsx
+++ b/includes/settings/js/src/components/ViewContentModelsList.jsx
@@ -11,28 +11,15 @@ function Header({ showButtons = true }) {
 		<section className="heading flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
 			<h2>Content Models</h2>
 			{showButtons && (
-				<>
-					<button
-						className="tertiary taxonomies"
-						onClick={() =>
-							history.push(
-								atlasContentModeler.appPath + "&view=taxonomies"
-							)
-						}
-					>
-						{__("View Taxonomies", "atlas-content-modeler")}
-					</button>
-					<button
-						onClick={() =>
-							history.push(
-								atlasContentModeler.appPath +
-									"&view=create-model"
-							)
-						}
-					>
-						{__("New Model", "atlas-content-modeler")}
-					</button>
-				</>
+				<button
+					onClick={() =>
+						history.push(
+							atlasContentModeler.appPath + "&view=create-model"
+						)
+					}
+				>
+					{__("New Model", "atlas-content-modeler")}
+				</button>
 			)}
 		</section>
 	);

--- a/includes/settings/settings-callbacks.php
+++ b/includes/settings/settings-callbacks.php
@@ -25,6 +25,24 @@ function register_admin_menu_page(): void {
 		__NAMESPACE__ . '\render_admin_menu_page',
 		$icon
 	);
+
+	add_submenu_page(
+		'atlas-content-modeler',
+		esc_html__( 'Models', 'atlas-content-modeler' ),
+		esc_html__( 'Models', 'atlas-content-modeler' ),
+		'manage_options',
+		'atlas-content-modeler',
+		'__return_null'
+	);
+
+	add_submenu_page(
+		'atlas-content-modeler',
+		esc_html__( 'Taxonomies', 'atlas-content-modeler' ),
+		esc_html__( 'Taxonomies', 'atlas-content-modeler' ),
+		'manage_options',
+		'atlas-content-modeler&view=taxonomies',
+		'__return_null'
+	);
 }
 
 /**

--- a/includes/settings/settings-callbacks.php
+++ b/includes/settings/settings-callbacks.php
@@ -40,7 +40,7 @@ function register_admin_menu_page(): void {
 		esc_html__( 'Taxonomies', 'atlas-content-modeler' ),
 		esc_html__( 'Taxonomies', 'atlas-content-modeler' ),
 		'manage_options',
-		'atlas-content-modeler&view=taxonomies',
+		'atlas-content-modeler&amp;view=taxonomies',
 		'__return_null'
 	);
 }

--- a/includes/settings/settings-callbacks.php
+++ b/includes/settings/settings-callbacks.php
@@ -55,7 +55,7 @@ add_filter( 'parent_file', __NAMESPACE__ . '\maybe_override_submenu_file' );
  * @link https://wordpress.stackexchange.com/a/131873
  * @link https://developer.wordpress.org/reference/hooks/parent_file/
  * @param string $parent_file The original parent file.
- * @return string The $parent_file unaltered. Only the submenu_file global is altered.
+ * @return string The $parent_file unaltered. Only the $submenu_file global is altered.
  */
 function maybe_override_submenu_file( $parent_file ) {
 	global $submenu_file;

--- a/includes/settings/settings-callbacks.php
+++ b/includes/settings/settings-callbacks.php
@@ -45,6 +45,31 @@ function register_admin_menu_page(): void {
 	);
 }
 
+add_filter( 'parent_file', __NAMESPACE__ . '\maybe_override_submenu_file' );
+/**
+ * Overrides the “submenu file” that determines which admin submenu item gains
+ * the `current` CSS class. Without this, WordPress incorrectly gives the
+ * “Model” subpage the `current` class when the “Taxonomies” subpage is active.
+ *
+ * @link https://github.com/WordPress/WordPress/blob/9937fea517ac165ad01f67c54216469e48c48ca7/wp-admin/menu-header.php#L223-L227
+ * @link https://wordpress.stackexchange.com/a/131873
+ * @link https://developer.wordpress.org/reference/hooks/parent_file/
+ * @param string $parent_file The original parent file.
+ * @return string The $parent_file unaltered. Only the submenu_file global is altered.
+ */
+function maybe_override_submenu_file( $parent_file ) {
+	global $submenu_file;
+
+	$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+	$view = filter_input( INPUT_GET, 'view', FILTER_SANITIZE_STRING );
+
+	if ( $page === 'atlas-content-modeler' && $view === 'taxonomies' ) {
+		$submenu_file = 'atlas-content-modeler&amp;view=taxonomies'; // phpcs:ignore -- global override needed to set current submenu page without JavaScript.
+	}
+
+	return $parent_file;
+}
+
 /**
  * Renders the wp-admin menu page.
  */

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -4,6 +4,7 @@ class CreateTaxonomyCest
 {
 	public function _before(\AcceptanceTester $I)
 	{
+		$I->resizeWindow(1024, 1024);
 		$I->maximizeWindow();
 		$I->loginAsAdmin();
 		$I->haveContentModel('goose', 'geese');

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -14,8 +14,8 @@ class CreateTaxonomyCest
 	{
 		$I->amOnWPEngineContentModelPage();
 		$I->wait(1);
-		$I->see('View Taxonomies', 'button.taxonomies');
-		$I->click('button.taxonomies');
+		$I->see('Taxonomies', '#toplevel_page_atlas-content-modeler .wp-submenu');
+		$I->click('Taxonomies', '#toplevel_page_atlas-content-modeler .wp-submenu');
 		$I->wait(1);
 		$I->see('Taxonomies', 'section.heading h2');
 	}

--- a/tests/acceptance/DeleteContentModelCest.php
+++ b/tests/acceptance/DeleteContentModelCest.php
@@ -51,7 +51,7 @@ class DeleteContentModelCest
 		$I->wait(1);
 
 		// Test that React state was updated without reloading the page.
-		$I->click('button.taxonomies');
+		$I->click('Taxonomies', '#toplevel_page_atlas-content-modeler .wp-submenu');
 		$I->see('moose', '.taxonomy-list');
 		$I->dontSee('goose', '.taxonomy-list');
 

--- a/tests/acceptance/DeleteContentModelCest.php
+++ b/tests/acceptance/DeleteContentModelCest.php
@@ -4,6 +4,7 @@ class DeleteContentModelCest
 {
 	public function _before(\AcceptanceTester $I)
 	{
+		$I->resizeWindow(1024, 1024);
 		$I->maximizeWindow();
 		$I->loginAsAdmin();
 		$I->wait(1);


### PR DESCRIPTION
Addresses design feedback for the Taxonomies feature:

- Adds “Models” and “Taxonomies” submenu items to the top-level Atlas Content Modeler admin sidebar menu item.
- Removes “View Content Models”, “View Taxonomies” and “Cancel Editing” buttons from the Taxonomies page. (View buttons duplicated the new sidebar links. The Cancel Editing button duplicated the Cancel button at the bottom of the taxonomies edit form.)
- Changes the empty taxonomies list state to use an empty table instead of a plain paragraph element.
- Includes a JS-free workaround so that the Taxonomies menu item correctly gains the `current` class when it is active. (See `maybe_override_submenu_file()`.)

https://wpengine.atlassian.net/browse/BH-1167

## Testing

Existing e2e tests have been adjusted to click the sidebar menu items instead of the (now removed) buttons.

To test manually, visit the Taxonomies page from the admin sidebar and add/remove taxonomies to see the full and empty table states.

## Screenshots

| Before | After   |
|---|---|
| <img width="1392" alt="Screenshot 2021-08-11 at 20 39 38" src="https://user-images.githubusercontent.com/647669/129085781-11a90dba-f840-4669-8c74-fc240a9f3bb1.png"> | <img width="1387" alt="Screenshot 2021-08-11 at 20 38 56" src="https://user-images.githubusercontent.com/647669/129085838-3c836b8e-6a34-4e51-9905-e7533ff43215.png"> |


## Documentation Changes

n/a

## Dependant PRs

n/a