### PR TITLE
BH-1181: Prompt to save unsaved fields only if there are changes

### DIFF
--- a/includes/settings/js/src/components/EditContentModel.jsx
+++ b/includes/settings/js/src/components/EditContentModel.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useRef } from "react";
 import { useHistory } from "react-router-dom";
 import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import { useLocationSearch } from "../utils";
@@ -33,6 +33,7 @@ export default function EditContentModel() {
 	const fieldCount = Object.keys(fields).length;
 	const fieldOrder = getFieldOrder(fields);
 	const history = useHistory();
+	const hasDirtyField = useRef(false);
 
 	const customStyles = {
 		overlay: {
@@ -52,7 +53,7 @@ export default function EditContentModel() {
 
 	const promptToSaveChanges = () => {
 		const openField = getOpenField(fields);
-		if (Object.keys(openField).length > 0) {
+		if (Object.keys(openField).length > 0 && hasDirtyField.current) {
 			updateUnsavedChangesModal({ open: true, field: openField });
 			return true;
 		}
@@ -130,6 +131,9 @@ export default function EditContentModel() {
 														editing={editing}
 														data={fields[id]}
 														setInfoTag={setInfoTag}
+														hasDirtyField={
+															hasDirtyField
+														}
 														promptToSaveChanges={
 															promptToSaveChanges
 														}
@@ -180,6 +184,7 @@ export default function EditContentModel() {
 										?.editing
 										? "closeField"
 										: "removeField";
+									hasDirtyField.current = false;
 									dispatch({
 										type: action,
 										model: id,

--- a/includes/settings/js/src/components/fields/Field.jsx
+++ b/includes/settings/js/src/components/fields/Field.jsx
@@ -25,6 +25,7 @@ function Field({
 	positionAfter,
 	setInfoTag,
 	promptToSaveChanges,
+	hasDirtyField,
 	type = "text",
 }) {
 	const [activeForm, setActiveForm] = useState(type);
@@ -186,6 +187,7 @@ function Field({
 					editing={editing}
 					id={id}
 					position={position}
+					hasDirtyField={hasDirtyField}
 				/>
 			</div>
 		</li>

--- a/tests/acceptance/UnsavedChangesCest.php
+++ b/tests/acceptance/UnsavedChangesCest.php
@@ -4,6 +4,7 @@ class UnsavedChangesCest
 {
 	public function _before(\AcceptanceTester $I)
 	{
+		$I->resizeWindow(1024, 1024);
 		$I->maximizeWindow();
 
 		$I->loginAsAdmin();
@@ -49,11 +50,26 @@ class UnsavedChangesCest
 		// Start to edit the first field again.
 		$I->clickWithLeftButton('button.edit', 10, 10);
 
+		// Make a change to a field.
+		$I->fillField(['name' => 'name'], 'Name Edited');
+
 		// Attempt to navigate away via the breadcrumb.
-		$I->click('Content Models');
+		$I->click('Content Models', '.heading');
+
+		// Check the modal appears, but discard changes.
+		$I->see('Unsaved Changes');
+		$I->click('.ReactModal__Content button.tertiary');
+		$I->dontSee('Name Edited');
+		$I->see('Name');
+
+		// Start to edit the first field again.
+		$I->clickWithLeftButton('button.edit', 10, 10);
+
+		// Attempt to navigate away via the breadcrumb.
+		$I->click('Content Models', '.heading');
 
 		// Confirm the modal does *not* appear, because there are no unsaved changes.
 		$I->dontSee('Unsaved Changes');
-		$I->see('Models');
+		$I->see('New Model'); // Model index page.
 	}
 }

--- a/tests/acceptance/UnsavedChangesCest.php
+++ b/tests/acceptance/UnsavedChangesCest.php
@@ -45,5 +45,15 @@ class UnsavedChangesCest
 		// Click “Discard Changes” and confirm our incomplete Hobbies field is gone.
 		$I->click('.ReactModal__Content button.tertiary');
 		$I->dontSee('Hobbies');
+
+		// Start to edit the first field again.
+		$I->clickWithLeftButton('button.edit', 10, 10);
+
+		// Attempt to navigate away via the breadcrumb.
+		$I->click('Content Models');
+
+		// Confirm the modal does *not* appear, because there are no unsaved changes.
+		$I->dontSee('Unsaved Changes');
+		$I->see('Models');
 	}
 }


### PR DESCRIPTION
## Description

Prevents the “unsaved changes” modal from appearing if no edits were made to a field when a user attempts to open another field.

https://wpengine.atlassian.net/browse/BH-1181

## Testing

I extended an existing e2e test to check the modal only appears if changes were made.

To test manually:

- Edit an existing model.
- Open an existing field.
- Click a different field to open it, or click the "Content Models" link in the breadcrumb navigation at the top.
- You should see no modal prompting you to save unsaved changes.
