### PR TITLE
[BH-1254] Ensure field slugs and reverse slugs are unique in GraphQL

### DIFF
--- a/includes/rest-api/fields.php
+++ b/includes/rest-api/fields.php
@@ -125,7 +125,9 @@ function content_model_field_exists( string $slug, string $id, string $model_id 
 		foreach ( $type['fields'] as $field ) {
 			if ( 'relationship' === $field['type'] &&
 				$model_id === $field['reference'] &&
+				isset( $field['enableReverse'] ) &&
 				true === $field['enableReverse'] &&
+				isset( $field['reverseSlug'] ) &&
 				$slug === $field['reverseSlug']
 			) {
 				return true;

--- a/includes/rest-api/fields.php
+++ b/includes/rest-api/fields.php
@@ -100,10 +100,13 @@ function cleanup_detached_relationship_references( string $slug ) {
  *
  * @param string $slug  The current field slug.
  * @param string $id    The current field id.
- * @param array  $model The content model to check for duplicate slugs.
+ * @param string $model_id The id of the content model to check for duplicate slugs.
  * @return bool
  */
-function content_model_field_exists( string $slug, string $id, array $model ): bool {
+function content_model_field_exists( string $slug, string $id, string $model_id ): bool {
+	$content_types = get_registered_content_types();
+	$model         = $content_types[ $model_id ];
+
 	if ( ! isset( $model['fields'] ) ) {
 		return false;
 	}
@@ -115,6 +118,18 @@ function content_model_field_exists( string $slug, string $id, array $model ): b
 		}
 		if ( $field['slug'] === $slug ) {
 			return true;
+		}
+	}
+
+	foreach ( $content_types as $type ) {
+		foreach ( $type['fields'] as $field ) {
+			if ( 'relationship' === $field['type'] &&
+				$model_id === $field['reference'] &&
+				true === $field['enableReverse'] &&
+				$slug === $field['reverseSlug']
+			) {
+				return true;
+			}
 		}
 	}
 

--- a/includes/rest-api/fields.php
+++ b/includes/rest-api/fields.php
@@ -104,25 +104,23 @@ function cleanup_detached_relationship_references( string $slug ) {
  * @return bool
  */
 function content_model_field_exists( string $slug, string $id, string $model_id ): bool {
-	$content_types = get_registered_content_types();
-	$model         = $content_types[ $model_id ];
+	$models = get_registered_content_types();
 
-	if ( ! isset( $model['fields'] ) ) {
-		return false;
-	}
-
-	foreach ( $model['fields'] as $field ) {
-		// Exclude the field being edited from slug collision checks.
-		if ( $field['id'] === $id ) {
+	foreach ( $models as $current_model => $model ) {
+		if ( ! isset( $model['fields'] ) ) {
 			continue;
 		}
-		if ( $field['slug'] === $slug ) {
-			return true;
-		}
-	}
 
-	foreach ( $content_types as $type ) {
-		foreach ( $type['fields'] as $field ) {
+		foreach ( $model['fields'] as $field ) {
+			if ( $current_model === $model_id && $field['id'] === $id ) {
+				continue;
+			}
+
+			if ( $model_id === $current_model &&
+			$field['slug'] === $slug ) {
+				return true;
+			}
+
 			if ( 'relationship' === $field['type'] &&
 				$model_id === $field['reference'] &&
 				isset( $field['enableReverse'] ) &&

--- a/includes/rest-api/routes/content-model-field.php
+++ b/includes/rest-api/routes/content-model-field.php
@@ -137,7 +137,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		content_model_field_exists(
 			$params['slug'],
 			$params['id'],
-			$content_types[ $params['model'] ]
+			$params['model']
 		)
 	) {
 		return new WP_Error(
@@ -155,7 +155,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		content_model_field_exists(
 			$params['reverseSlug'],
 			$params['id'],
-			$content_types[ $params['reference'] ]
+			$params['reference']
 		)
 	) {
 			return new WP_Error(

--- a/includes/rest-api/routes/content-model-field.php
+++ b/includes/rest-api/routes/content-model-field.php
@@ -161,7 +161,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 			return new WP_Error(
 				'wpe_duplicate_field_reverse_slug',
 				sprintf(
-					/* translators: %s: reference id of the reffered to field */
+					/* translators: %s: reference id of the referenced to field */
 					__( 'Another field in the model %s model has the same API identifier.', 'atlas-content-modeler' ),
 					$params['reference']
 				),

--- a/includes/rest-api/routes/content-model-field.php
+++ b/includes/rest-api/routes/content-model-field.php
@@ -147,6 +147,28 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		);
 	}
 
+	if (
+		isset( $params['type'] ) &&
+		$params['type'] === 'relationship' &&
+		isset( $params['enableReverse'] ) &&
+		true === $params['enableReverse'] &&
+		content_model_field_exists(
+			$params['reverseSlug'],
+			$params['id'],
+			$content_types[ $params['reference'] ]
+		)
+	) {
+			return new WP_Error(
+				'wpe_duplicate_field_reverse_slug',
+				sprintf(
+					/* translators: %s: reference id of the reffered to field */
+					__( 'Another field in the model %s model has the same API identifier.', 'atlas-content-modeler' ),
+					$params['reference']
+				),
+				array( 'status' => 400 )
+			);
+	}
+
 	/**
 	 * Remove isTitle from all fields if isTitle is set on this field. Only one
 	 * field can be used as the entry title.
@@ -170,13 +192,13 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 	);
 }
 
-/**
- * Handles model field DELETE requests from the REST API to delete an existing field.
- *
- * @param WP_REST_Request $request The REST API request object.
- *
- * @return WP_Error|\WP_HTTP_Response|\WP_REST_Response
- */
+	/**
+	 * Handles model field DELETE requests from the REST API to delete an existing field.
+	 *
+	 * @param WP_REST_Request $request The REST API request object.
+	 *
+	 * @return WP_Error|\WP_HTTP_Response|\WP_REST_Response
+	 */
 function dispatch_delete_content_model_field( WP_REST_Request $request ) {
 	$route         = $request->get_route();
 	$field_id      = substr( strrchr( $route, '/' ), 1 );

--- a/includes/rest-api/routes/content-model-field.php
+++ b/includes/rest-api/routes/content-model-field.php
@@ -133,6 +133,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		}
 	}
 
+	// Checks the field slug on the current model.
 	if (
 		content_model_field_exists(
 			$params['slug'],
@@ -147,6 +148,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		);
 	}
 
+	// Checks the reverse slug on the reference model.
 	if (
 		isset( $params['type'] ) &&
 		$params['type'] === 'relationship' &&

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -255,6 +255,9 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 				) {
 					setError("reference", { type: "invalidRelatedModel" });
 				}
+				if (err.code === "wpe_duplicate_field_reverse_slug") {
+					setError("reverseSlug", { type: "reverseIdExists" });
+				}
 			});
 	}
 

--- a/includes/settings/js/src/components/fields/RelationshipFields.jsx
+++ b/includes/settings/js/src/components/fields/RelationshipFields.jsx
@@ -407,7 +407,7 @@ const RelationshipFields = ({
 									<Icon type="error" />
 									<span role="alert">
 										{__(
-											"Another field in the related model has the same API identifier.",
+											"A field in the related model has the same API identifier.",
 											"atlas-content-modeler"
 										)}
 									</span>

--- a/includes/settings/js/src/components/fields/RelationshipFields.jsx
+++ b/includes/settings/js/src/components/fields/RelationshipFields.jsx
@@ -402,12 +402,12 @@ const RelationshipFields = ({
 								</span>
 							)}
 						{errors.reverseSlug &&
-							errors.reverseSlug.type === "idExists" && (
+							errors.reverseSlug.type === "reverseIdExists" && (
 								<span className="error">
 									<Icon type="error" />
 									<span role="alert">
 										{__(
-											"Another field in this model has the same API identifier.",
+											"Another field in the related model has the same API identifier.",
 											"atlas-content-modeler"
 										)}
 									</span>


### PR DESCRIPTION
## Description

Checks new and edited fields to ensure a slug conflict does not occur when a reverse-relationship is connected. When a duplicate slug is found an error is shown on the appropriate field.

https://wpengine.atlassian.net/browse/BH-1254

## Testing

Appropriate unit tests have been created to determine when a collision should occur and check for the appropriate error.


## Notes

I've done what I believe is extensive testing of new and edited fields to ensure the error is present when needed and only when needed. Please verify the logic in your own testing as, I fully admit, the determination of the error condition was far trickier than I had anticipated.
