### PR TITLE
BH-1211: Remove required option from Relationship field.

### DIFF
--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -398,7 +398,9 @@ function Form({ id, position, type, editing, storedData }) {
 					/>
 				)}
 
-				{!["richtext", "multipleChoice"].includes(type) && (
+				{!["richtext", "multipleChoice", "relationship"].includes(
+					type
+				) && (
 					<div className="field">
 						<legend>Field Options</legend>
 						<input


### PR DESCRIPTION
## Description
Removes the "required" field option from the Relationship field.

This is temporary until we work out a better UX.

I did not remove the required logic within the publisher app components, as we'll be bringing this feature back in the near future, and everything should work fine with it there in the meantime.

https://wpengine.atlassian.net/browse/BH-1211

## Documentation Changes
Removed "Make this field required" option from the Relationship field.
