### PR TITLE
[NO JIRA] build: Use alias to map `@wordpress/i18n` dependency to WP global. #182

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@babel/plugin-syntax-jsx": "^7.12.13",
         "@wordpress/api-fetch": "^3.21.5",
-        "@wordpress/i18n": "^3.19.1",
         "bootstrap": "^5.0.1",
         "react": "^17.0.1",
         "react-beautiful-dnd": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@babel/plugin-syntax-jsx": "^7.12.13",
     "@wordpress/api-fetch": "^3.21.5",
-    "@wordpress/i18n": "^3.19.1",
     "bootstrap": "^5.0.1",
     "react": "^17.0.1",
     "react-beautiful-dnd": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
       "global": "wp.apiFetch"
     },
     "acm-icons": {
-      "fileName": "./includes/components/icons",
+      "fileName": "./includes/components/icons"
+    },
     "@wordpress/i18n": {
       "global": "wp.i18n"
     }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
       "global": "wp.apiFetch"
     },
     "acm-icons": {
-      "fileName": "./includes/components/icons"
+      "fileName": "./includes/components/icons",
+    "@wordpress/i18n": {
+      "global": "wp.i18n"
     }
   }
 }

--- a/tests/integration/publisher/test-script-dependencies.php
+++ b/tests/integration/publisher/test-script-dependencies.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for script dependencies.
+ *
+ * @package AtlasContentModeler
+ */
+
+use WPE\AtlasContentModeler\FormEditingExperience;
+use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
+
+/**
+ * Class TestPublisherScriptDependencies
+ */
+class TestPublisherScriptDependencies extends WP_UnitTestCase {
+
+	private $models = [
+		'recipe' => [
+			'singular' => 'Recipe',
+			'plural'   => 'Recipes',
+			'slug'     => 'recipe',
+		],
+	];
+
+	public function setUp() {
+		wp_set_current_user( 1 );
+
+		parent::setUp();
+
+		update_registered_content_types( $this->models );
+
+		$pubex = new FormEditingExperience();
+		$pubex->bootstrap();
+
+		do_action( 'init' );
+
+		set_current_screen( 'post.php' );
+		global $current_screen;
+		$current_screen->post_type = 'recipe';
+		do_action( 'admin_enqueue_scripts', 'post.php' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		wp_set_current_user( null );
+		delete_option( 'atlas_content_modeler_post_types' );
+	}
+
+	public function test_wp_i18n_script_is_enqueued_on_the_publisher_view(): void {
+		self::assertTrue( wp_script_is( 'wp-i18n', 'enqueued' ) );
+	}
+
+	public function test_wp_api_fetch_script_is_enqueued_on_the_publisher_view(): void {
+		self::assertTrue( wp_script_is( 'wp-api-fetch', 'enqueued' ) );
+	}
+
+	public function test_acm_feedback_banner_script_is_enqueued_on_the_publisher_view(): void {
+		self::assertTrue( wp_script_is( 'atlas-content-modeler-feedback-banner', 'enqueued' ) );
+	}
+
+	public function test_acm_pubex_script_is_enqueued(): void {
+		self::assertTrue( wp_script_is( 'atlas-content-modeler-form-editing-experience', 'enqueued' ) );
+	}
+}


### PR DESCRIPTION
## Description
This instructs Parcel to map imports to the `wp` global available at runtime when the `wp-i18n` scripts is enqueued.
See: https://v2.parceljs.org/features/module-resolution#aliases

Closes #182 


Build file size differences, using `npm run build`:
`includes/publisher/dist/index.js`
before - 54k
after - 40k

`includes/developer/dist/index.js`
before - 332k
after - 320k
