### PR TITLE
Improve modal z-index and scroll behavior

### DIFF
--- a/includes/settings/scss/_model-list.scss
+++ b/includes/settings/scss/_model-list.scss
@@ -136,11 +136,13 @@
 		padding-bottom: 17px;
 		padding-right: 17px;
 		box-sizing: content-box;
+		z-index: 99999; /* renders modal above WP Admin bar */
 	}
 
 	.ReactModal__Content--after-open {
 		width: 100%;
 		max-width: 600px;
+		max-height: 100%;
 
 		input,
 		textarea,


### PR DESCRIPTION
## Description

Closes #232

This PR only contains 2 lines of new SCSS.

The first line ensures that the modal overlay is rendered above the WP admin bar, footer, and menu (`99999` happens to be the z-index of the WP admin bar, so we have to match or exceed that value) :

```css
.ReactModal__Overlay--after-open {
	...
	z-index: 99999;
}
```

The second line ensures that the contents of the modal window can be scrolled if the viewport is too short.
```css
.ReactModal__Content--after-open {
	...
	max-height: 100%;
}
```

## Testing

Manually tested in Chrome, Firefox, and Safari with the following steps:

1. Create and save a new model.
2. Select the ellipsis button and then select "Edit" from the dropdown menu.
3. Resize the browser to `1300x600`
4. Confirm that the footer no longer overlaps the modal.
5. Confirm that the entire contents of the modal can be scrolled into view.

## Screenshots

### Before

![atlas-content-modeler test_wp-admin_admin php_page=atlas-content-modeler (3)](https://user-images.githubusercontent.com/1938671/130303794-c9ecb618-e692-4e2e-8284-6d6824429182.png)

1. WP footer was overlapping modal.
2. Save/Cancel buttons were hidden outside of the viewport with no ability to scroll.
3. The top of the modal was also getting cropped by the viewport, which means the modal title and possibly the first row of fields could be outside of the viewport with no ability to scroll.

### After

![CleanShot 2021-08-20 at 17 54 19](https://user-images.githubusercontent.com/1938671/130298972-3e9d708b-e392-4b42-ac1f-522457b5cc14.gif)

WP footer no longer overlaps the modal and the entire contents of the modal can be scrolled if the viewport is too small.