### PR TITLE
[BH-1191] Wire posts to posts lib

### DIFF
--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -301,6 +301,8 @@ final class FormEditingExperience {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$posted_values = $_POST['atlas-content-modeler'][ $post->post_type ];
 
+		$saved_replationships = array();
+
 		// Sanitize field values.
 		foreach ( $posted_values as $field_id => &$field_value ) {
 			$field_type = get_field_type_from_slug(
@@ -313,6 +315,7 @@ final class FormEditingExperience {
 			if ( 'relationship' === $field_type ) {
 				unset( $posted_values[ $field_id ] );
 				$this->save_relationship_field( $field_id, $post, $field_value );
+				$saved_replationships[] = $field_id;
 			}
 		}
 
@@ -332,7 +335,9 @@ final class FormEditingExperience {
 				);
 
 				if ( 'relationship' === $field_type ) {
-					$this->save_relationship_field( $slug, $post, '' );
+					if ( ! in_array( $slug, $saved_replationships, true ) ) {
+						$this->save_relationship_field( $slug, $post, '' );
+					}
 				} else {
 					$existing = get_post_meta( $post_id, sanitize_text_field( $slug ), true );
 					if ( empty( $existing ) ) {

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -301,7 +301,7 @@ final class FormEditingExperience {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$posted_values = $_POST['atlas-content-modeler'][ $post->post_type ];
 
-		$saved_replationships = array();
+		$saved_relationships = array();
 
 		// Sanitize field values.
 		foreach ( $posted_values as $field_id => &$field_value ) {
@@ -315,7 +315,7 @@ final class FormEditingExperience {
 			if ( 'relationship' === $field_type ) {
 				unset( $posted_values[ $field_id ] );
 				$this->save_relationship_field( $field_id, $post, $field_value );
-				$saved_replationships[] = $field_id;
+				$saved_relationships[] = $field_id;
 			}
 		}
 
@@ -335,7 +335,11 @@ final class FormEditingExperience {
 				);
 
 				if ( 'relationship' === $field_type ) {
-					if ( ! in_array( $slug, $saved_replationships, true ) ) {
+					if ( ! in_array(
+						$slug,
+						$saved_relationships,
+						true
+					) ) {
 						$this->save_relationship_field( $slug, $post, '' );
 					}
 				} else {

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -385,10 +385,15 @@ final class FormEditingExperience {
 			$this->models[ $post->post_type ]['fields'] ?? []
 		);
 
-		$registry     = \WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->get_registry();
-		$relationship = $registry->get_post_to_post_relationship( $post->post_type, $field['reference'], $field_id );
+		$registry      = \WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->get_registry();
+		$relationship  = $registry->get_post_to_post_relationship( $post->post_type, $field['reference'], $field_id );
+		$related_posts = array();
+
 		if ( $relationship ) {
-			$related_posts = explode( ',', $field_value );
+			if ( '' !== $field_value ) {
+				$related_posts = explode( ',', $field_value );
+			}
+
 			$relationship->replace_relationships( $post->ID, $related_posts );
 		}
 	}

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -298,11 +298,16 @@ final class FormEditingExperience {
 
 		// Sanitize field values.
 		foreach ( $posted_values as $field_id => &$field_value ) {
-			$field_type  = get_field_type_from_slug(
+			$field_type = get_field_type_from_slug(
 				$field_id,
 				$this->models[ $post->post_type ]['fields'] ?? []
 			);
+
 			$field_value = sanitize_field( $field_type, wp_unslash( $field_value ) );
+
+			if ( 'relationship' === $field_type ) {
+				unset( $posted_values[ $field_id ] );
+			}
 		}
 
 		// Delete any meta values missing from the submitted data.

--- a/includes/publisher/lib/field-functions.php
+++ b/includes/publisher/lib/field-functions.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WPE\AtlasContentModeler;
 
+use phpDocumentor\Reflection\Types\Boolean;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -71,6 +73,28 @@ function get_field_type_from_slug( string $slug, array $fields ): string {
 
 	return $field_type;
 }
+
+/**
+ * Gets the field from the field slug.
+ *
+ * @param string $slug The slug of the field to look for.
+ * @param array  $fields Fields to search for the `$slug`.
+ *
+ * @return array The field array of the associated slugs or false if not found.
+ */
+function get_field_from_slug( string $slug, array $fields ): ?array {
+	$found = false;
+
+	foreach ( $fields as $field ) {
+		if ( $field['slug'] === $slug ) {
+			$found = $field;
+			break;
+		}
+	}
+
+	return $found;
+}
+
 
 /**
  * Sanitizes field data based on the field type.

--- a/includes/publisher/lib/field-functions.php
+++ b/includes/publisher/lib/field-functions.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace WPE\AtlasContentModeler;
 
-use phpDocumentor\Reflection\Types\Boolean;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }


### PR DESCRIPTION
## Description

This wires the acm content library to the plugin to allow for saving and editing relationships in a much more robust platform.

https://wpengine.atlassian.net/browse/BH-1191
