### PR TITLE
[NOJIRA] Pass TEST env var to make test-php-unit to run single unit tests locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,19 @@ test-php-unit: | install-composer build-docker-phpunit ## Run PHPunit tests
 		docker-compose -f ./docker-compose-phpunit.yml down; \
 	fi
 	docker-compose -f ./docker-compose-phpunit.yml up -d
-	docker-compose \
-		-f ./docker-compose-phpunit.yml\
-		exec \
-		-w /app \
-		phpunit \
-		bash -c "composer test"
+	if [ -z "$(TEST)" ]; then \
+		docker-compose \
+			-f ./docker-compose-phpunit.yml \
+			exec \
+			-w /app \
+			phpunit \
+			bash -c "composer test"; \
+	else \
+		docker-compose \
+			-f ./docker-compose-phpunit.yml \
+			exec \
+			-w /app \
+			phpunit \
+			bash -c "vendor/bin/phpunit $(TEST)"; \
+	fi
 	docker-compose -f ./docker-compose-phpunit.yml down

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -51,10 +51,22 @@ make help
 TEST=<test> make test-e2e
 ```
 
-example:
+Example:
 
 ```
 TEST=CreateContentModelMediaFieldCest:i_can_add_a_media_field_to_a_content_model make test-e2e
+```
+
+#### Running a single PHP unit test
+
+```
+TEST=<test> make test-php-unit
+```
+
+Example:
+
+```
+TEST=tests/integration/api-validation/test-graphql-endpoints.php make test-php-unit
 ```
 
 ### Manual test setup


### PR DESCRIPTION
## Description

Allows us to run PHP unit tests by filename locally, in a similar way as we can run e2e tests individually.

## Testing

Try running a test by filename:

```
TEST=tests/integration/api-validation/test-graphql-endpoints.php make test-php-unit
```

You should see only test results from that file.


The `make test-php-unit` command should continue to run all PHP unit tests.

## Documentation Changes

PR includes developer documentation.