### PR TITLE
chore: enable e2e tests as requirement for deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,7 +595,7 @@ workflows:
            requires:
              - plugin-build-zip
              - plugin-build-json
-            #  - plugin-test-e2e
+             - plugin-test-e2e
              - plugin-test-lint-js
              - plugin-test-lint-php
              - plugin-test-jest


### PR DESCRIPTION
This was temporarily disabled to make debugging SVN deploys quicker.

This reverts that change and brings the config back to the original state.

