### PR TITLE
FIX: Use a more appropriate name for the relationship

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -621,8 +621,6 @@ function register_relationship_connection( array $parent_model, array $reference
 			'connectionTypeName' => $connection_type_name,
 		)
 	);
-
-	return $connection_type_name;
 }
 
 /**

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -389,7 +389,7 @@ final class FormEditingExperience {
 		);
 
 		$registry      = ContentConnect::instance()->get_registry();
-		$relationship  = $registry->get_post_to_post_relationship( $post->post_type, $field['reference'], $field_id );
+		$relationship  = $registry->get_post_to_post_relationship( $post->post_type, $field['reference'], $post->post_type . '-' . $field['reference'] );
 		$related_posts = array();
 
 		if ( $relationship ) {
@@ -416,7 +416,7 @@ final class FormEditingExperience {
 		$relationship = $registry->get_post_to_post_relationship(
 			$post_type,
 			$relationship_type,
-			$field_name
+			$post_type . '-' . $relationship_type
 		);
 
 		$relationship_ids = $relationship->get_related_object_ids( $post_id );

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -87,7 +87,7 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 		foreach ( $this->models as $post_type => $model ) {
 			foreach ( $model['fields'] as $field ) {
 				if ( $field['type'] === 'relationship' ) {
-					$relationship = $registry->get_post_to_post_relationship( $post_type, $field['reference'], $field['slug'] );
+					$relationship = $registry->get_post_to_post_relationship( $post_type, $field['reference'], $post_type . '-' . $field['reference'] );
 					self::assertInstanceOf('WPE\AtlasContentModeler\ContentConnect\Relationships\PostToPost', $relationship);
 				}
 			}


### PR DESCRIPTION
## Description

Uses a more appropriate name to define the relationship. This is a split off of #276 in order to keep this change separate.