### PR TITLE
[BH-1225] Stop relationship modal button from intercepting form submission

### DIFF
--- a/includes/publisher/js/src/components/relationship/LinkButton.jsx
+++ b/includes/publisher/js/src/components/relationship/LinkButton.jsx
@@ -30,6 +30,7 @@ export default function LinkButton({
 			<button
 				className="button button-primary link-button"
 				style={{ marginTop: "5px" }}
+				type="button"
 				id={`atlas-content-modeler[${modelSlug}][${field.slug}]`}
 				onClick={(e) => {
 					e.preventDefault();


### PR DESCRIPTION
## Description

Prevents an issue where pressing enter in an input field that appears before a relationship field button would open the relationship modal instead of submitting the publisher form.

Caused by `button` elements having a default `type` of `submit` and appearing before the actual submit button. Fixed by specifying the `type` of the relationship field button as `button`.

https://wpengine.atlassian.net/browse/BH-1225

## Testing

I did not add a regression test for this: the impact of a regression seems very low compared to the time taken for an e2e test.

Existing e2e tests already cover the relationship button and modal to confirm it otherwise works as expected.

### To test manually

1. Create a model with a text field and relationship field.
2. Add a new entry.
3. Press enter with focus in the text field.

The publisher form should submit instead of the relationship modal opening.

The relationship field button should still respond to mouse and keyboard activation.

## Screenshots

<img width="710" alt="Screenshot 2021-09-08 at 11 38 26" src="https://user-images.githubusercontent.com/647669/132485911-6486fe21-8625-4c4b-8732-5661435b75ed.png">

## Documentation Changes

n/a

## Dependant PRs

Targets #264 and should be merged before it.