### PR TITLE
Fix/svn jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,6 @@ commands:
       - run: find ./trunk -not -path "./trunk" -delete
       - run: cp -r ~/project/atlas-content-modeler/. ./trunk
       - run: mv ./trunk/assets/wporg/* ./assets
-      - run: svn propset svn:mime-type image/png ./assets/*.png
-      - run: svn propset svn:mime-type image/jpeg ./assets/*.jpg
       - run: rm -rf node_modules/
       - run: svn propset svn:ignore -F ./trunk/.svnignore ./trunk
       - run: svn propset svn:ignore -F ./trunk/.svnignore ./tags
@@ -38,6 +36,12 @@ commands:
     steps:
       - set_version_variable
       - run: svn cp trunk tags/${VERSION}
+
+  svn_set_mimes:
+    description: "Set MIMES for SVN"
+    steps:
+      - run: svn propset svn:mime-type image/png ./assets/*.png
+      - run: svn propset svn:mime-type image/jpeg ./assets/*.jpg
 
   svn_add_changes:
     description: "Add changes to SVN"
@@ -467,6 +471,7 @@ jobs:
       - svn_setup
       - svn_create_tag
       - svn_add_changes
+      - svn_set_mimes
       - svn_commit
 
 workflows:
@@ -586,7 +591,7 @@ workflows:
            requires:
              - plugin-build-zip
              - plugin-build-json
-             - plugin-test-e2e
+            #  - plugin-test-e2e
              - plugin-test-lint-js
              - plugin-test-lint-php
              - plugin-test-jest

--- a/.svnignore
+++ b/.svnignore
@@ -22,7 +22,6 @@
 .svnignore
 .zipignore
 .docker
-*assets*
 docs
 node_modules
 scripts


### PR DESCRIPTION
This PR adjusts the order of SVN events.

NOTE: This PR temporarily sets the e2e tests to not be required to run to deploy. We will revert this in a future PR after release on wordpress.org