### PR TITLE
[BH-1222]: Add relationship modal empty state and “create entry” link

### DIFF
--- a/includes/components/icons/ExternalLink.jsx
+++ b/includes/components/icons/ExternalLink.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+const ExternalLinkIcon = () => {
+	return (
+		<svg
+			width="16"
+			height="16"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			className="icon-external-link"
+		>
+			<path
+				d="M3 0a3 3 0 00-3 3v5a1 1 0 102 0V3a1 1 0 011-1h10a1 1 0 011 1v10a1 1 0 01-1 1H5.828c-.89 0-1.337-1.077-.707-1.707L9 8.414V10a1 1 0 102 0V6v-.005a.995.995 0 00-.29-.699l-.006-.006A.996.996 0 0010 5H6a1 1 0 000 2h1.586l-3.879 3.879C1.817 12.769 3.156 16 5.828 16H13a3 3 0 003-3V3a3 3 0 00-3-3H3z"
+				fill="#002838"
+			/>
+		</svg>
+	);
+};
+
+export default ExternalLinkIcon;

--- a/includes/components/icons/index.js
+++ b/includes/components/icons/index.js
@@ -5,6 +5,7 @@ import CloseIcon from "./CloseIcon";
 import DateIcon from "./DateIcon";
 import DownArrow from "./DownArrow";
 import ErrorIcon from "./ErrorIcon";
+import ExternalLinkIcon from "./ExternalLink";
 import LinkIcon from "./LinkIcon";
 import MediaIcon from "./MediaIcon";
 import MultipleChoiceIcon from "./MultipleChoiceIcon";
@@ -32,6 +33,8 @@ export default function Icon({ type, size }) {
 			return <DownArrow />;
 		case "error":
 			return <ErrorIcon size={size} />;
+		case "external-link":
+			return <ExternalLinkIcon />;
 		case "link":
 			return <LinkIcon />;
 		case "media":

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -187,6 +187,7 @@ final class FormEditingExperience {
 				'models'           => $models,
 				'postType'         => $this->current_screen_post_type,
 				'allowedMimeTypes' => get_allowed_mime_types(),
+				'adminUrl'         => admin_url(),
 			]
 		);
 

--- a/includes/publisher/js/src/components/relationship/modal/Pagination.jsx
+++ b/includes/publisher/js/src/components/relationship/modal/Pagination.jsx
@@ -59,15 +59,20 @@ export default function Pagination({ totalPages, page, setPage }) {
 					</button>
 				</div>
 			)}
-			<div className="mx-3">
-				<span className="align-middle" style={{ lineHeight: "55px" }}>
-					{sprintf(
-						__("Page %d of %d", "atlas-content-modeler"),
-						page,
-						totalPages
-					)}
-				</span>
-			</div>
+			{totalPages > 0 && (
+				<div className="mx-3">
+					<span
+						className="align-middle"
+						style={{ lineHeight: "55px" }}
+					>
+						{sprintf(
+							__("Page %d of %d", "atlas-content-modeler"),
+							page,
+							totalPages
+						)}
+					</span>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/includes/publisher/js/src/components/relationship/modal/Table.jsx
+++ b/includes/publisher/js/src/components/relationship/modal/Table.jsx
@@ -45,7 +45,7 @@ export default function Table({
 								>
 									{sprintf(
 										__(
-											// translators: the singular of the model, or "entry" if no singular name known.
+											// translators: the singular name of the model, or "entry" if no singular name known.
 											"Create a new %s.",
 											"atlas-content-modeler"
 										),

--- a/includes/publisher/js/src/components/relationship/modal/Table.jsx
+++ b/includes/publisher/js/src/components/relationship/modal/Table.jsx
@@ -5,11 +5,15 @@ const { date } = wp;
 
 export default function Table({
 	pagedEntries,
+	setPagedEntries,
 	page,
 	field,
 	chosenEntries,
 	handleSelect,
+	setIsOpen,
 }) {
+	const { models, adminUrl } = atlasContentModelerFormEditingExperience;
+
 	return (
 		<table className="table table-striped mt-2">
 			<thead>
@@ -20,6 +24,39 @@ export default function Table({
 				</tr>
 			</thead>
 			<tbody>
+				{pagedEntries[page]?.length === 0 && (
+					<tr className="empty">
+						<td>&nbsp;</td>
+						<td colSpan="2">
+							<span>
+								{__(
+									"No published entries.",
+									"atlas-content-modeler"
+								)}{" "}
+								<a
+									href={`${adminUrl}post-new.php?post_type=${field.reference}`}
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={() => {
+										// So users don't see stale data when they return to the tab.
+										setPagedEntries({});
+										setIsOpen(false);
+									}}
+								>
+									{sprintf(
+										__(
+											// translators: the singular of the model, or "entry" if no singular name known.
+											"Create a new %s.",
+											"atlas-content-modeler"
+										),
+										models[field.reference]?.singular ??
+											__("entry", "atlas-content-modeler")
+									)}
+								</a>
+							</span>
+						</td>
+					</tr>
+				)}
 				{pagedEntries[page].map((entry) => {
 					const { modified, id, title } = entry;
 					const selectEntryLabel = sprintf(

--- a/includes/publisher/js/src/components/relationship/modal/Table.jsx
+++ b/includes/publisher/js/src/components/relationship/modal/Table.jsx
@@ -13,6 +13,16 @@ export default function Table({
 }) {
 	const { models, adminUrl } = atlasContentModelerFormEditingExperience;
 
+	const createNewEntryLabel = sprintf(
+		__(
+			// translators: the singular name of the model, or "entry" if no singular name known.
+			"Create a new %s.",
+			"atlas-content-modeler"
+		),
+		models[field.reference]?.singular ??
+			__("entry", "atlas-content-modeler")
+	);
+
 	return (
 		<table className="table table-striped mt-2">
 			<thead>
@@ -37,16 +47,16 @@ export default function Table({
 									target="_blank"
 									rel="noopener noreferrer"
 									className="d-inline-flex"
-								>
-									{sprintf(
+									aria-label={
+										createNewEntryLabel +
+										" " +
 										__(
-											// translators: the singular name of the model, or "entry" if no singular name known.
-											"Create a new %s.",
+											"Opens in a new window.",
 											"atlas-content-modeler"
-										),
-										models[field.reference]?.singular ??
-											__("entry", "atlas-content-modeler")
-									)}
+										)
+									}
+								>
+									{createNewEntryLabel}
 									<Icon type="external-link" />
 								</a>
 							</span>

--- a/includes/publisher/js/src/components/relationship/modal/Table.jsx
+++ b/includes/publisher/js/src/components/relationship/modal/Table.jsx
@@ -6,12 +6,10 @@ const { date } = wp;
 
 export default function Table({
 	pagedEntries,
-	setPagedEntries,
 	page,
 	field,
 	chosenEntries,
 	handleSelect,
-	setIsOpen,
 }) {
 	const { models, adminUrl } = atlasContentModelerFormEditingExperience;
 
@@ -39,11 +37,6 @@ export default function Table({
 									target="_blank"
 									rel="noopener noreferrer"
 									className="d-inline-flex"
-									onClick={() => {
-										// So users don't see stale data when they return to the tab.
-										setPagedEntries({});
-										setIsOpen(false);
-									}}
 								>
 									{sprintf(
 										__(

--- a/includes/publisher/js/src/components/relationship/modal/Table.jsx
+++ b/includes/publisher/js/src/components/relationship/modal/Table.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { sprintf, __ } from "@wordpress/i18n";
+import Icon from "acm-icons";
 const { wp } = window;
 const { date } = wp;
 
@@ -37,6 +38,7 @@ export default function Table({
 									href={`${adminUrl}post-new.php?post_type=${field.reference}`}
 									target="_blank"
 									rel="noopener noreferrer"
+									className="d-inline-flex"
 									onClick={() => {
 										// So users don't see stale data when they return to the tab.
 										setPagedEntries({});
@@ -52,6 +54,7 @@ export default function Table({
 										models[field.reference]?.singular ??
 											__("entry", "atlas-content-modeler")
 									)}
+									<Icon type="external-link" />
 								</a>
 							</span>
 						</td>

--- a/includes/publisher/js/src/components/relationship/modal/index.jsx
+++ b/includes/publisher/js/src/components/relationship/modal/index.jsx
@@ -186,10 +186,12 @@ export default function RelationshipModal({
 				<>
 					<Table
 						pagedEntries={pagedEntries}
+						setPagedEntries={setPagedEntries}
 						page={page}
 						field={field}
 						chosenEntries={chosenEntries}
 						handleSelect={handleSelect}
+						setIsOpen={setIsOpen}
 					/>
 					<Pagination
 						totalPages={totalPages}

--- a/includes/publisher/scss/_relationship-modal.scss
+++ b/includes/publisher/scss/_relationship-modal.scss
@@ -4,3 +4,7 @@ h2 {
 	font-size: 24px !important;
 	padding: 0px !important;
 }
+
+.icon-external-link {
+	margin-left: 0.2rem;
+}

--- a/includes/publisher/scss/_table.scss
+++ b/includes/publisher/scss/_table.scss
@@ -5,7 +5,7 @@
 		--bs-table-striped-bg: #f4f7fa;
 	}
 
-	.table-striped > tbody > tr:hover > td {
+	.table-striped > tbody > tr:hover:not(.empty) > td {
 		box-shadow: inset 0 0 0 9999px darken($color-secondary-light, 5);
 	}
 
@@ -38,7 +38,8 @@
 		vertical-align: middle;
 	}
 
-	table td label {
+	table td label,
+	table tr.empty td span {
 		display: inline-block;
 		padding-top: 20px;
 		padding-bottom: 20px;

--- a/includes/shared-assets/js/hooks/usePageVisibility.js
+++ b/includes/shared-assets/js/hooks/usePageVisibility.js
@@ -1,0 +1,56 @@
+/**
+ * The usePageVisibility hook monitors the browser page for focus.
+ *
+ * @link https://github.com/Darth-Knoppix/example-react-page-visibility
+ */
+import { useEffect, useState } from "react";
+
+/**
+ * usePageVisibility hook.
+ *
+ * @example
+ * ```
+ * const pageIsVisible = usePageVisibility();
+ * ```
+ */
+export default function usePageVisibility() {
+	const [isVisible, setIsVisible] = useState(getIsDocumentHidden());
+	const onVisibilityChange = () => setIsVisible(getIsDocumentHidden());
+
+	useEffect(() => {
+		const visibilityChange = getBrowserVisibilityProp();
+
+		document.addEventListener(visibilityChange, onVisibilityChange, false);
+
+		return () => {
+			document.removeEventListener(visibilityChange, onVisibilityChange);
+		};
+	});
+
+	return isVisible;
+}
+
+function getBrowserVisibilityProp() {
+	if (typeof document.hidden !== "undefined") {
+		// Opera 12.10 and Firefox 18 and later support
+		return "visibilitychange";
+	} else if (typeof document.msHidden !== "undefined") {
+		return "msvisibilitychange";
+	} else if (typeof document.webkitHidden !== "undefined") {
+		return "webkitvisibilitychange";
+	}
+}
+
+function getBrowserDocumentHiddenProp() {
+	if (typeof document.hidden !== "undefined") {
+		return "hidden";
+	} else if (typeof document.msHidden !== "undefined") {
+		return "msHidden";
+	} else if (typeof document.webkitHidden !== "undefined") {
+		return "webkitHidden";
+	}
+}
+
+function getIsDocumentHidden() {
+	return !document[getBrowserDocumentHiddenProp()];
+}

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -110,13 +110,14 @@ class CreateRelationshipFieldEntryCest
 		$I->wait(1);
 
 		// Check the new company appears in the updated modal.
-		$I->switchToPreviousTab(); // Focus on the original employee tab.
-		$I->wait(2); // The modal should auto-refresh to reveal the newly added company.
-		$I->see('WP Engine', '.atlas-content-modeler-relationship-modal-container');
+		$I->closeTab(); // Focus on the original employee tab.
 
-		// Required cleanup to leave one tab open.
-		$I->switchToNextTab();
-		$I->closeTab();
-		$I->wait(1);
+		// Test that the modal is still visible.
+		$I->see('Select Company', '.atlas-content-modeler-relationship-modal-container h2');
+
+		// This is as far as we can test in headless mode under CircleCI.
+		// The visibilitychange event does not fire in headless mode,
+		// so we can't check that the modal refreshed to show the
+		// newly-added “WP Engine” company.
 	}
 }

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -110,7 +110,7 @@ class CreateRelationshipFieldEntryCest
 		$I->wait(1);
 
 		// Reopen the closed modal and check our newly-entered company appears.
-		$I->switchToPreviousTab(); // Focus on the original employee tab.
+		$I->closeTab(); // Focus on the original employee tab.
 		$I->click('#atlas-content-modeler[employee][company]');
 		$I->wait(2);
 		$I->see('WP Engine', '.atlas-content-modeler-relationship-modal-container');

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -109,10 +109,9 @@ class CreateRelationshipFieldEntryCest
 		$I->click('Publish', '#publishing-action');
 		$I->wait(1);
 
-		// Reopen the closed modal and check our newly-entered company appears.
+		// Check the new company appears in the updated modal.
 		$I->closeTab(); // Focus on the original employee tab.
-		$I->click('#atlas-content-modeler[employee][company]');
-		$I->wait(2);
+		$I->wait(2); // The modal should auto-refresh to reveal the newly added company.
 		$I->see('WP Engine', '.atlas-content-modeler-relationship-modal-container');
 	}
 }

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -111,7 +111,7 @@ class CreateRelationshipFieldEntryCest
 
 		// Check the new company appears in the updated modal.
 		$I->closeTab(); // Focus on the original employee tab.
-		$I->wait(2); // The modal should auto-refresh to reveal the newly added company.
+		$I->wait(4); // The modal should auto-refresh to reveal the newly added company.
 		$I->see('WP Engine', '.atlas-content-modeler-relationship-modal-container');
 	}
 }

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -110,8 +110,13 @@ class CreateRelationshipFieldEntryCest
 		$I->wait(1);
 
 		// Check the new company appears in the updated modal.
-		$I->closeTab(); // Focus on the original employee tab.
-		$I->wait(4); // The modal should auto-refresh to reveal the newly added company.
+		$I->switchToPreviousTab(); // Focus on the original employee tab.
+		$I->wait(2); // The modal should auto-refresh to reveal the newly added company.
 		$I->see('WP Engine', '.atlas-content-modeler-relationship-modal-container');
+
+		// Required cleanup to leave one tab open.
+		$I->switchToNextTab();
+		$I->closeTab();
+		$I->wait(1);
 	}
 }

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -91,4 +91,28 @@ class CreateRelationshipFieldEntryCest
 		$I->see('WP Engine', 'div.relation-model-card');
 		$I->see('Another Company Name', 'div.relation-model-card');
 	}
+
+	public function i_can_create_a_new_entry_from_an_empty_relationships_modal_table(AcceptanceTester $I) {
+		// Try to create an employee before any companies have been entered.
+		$I->amOnPage('/wp-admin/post-new.php?post_type=employee');
+		$I->see('Company', 'div.field.relationship');
+		$I->click('#atlas-content-modeler[employee][company]');
+		$I->see('Select Company', '.atlas-content-modeler-relationship-modal-container h2');
+		$I->wait(2);
+		$I->see('No published entries');
+
+		// Create a company via the link in the relationships modal.
+		$I->click('Create a new Company');
+		$I->wait(1);
+		$I->switchToNextTab(); // Focus on the Create Company tab.
+		$I->fillField(['name' => 'atlas-content-modeler[company][company]'], 'WP Engine');
+		$I->click('Publish', '#publishing-action');
+		$I->wait(1);
+
+		// Reopen the closed modal and check our newly-entered company appears.
+		$I->switchToPreviousTab(); // Focus on the original employee tab.
+		$I->click('#atlas-content-modeler[employee][company]');
+		$I->wait(2);
+		$I->see('WP Engine', '.atlas-content-modeler-relationship-modal-container');
+	}
 }

--- a/tests/acceptance/OpenInGraphiQLCest.php
+++ b/tests/acceptance/OpenInGraphiQLCest.php
@@ -19,7 +19,7 @@ class OpenInGraphiQLCest
 		$I->click('.heading .options'); // Model options button.
 		$I->click('.show-in-graphiql');
 		$I->switchToNextTab(); // GraphiQL opens in a new tab.
-		$I->wait(2); // Give GraphiQL time for linting.
+		$I->wait(3); // Give GraphiQL time for linting.
 
 		$I->see('Dog', '#graphiql');
 		// Check for query errors marked by GraphiQL linter.
@@ -44,7 +44,7 @@ class OpenInGraphiQLCest
 		$I->click('.heading .options'); // Model options button.
 		$I->click('.show-in-graphiql');
 		$I->switchToNextTab(); // GraphiQL opens in a new tab.
-		$I->wait(2); // Give GraphiQL time for linting.
+		$I->wait(3); // Give GraphiQL time for linting.
 
 		$I->see('wagsPerMinute', '#graphiql');
 		// Check for query errors marked by GraphiQL linter.
@@ -82,7 +82,7 @@ class OpenInGraphiQLCest
 		$I->click('.heading .options'); // Model options button.
 		$I->click('.show-in-graphiql');
 		$I->switchToNextTab(); // GraphiQL opens in a new tab.
-		$I->wait(2); // Give GraphiQL time for linting.
+		$I->wait(3); // Give GraphiQL time for linting.
 
 		$I->see('Deer', '#graphiql');
 		// Check for query errors marked by GraphiQL linter.

--- a/tests/acceptance/OpenInGraphiQLCest.php
+++ b/tests/acceptance/OpenInGraphiQLCest.php
@@ -19,7 +19,7 @@ class OpenInGraphiQLCest
 		$I->click('.heading .options'); // Model options button.
 		$I->click('.show-in-graphiql');
 		$I->switchToNextTab(); // GraphiQL opens in a new tab.
-		$I->wait(3); // Give GraphiQL time for linting.
+		$I->wait(2); // Give GraphiQL time for linting.
 
 		$I->see('Dog', '#graphiql');
 		// Check for query errors marked by GraphiQL linter.
@@ -44,7 +44,7 @@ class OpenInGraphiQLCest
 		$I->click('.heading .options'); // Model options button.
 		$I->click('.show-in-graphiql');
 		$I->switchToNextTab(); // GraphiQL opens in a new tab.
-		$I->wait(3); // Give GraphiQL time for linting.
+		$I->wait(2); // Give GraphiQL time for linting.
 
 		$I->see('wagsPerMinute', '#graphiql');
 		// Check for query errors marked by GraphiQL linter.
@@ -82,7 +82,7 @@ class OpenInGraphiQLCest
 		$I->click('.heading .options'); // Model options button.
 		$I->click('.show-in-graphiql');
 		$I->switchToNextTab(); // GraphiQL opens in a new tab.
-		$I->wait(3); // Give GraphiQL time for linting.
+		$I->wait(2); // Give GraphiQL time for linting.
 
 		$I->see('Deer', '#graphiql');
 		// Check for query errors marked by GraphiQL linter.


### PR DESCRIPTION
Improves the empty state of the relationships modal table:

- Removes the pagination if there are zero pages. (Previously, “Page 1 of 0” would appear if there were no entries.)
- Displays an empty message if there are no entries. 
- Adds a link in the modal to create a new entry if there are no entries. Clicking the link closes the modal and opens the “New [Singular]` page in a new tab. This removes a potential dead end, where the user would have to figure out how to create a related entry themselves and then refresh the original page to see those new entries (potentially losing unsaved work in the process).

## Testing

Includes an e2e test for the “create new entry” flow.

### To test manually

1. Create a “Monkey” model with a “name” text field set as the title, and a “Monkey Friends” relationship field that refers to other monkeys.
2. Add your first monkey.
3. Click the relationship field to open the relationship modal. You should see no entries. Click the link named, “Create a new Monkey”.
4. In the new tab that opens, create a new monkey by just filling its name, then publish it.
5. Close the tab to return to the original monkey entry.
6. The relationship modal should update to show the monkey you entered.

## Screenshots

| Before | After |
| - | - |
| <img width="947" alt="Screenshot 2021-08-31 at 13 29 10" src="https://user-images.githubusercontent.com/647669/131495051-b762b039-caf8-4a85-97fb-82ee1b01fdfd.png"> | <img width="948" alt="Screenshot 2021-08-31 at 13 28 42" src="https://user-images.githubusercontent.com/647669/131495090-c24b49af-77ac-4856-9985-bc70d58308ef.png"> |