### PR TITLE
[BH-1280] Prevent editing existing field slugs

### DIFF
--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -365,6 +365,7 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 							onChange={(e) =>
 								onChangeGeneratedValue(e.target.value)
 							}
+							readOnly={editing}
 						/>
 						<p className="field-messages">
 							{errors.slug && errors.slug.type === "required" && (

--- a/tests/acceptance/EditFieldCest.php
+++ b/tests/acceptance/EditFieldCest.php
@@ -1,0 +1,30 @@
+<?php
+
+class EditFieldCest
+{
+	/**
+	 * Ensure a user can add a text field and set it as the entry title.
+	 */
+	public function i_cannot_edit_a_field_slug_after_the_field_has_been_created(AcceptanceTester $I)
+	{
+		$I->loginAsAdmin();
+		$I->haveContentModel('Candy', 'Candies');
+		$I->wait(1);
+
+		$I->click('Text', '.field-buttons');
+		$I->wait(1);
+		$I->fillField(['name' => 'name'], 'Name');
+		$I->seeInField('#slug','name');
+		$I->click('.open-field label.checkbox.is-title');
+		$I->click('.open-field button.primary');
+		$I->wait(1);
+
+		$I->see('Text', '.field-list div.type');
+		$I->see('Name', '.field-list div.widest');
+		$I->see('entry title', '.field-list div.tags');
+
+        $I->click( '.field-list div.widest' );
+		$I->see( 'Editing “Name” Field' );
+        $I->seeElement( '#slug', array( 'readonly'=> true ) );
+	}
+}

--- a/tests/acceptance/EditFieldCest.php
+++ b/tests/acceptance/EditFieldCest.php
@@ -1,30 +1,29 @@
 <?php
 
-class EditFieldCest
-{
+class EditFieldCest {
+
 	/**
 	 * Ensure a user can add a text field and set it as the entry title.
 	 */
-	public function i_cannot_edit_a_field_slug_after_the_field_has_been_created(AcceptanceTester $I)
-	{
+	public function i_cannot_edit_a_field_slug_after_the_field_has_been_created( AcceptanceTester $I ) {
 		$I->loginAsAdmin();
-		$I->haveContentModel('Candy', 'Candies');
-		$I->wait(1);
+		$I->haveContentModel( 'Candy', 'Candies' );
+		$I->wait( 1 );
 
-		$I->click('Text', '.field-buttons');
-		$I->wait(1);
-		$I->fillField(['name' => 'name'], 'Name');
-		$I->seeInField('#slug','name');
-		$I->click('.open-field label.checkbox.is-title');
-		$I->click('.open-field button.primary');
-		$I->wait(1);
+		$I->click( 'Text', '.field-buttons' );
+		$I->wait( 1 );
+		$I->fillField( [ 'name' => 'name' ], 'Name' );
+		$I->seeInField( '#slug', 'name' );
+		$I->click( '.open-field label.checkbox.is-title' );
+		$I->click( '.open-field button.primary' );
+		$I->wait( 1 );
 
-		$I->see('Text', '.field-list div.type');
-		$I->see('Name', '.field-list div.widest');
-		$I->see('entry title', '.field-list div.tags');
+		$I->see( 'Text', '.field-list div.type' );
+		$I->see( 'Name', '.field-list div.widest' );
+		$I->see( 'entry title', '.field-list div.tags' );
 
-        $I->click( '.field-list div.widest' );
+		$I->click( '.field-list div.widest' );
 		$I->see( 'Editing “Name” Field' );
-        $I->seeElement( '#slug', array( 'readonly'=> true ) );
+		$I->seeElement( '#slug', array( 'readonly' => true ) );
 	}
 }


### PR DESCRIPTION
Simply sets _readonly_ to true on the slug when editing a field 