### PR TITLE
chore: set SVN mime type for wp.org image assets.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ commands:
       - run: find ./trunk -not -path "./trunk" -delete
       - run: cp -r ~/project/atlas-content-modeler/. ./trunk
       - run: mv ./trunk/assets/wporg/* ./assets
+      - run: svn propset svn:mime-type image/png ./assets/*.png
+      - run: svn propset svn:mime-type image/jpeg ./assets/*.jpg
       - run: rm -rf node_modules/
       - run: svn propset svn:ignore -F ./trunk/.svnignore ./trunk
       - run: svn propset svn:ignore -F ./trunk/.svnignore ./tags


### PR DESCRIPTION
This prevents an issue where images are downloaded instead of being enlarged
when clicking a screenshot on the wp.org plugin page.

See: https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/#issues
