### PR TITLE
chore: ensure return value is always an array

### DIFF
--- a/includes/content-registration/register-taxonomies.php
+++ b/includes/content-registration/register-taxonomies.php
@@ -134,7 +134,7 @@ function get_props( array $args ): array {
  * @since 0.6.0
  */
 function get_acm_taxonomies(): array {
-	return get_option( 'atlas_content_modeler_taxonomies', array() );
+	return (array) get_option( 'atlas_content_modeler_taxonomies', array() );
 }
 
 /**


### PR DESCRIPTION
## Description
`get_acm_taxonomies()` returns the value from `get_option()`, which can be filtered by other code. Casting the return value to array ensures this function doesn't fatal error due to an invalid return type caused by other code.

## Testing
Without this change, the following code would result in a PHP fatal error:
```
add_filter( 'option_atlas_content_modeler_taxonomies', function() {
	return 'string';
} );
```
