### PR TITLE
[NO JIRA] Change “Relation Cardinality” label to “Connections” for relationship field

### DIFF
--- a/includes/settings/js/src/components/fields/RelationshipFields.jsx
+++ b/includes/settings/js/src/components/fields/RelationshipFields.jsx
@@ -91,7 +91,7 @@ const RelationshipFields = ({ register, data, editing, watch, errors }) => {
 				</div>
 				<div className={editing ? "field read-only editing" : "field"}>
 					<legend>
-						{__("Relation Cardinality", "atlas-content-modeler")}
+						{__("Connections", "atlas-content-modeler")}
 					</legend>
 					<fieldset>
 						<div className="radio-row">


### PR DESCRIPTION
## Description

Updates the cardinality field with a friendlier label, as suggested in sprint demo feedback. [Discussed in Slack](https://wpengine.slack.com/archives/C020RTG8Y0L/p1630415243030100) with Mason/John. Change approved by Mason.

The field is still referred to as 'cardinality' internally.

## Testing

n/a

## Screenshots

| Before | After |
|-|-|
| <img width="642" alt="Screenshot 2021-09-08 at 11 58 38" src="https://user-images.githubusercontent.com/647669/132489363-d67fcc1a-fcdb-4f93-b336-09b443d03a81.png"> | <img width="627" alt="Screenshot 2021-09-08 at 12 01 22" src="https://user-images.githubusercontent.com/647669/132489533-65d987ed-2df1-4827-9de6-f7e528ee3198.png"> |


## Documentation Changes

n/a

## Dependant PRs

Targets #264 and should be merged first.