### PR TITLE
chore: update required WP version to 5.7

### DIFF
--- a/atlas-content-modeler.php
+++ b/atlas-content-modeler.php
@@ -8,7 +8,7 @@
  * Text Domain: atlas-content-modeler
  * Domain Path: /languages
  * Version: 0.5.0
- * Requires at least: 5.2
+ * Requires at least: 5.7
  * Requires PHP: 7.2
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Description

Updates the plugin header to specify that the minimum required version of WordPress is 5.7. As we move towards deploying this on wp.org, we need to firm up these kinds of things. I'll open a separate PR to update the release docs to include ensuring the PHP and WP versions are updated in the plugin header.

## Testing

Tested on WP 5.7.2

