### PR TITLE
[NOJIRA] Initialise Analytics

### DIFF
--- a/includes/content-registration/register-taxonomies.php
+++ b/includes/content-registration/register-taxonomies.php
@@ -134,7 +134,7 @@ function get_props( array $args ): array {
  * @since 0.6.0
  */
 function get_acm_taxonomies(): array {
-	return get_option( 'atlas_content_modeler_taxonomies', array() );
+	return (array) get_option( 'atlas_content_modeler_taxonomies', array() );
 }
 
 /**

--- a/includes/publisher/js/src/App.jsx
+++ b/includes/publisher/js/src/App.jsx
@@ -1,13 +1,12 @@
 import React, { useEffect } from "react";
 import Fields from "./components/Fields";
 import { __ } from "@wordpress/i18n";
-import { initializeAnalytics, sendPageView } from "acm-analytics";
+import { sendPageView } from "acm-analytics";
 
 export default function App({ model, mode }) {
 	const isEditMode = mode === "edit";
 
 	useEffect(() => {
-		initializeAnalytics();
 		sendPageView("ACM Publisher Entry");
 	}, []);
 

--- a/includes/publisher/js/src/App.jsx
+++ b/includes/publisher/js/src/App.jsx
@@ -1,20 +1,15 @@
-import React from "react";
-import ReactGA from "react-ga4";
+import React, { useEffect } from "react";
 import Fields from "./components/Fields";
-import { sprintf, __ } from "@wordpress/i18n";
-
-const GA_ID = "G-S056CLLZ34";
-
-/**
- * React-GA4 Library and usage
- * {@link https://github.com/PriceRunner/react-ga4#readme}
- */
-ReactGA.initialize(GA_ID, { gtagOptions: { anonymize_ip: true } });
+import { __ } from "@wordpress/i18n";
+import { initializeAnalytics, sendPageView } from "acm-analytics";
 
 export default function App({ model, mode }) {
 	const isEditMode = mode === "edit";
 
-	ReactGA.send({ hitType: "pageview", page: "ACM Publisher Entry" });
+	useEffect(() => {
+		initializeAnalytics();
+		sendPageView("ACM Publisher Entry");
+	}, []);
 
 	/**
 	 * Navigate to the post new php file for current slug

--- a/includes/settings/js/src/App.jsx
+++ b/includes/settings/js/src/App.jsx
@@ -9,13 +9,8 @@ import EditContentModel from "./components/EditContentModel";
 import Taxonomies from "./components/Taxonomies";
 import { useLocationSearch } from "./utils";
 import { ModelsContextProvider } from "./ModelsContext";
-import { initializeAnalytics } from "acm-analytics";
 
 export default function App() {
-	useEffect(() => {
-		initializeAnalytics();
-	}, []);
-
 	return (
 		<div className="app atlas-content-modeler">
 			<ModelsContextProvider>

--- a/includes/settings/js/src/App.jsx
+++ b/includes/settings/js/src/App.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import ReactGA from "react-ga4";
+import React, { useEffect } from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { ToastContainer, Flip } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -10,20 +9,13 @@ import EditContentModel from "./components/EditContentModel";
 import Taxonomies from "./components/Taxonomies";
 import { useLocationSearch } from "./utils";
 import { ModelsContextProvider } from "./ModelsContext";
-
-const GA_ID = "G-S056CLLZ34";
-
-/**
- * React-GA4 Library and usage
- * {@link https://github.com/PriceRunner/react-ga4#readme}
- */
-ReactGA.initialize(GA_ID, { gtagOptions: { anonymize_ip: true } });
+import { initializeAnalytics } from "acm-analytics";
 
 export default function App() {
-	ReactGA.send({
-		hitType: "pageview",
-		page: "ACM Models Home",
-	});
+	useEffect(() => {
+		initializeAnalytics();
+	}, []);
+
 	return (
 		<div className="app atlas-content-modeler">
 			<ModelsContextProvider>

--- a/includes/settings/js/src/components/ViewContentModelsList.jsx
+++ b/includes/settings/js/src/components/ViewContentModelsList.jsx
@@ -1,7 +1,8 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { ModelsContext } from "../ModelsContext";
 import { sanitizeFields } from "../queries";
+import { sendPageView } from "acm-analytics";
 import { ContentModelDropdown } from "./ContentModelDropdown";
 import { sprintf, __ } from "@wordpress/i18n";
 
@@ -29,6 +30,10 @@ export default function ViewContentModelsList() {
 	const { models } = useContext(ModelsContext);
 	const hasModels = Object.keys(models || {}).length > 0;
 	const history = useHistory();
+
+	useEffect(() => {
+		sendPageView("ACM Models Home");
+	}, []);
 
 	return (
 		<div className="app-card">

--- a/includes/shared-assets/js/analytics.js
+++ b/includes/shared-assets/js/analytics.js
@@ -7,17 +7,21 @@ import ReactGA from "react-ga4";
 
 const ANALYTICS_ID = "G-S056CLLZ34";
 
-export const initializeAnalytics = () => {
-	ReactGA.initialize(ANALYTICS_ID, {
-		gtagOptions: { anonymize_ip: true },
-	});
+const maybeInitializeAnalytics = () => {
+	if (!ReactGA?.isInitialized) {
+		ReactGA.initialize(ANALYTICS_ID, {
+			gtagOptions: { anonymize_ip: true },
+		});
+	}
 };
 
 export const sendEvent = (data) => {
+	maybeInitializeAnalytics();
 	return ReactGA.event(data);
 };
 
 export const sendPageView = (page = "") => {
+	maybeInitializeAnalytics();
 	return ReactGA.send({
 		hitType: "pageview",
 		page,

--- a/includes/shared-assets/js/analytics.js
+++ b/includes/shared-assets/js/analytics.js
@@ -1,0 +1,25 @@
+/**
+ * Analytics helpers.
+ *
+ * {@link https://github.com/PriceRunner/react-ga4#readme}
+ */
+import ReactGA from "react-ga4";
+
+const ANALYTICS_ID = "G-S056CLLZ34";
+
+export const initializeAnalytics = () => {
+	ReactGA.initialize(ANALYTICS_ID, {
+		gtagOptions: { anonymize_ip: true },
+	});
+};
+
+export const sendEvent = (data) => {
+	return ReactGA.event(data);
+};
+
+export const sendPageView = (page = "") => {
+	return ReactGA.send({
+		hitType: "pageview",
+		page,
+	});
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
 		atlasContentModeler: {},
 	},
 	moduleNameMapper: {
+		"acm-analytics": "<rootDir>/includes/shared-assets/js/analytics.js",
 		"^.+\\.(css|less|scss)$": "jest-css-modules-transform",
 	},
 };

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     },
     "@wordpress/api-fetch": {
       "global": "wp.apiFetch"
+    },
+    "acm-analytics": {
+      "fileName": "./includes/shared-assets/js/analytics.js"
     }
   }
 }


### PR DESCRIPTION
## Description
An alternative to #249 for consideration.

Context in https://github.com/wpengine/atlas-content-modeler/pull/249#issuecomment-906309264.

## Testing

- Install the [Google Analytics Debugger extension for Chrome](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna/related?hl=en).
- Disable adblockers for your test site.
- Visit the WP admin and enable the Google Analytics Debugger (click its icon in your browser toolbar. “Tag Assistant Not Connected” is expected).
- Open the console and visit the model list at `/wp-admin/admin.php?page=atlas-content-modeler`. You should see a config and a pageview event in the console. Browse to a model and back to the model index again (by clicking “Content Models” in the title breadcrumb, without refreshing the page). You should see a pageview event and not a new config event.
- Leave the console open and visit a Publisher entry page. You should see a config and a pageview event in the console.