### PR TITLE
[BH-1136] One to many relationship

### DIFF
--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -95,10 +95,17 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 			 */
 			function getRelatedTitles(field) {
 				const { models } = atlasContentModelerFormEditingExperience;
+				let values = field.value.split(",");
+				let query = "";
+
+				values.forEach((relationship) => {
+					let lead = query === "" ? "?" : "&";
+					query = query + `${lead}include[]=${relationship}`;
+				});
 
 				const endpoint = `/wp/v2/${
 					models[field.reference].wp_rest_base
-				}/?include[]=${field.value}`;
+				}/${query}`;
 
 				const params = {
 					path: endpoint,
@@ -129,11 +136,14 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 			 * Caches those entries in the pagedEntries object, keyed by page.
 			 */
 			useEffect(() => {
-				getRelatedTitles(field).then((entries) => {
-					setRelatedContent(() => {
-						return entries;
+				if (field.value !== "") {
+					// let's not make the call if we don't have to.
+					getRelatedTitles(field).then((entries) => {
+						setRelatedContent(() => {
+							return entries;
+						});
 					});
-				});
+				}
 			}, [field.value]);
 
 			function relationshipClickHandler(

--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -172,7 +172,6 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 										<section className="card-content">
 											<ul className="model-list">
 												<li>
-													{console.log(field.value)}
 													<div className="relation-model-card flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
 														<span className="flex-item mb-3 mb-sm-0 pr-1">
 															<p className="label">

--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -133,8 +133,7 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 			}
 
 			/**
-			 * Gets entries whenever the state of 'page' changes.
-			 * Caches those entries in the pagedEntries object, keyed by page.
+			 * Gets post information to display to the user outside of the modal.
 			 */
 			useEffect(() => {
 				if (field.value !== "") {
@@ -170,7 +169,10 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 													<div className="relation-model-card flex-wrap d-flex flex-column d-sm-flex flex-sm-row">
 														<span className="flex-item mb-3 mb-sm-0 pr-1">
 															<p className="label">
-																Linked Reference
+																{__(
+																	"Linked Reference",
+																	"atlas-content-modeler"
+																)}
 															</p>
 															<p className="value">
 																<strong>

--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -95,18 +95,13 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 			 */
 			function getRelatedTitles(field) {
 				const { models } = atlasContentModelerFormEditingExperience;
-				let values = field.value.split(",");
-				let query = "";
-
-				// Allow for 1:many calls
-				values.forEach((relationship) => {
-					let lead = query === "" ? "?" : "&";
-					query = query + `${lead}include[]=${relationship}`;
+				let query = new URLSearchParams({
+					include: field.value.split(","),
 				});
 
 				const endpoint = `/wp/v2/${
 					models[field.reference].wp_rest_base
-				}/${query}`;
+				}/?=${query}`;
 
 				const params = {
 					path: endpoint,

--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -98,6 +98,7 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 				let values = field.value.split(",");
 				let query = "";
 
+				// Allow for 1:many calls
 				values.forEach((relationship) => {
 					let lead = query === "" ? "?" : "&";
 					query = query + `${lead}include[]=${relationship}`;
@@ -146,13 +147,7 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 				}
 			}, [field.value]);
 
-			function relationshipClickHandler(
-				e,
-				field,
-				modelSlug,
-				errors,
-				validate
-			) {
+			function relationshipClickHandler() {
 				setEditSingleRelModalIsOpen(true);
 			}
 
@@ -165,7 +160,7 @@ function fieldMarkup(field, modelSlug, errors, validate) {
 					</label>
 					{field.value &&
 						relatedContent?.map((entry) => {
-							const { id, title } = entry;
+							const { title } = entry;
 							return (
 								<>
 									<div className="app-card">

--- a/includes/publisher/js/src/components/RelationshipModal.jsx
+++ b/includes/publisher/js/src/components/RelationshipModal.jsx
@@ -41,6 +41,11 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 		},
 	};
 
+	/**
+	 * Handles the selection of checkbox or radio button.
+	 *
+	 * @param {object} event
+	 */
 	function handleSelect(event) {
 		const { value, checked, type } = event.target;
 		let savedValues = [];

--- a/includes/publisher/js/src/components/RelationshipModal.jsx
+++ b/includes/publisher/js/src/components/RelationshipModal.jsx
@@ -43,19 +43,18 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 
 	function handleSelect(event) {
 		const { value, checked, type } = event.target;
+		let savedValues = [];
 		if (type === "checkbox") {
 			if (!checked) {
-				console.log("removing");
-				setSelectedEntry(
-					selectedEntry.splice(selectedEntry.indexOf(value), 1)
-				);
+				selectedEntry.splice(selectedEntry.indexOf(value), 1);
+				savedValues = selectedEntry;
 			} else {
-				console.log("adding");
-				setSelectedEntry([...selectedEntry, value]);
+				savedValues = [...new Set([...selectedEntry, value])];
 			}
 		} else {
-			setSelectedEntry([value]);
+			savedValues = [value];
 		}
+		setSelectedEntry(savedValues);
 	}
 
 	async function getEntries(page) {
@@ -170,6 +169,9 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 												id={`entry-${id}`}
 												value={id}
 												aria-label={selectEntryLabel}
+												defaultChecked={selectedEntry.includes(
+													id.toString()
+												)}
 												onChange={handleSelect}
 											/>
 										</td>

--- a/includes/publisher/js/src/components/RelationshipModal.jsx
+++ b/includes/publisher/js/src/components/RelationshipModal.jsx
@@ -19,7 +19,7 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 	const [page, setPage] = useState(1);
 	const [pagedEntries, setPagedEntries] = useState({});
 	const [totalEntries, setTotalEntries] = useState(0);
-	const [selectedEntry, setSelectedEntry] = useState(); // TODO: set initial state value from stored field value.
+	const [selectedEntry, setSelectedEntry] = useState([]); // TODO: set initial state value from stored field value.
 	const entriesPerPage = 5;
 	const totalPages = Math.ceil(totalEntries / entriesPerPage);
 
@@ -39,6 +39,21 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 			boxSizing: "border-box",
 		},
 	};
+
+	function handleSelect(event) {
+		const { value, checked, type } = event.target;
+		if (type === "checkbox") {
+			if (!checked) {
+				setSelectedEntry(
+					selectedEntry.splice(selectedEntry.indexOf(value), 1)
+				);
+			} else {
+				setSelectedEntry([...selectedEntry, value]);
+			}
+		} else {
+			setSelectedEntry([value]);
+		}
+	}
 
 	async function getEntries(page) {
 		const { models } = atlasContentModelerFormEditingExperience;
@@ -142,18 +157,17 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 									<tr key={id}>
 										<td>
 											<input
-												type="radio"
+												type={
+													field.cardinality ==
+													"one-to-many"
+														? "checkbox"
+														: "radio"
+												}
 												name="selected-entry"
 												id={`entry-${id}`}
 												value={id}
 												aria-label={selectEntryLabel}
-												checked={selectedEntry === id}
-												onChange={() => {
-													setSelectedEntryTitle(
-														title
-													);
-													setSelectedEntry(id);
-												}}
+												onChange={handleSelect}
 											/>
 										</td>
 										<td>
@@ -249,7 +263,6 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 				className="tertiary button button-large"
 				onClick={(event) => {
 					event.preventDefault();
-					setSelectedEntry(undefined);
 					setIsOpen(false);
 				}}
 			>

--- a/includes/publisher/js/src/components/RelationshipModal.jsx
+++ b/includes/publisher/js/src/components/RelationshipModal.jsx
@@ -20,8 +20,7 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 	const [pagedEntries, setPagedEntries] = useState({});
 	const [totalEntries, setTotalEntries] = useState(0);
 	const [selectedEntry, setSelectedEntry] = useState(); // TODO: set initial state value from stored field value.
-	const [selectedEntryTitle, setSelectedEntryTitle] = useState(); // TODO: set initial state value from stored field value.
-	const entriesPerPage = 5; // TODO: change to 5. 1 is for testing pagination only.
+	const entriesPerPage = 5;
 	const totalPages = Math.ceil(totalEntries / entriesPerPage);
 
 	const customStyles = {

--- a/includes/publisher/js/src/components/RelationshipModal.jsx
+++ b/includes/publisher/js/src/components/RelationshipModal.jsx
@@ -45,16 +45,17 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 		const { value, checked, type } = event.target;
 		if (type === "checkbox") {
 			if (!checked) {
+				console.log("removing");
 				setSelectedEntry(
 					selectedEntry.splice(selectedEntry.indexOf(value), 1)
 				);
 			} else {
+				console.log("adding");
 				setSelectedEntry([...selectedEntry, value]);
 			}
 		} else {
 			setSelectedEntry([value]);
 		}
-		console.log(selectedEntry);
 	}
 
 	async function getEntries(page) {
@@ -169,9 +170,6 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 												id={`entry-${id}`}
 												value={id}
 												aria-label={selectEntryLabel}
-												defaultChecked={selectedEntry.includes(
-													id.toString()
-												)}
 												onChange={handleSelect}
 											/>
 										</td>
@@ -302,7 +300,6 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 					className="tertiary mx-0"
 					onClick={(event) => {
 						event.preventDefault();
-						setSelectedEntry(undefined);
 						setIsOpen(false);
 					}}
 				>

--- a/includes/publisher/js/src/components/RelationshipModal.jsx
+++ b/includes/publisher/js/src/components/RelationshipModal.jsx
@@ -294,8 +294,6 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 					className="action-button mx-3"
 					onClick={(event) => {
 						event.preventDefault();
-						// TODO: Update the reference field's value here.
-						console.log(`Saving field ${selectedEntry}.`);
 						field.value = `${selectedEntry}`;
 						setIsOpen(false);
 					}}

--- a/includes/publisher/js/src/components/RelationshipModal.jsx
+++ b/includes/publisher/js/src/components/RelationshipModal.jsx
@@ -19,7 +19,7 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 	const [page, setPage] = useState(1);
 	const [pagedEntries, setPagedEntries] = useState({});
 	const [totalEntries, setTotalEntries] = useState(0);
-	const [selectedEntry, setSelectedEntry] = useState([]); // TODO: set initial state value from stored field value.
+	const [selectedEntry, setSelectedEntry] = useState(field.value.split(",")); // TODO: set initial state value from stored field value.
 	const entriesPerPage = 5;
 	const totalPages = Math.ceil(totalEntries / entriesPerPage);
 
@@ -53,6 +53,7 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 		} else {
 			setSelectedEntry([value]);
 		}
+		console.log(selectedEntry);
 	}
 
 	async function getEntries(page) {
@@ -167,6 +168,9 @@ export default function RelationshipModal({ field, isOpen, setIsOpen }) {
 												id={`entry-${id}`}
 												value={id}
 												aria-label={selectEntryLabel}
+												defaultChecked={selectedEntry.includes(
+													id.toString()
+												)}
 												onChange={handleSelect}
 											/>
 										</td>

--- a/includes/publisher/lib/field-functions.php
+++ b/includes/publisher/lib/field-functions.php
@@ -87,6 +87,7 @@ function sanitize_field( string $type, $value ) {
 		case 'richtext':
 			return wp_kses_post( $value );
 		case 'relationship':
+			// Sanitizes each value as an integer and saves as a comma-separated string.
 			$relationships = explode( ',', $value['relationshipEntryId'] );
 			foreach ( $relationships as $index => $id ) {
 				$relationships[ $index ] = filter_var( $id, FILTER_SANITIZE_NUMBER_INT );

--- a/includes/publisher/lib/field-functions.php
+++ b/includes/publisher/lib/field-functions.php
@@ -87,8 +87,11 @@ function sanitize_field( string $type, $value ) {
 		case 'richtext':
 			return wp_kses_post( $value );
 		case 'relationship':
-			// @TODO handle multis differently.
-			return filter_var( $value['relationshipEntryId'], FILTER_SANITIZE_NUMBER_INT );
+			$relationships = explode( ',', $value['relationshipEntryId'] );
+			foreach ( $relationships as $index => $id ) {
+				$relationships[ $index ] = filter_var( $id, FILTER_SANITIZE_NUMBER_INT );
+			}
+			return implode( ',', $relationships );
 		case 'number':
 			return filter_var( $value, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION );
 		case 'date':


### PR DESCRIPTION
*Note: This PR is against #222. Due to the nature of the changes I have not added independent tests nor have I solved for existing issues in that branch, yet.*

## Description

Expands the existing 1:1 relationship UI to be able to handle 1:many relationships.

This tries to maintain as much of the 1:1 code as possible and simply assumes that all entries could be an array of values. Values are saved as a comma-delimited string to the database until post-to-posts integration is complete. This maintains all existing functionality of the 1:1 relationships

https://wpengine.atlassian.net/browse/BH-1136

## Testing

At the moment, no additional tests have been added. I will work with Anthony for acceptable tests on the 1:1 relationship which then could be extended to this. Backend testing feels inappropriate at this juncture until we better know how the integration of 10up's library will affect data storage and other aspects.

## Screenshots

<img width="1552" alt="Screen Shot 2021-08-17 at 2 37 24 PM" src="https://user-images.githubusercontent.com/394675/129782589-849c9f98-fab8-439a-a129-0a514852e997.png">

<img width="1552" alt="Screen Shot 2021-08-17 at 2 37 38 PM" src="https://user-images.githubusercontent.com/394675/129782597-ef03b220-2ff7-4080-b46f-7aa95c40721d.png">

## Documentation Changes

<!--
List corresponding changes to the documentation and updated wiki pages.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. And in order to have these dependencies listed as part of the checks section, use the following syntax:

Depends on #1234
-->
