### PR TITLE
[NOJIRA] Fix the model icon picker to appear above the edit model modal

### DIFF
--- a/includes/settings/scss/_dashicons-picker.scss
+++ b/includes/settings/scss/_dashicons-picker.scss
@@ -9,6 +9,7 @@
 	overflow: hidden;
 	padding: 5px;
 	box-sizing: border-box;
+	z-index: 1000000; /* Above the edit model modal. */
 }
 .dashicon-picker-container ul {
 	margin: 0;

--- a/tests/acceptance/EditContentModelCest.php
+++ b/tests/acceptance/EditContentModelCest.php
@@ -1,15 +1,12 @@
 <?php
 class EditContentModelCest {
 	public function i_can_update_an_existing_content_model( AcceptanceTester $I ) {
+		$I->resizeWindow(1024, 1024);
 		$I->loginAsAdmin();
+
 		// First, create a new model.
 		$I->haveContentModel('Candy', 'Candies');
 		$I->wait(1);
-
-		// Modal content is too large for default size
-		// which causes modal title to not be visible
-		// and the link in #wpfooter to overlay Save button.
-		$I->resizeWindow(1024, 1024);
 
 		// Invoke edit mode.
 		$I->amOnWPEngineContentModelPage();
@@ -17,11 +14,16 @@ class EditContentModelCest {
 		$I->click( '.dropdown-content a.edit' );
 		$I->see( 'Edit Candies' );
 
-		// Update the model data and save.
+		// Update the model data.
 		$I->fillField(['name' => 'singular'], 'Cat');
 		$I->fillField(['name' => 'plural'], 'Cats');
 		$I->fillField(['name' => 'description'], 'Cats are better than candy.');
 		$I->see('27/250', 'span.count');
+
+		// Change the model's icon.
+		$I->click('.dashicons-picker');
+		$I->waitForElement('.dashicon-picker-container');
+		$I->click('.dashicon-picker-container .dashicons-admin-media');
 
 		$I->click('Save');
 
@@ -29,5 +31,9 @@ class EditContentModelCest {
 		$I->wait(1);
 		$I->see('Cats', '.model-list');
 		$I->see('Cats are better than candy.', '.model-list');
+
+		// Check the icon in the WP admin sidebar was updated.
+		$classes = $I->grabAttributeFrom('#menu-posts-candy .wp-menu-image', 'class');
+		$I->assertContains('dashicons-admin-media', $classes);
 	}
 }


### PR DESCRIPTION
## Description

Corrects a regression introduced in https://github.com/wpengine/atlas-content-modeler/pull/246 where the model icon picker appears below the edit model modal due to a z-index change.

Reported in [this WP.org review](https://wordpress.org/support/topic/great-start-53/) (item 1).

## Testing

I extended the existing edit model e2e test with an icon change check to prevent future regressions.

### Manual test
1. Create a model with a custom icon.
2. Edit the model and change the custom icon.

## Screenshots

| Before (current `main`) | After (this PR) |
| - | - |
| <img width="552" alt="Screenshot 2021-10-07 at 17 30 56" src="https://user-images.githubusercontent.com/647669/136544263-d9526191-6d09-42cd-ad32-527c3d7eefc0.png"> | <img width="398" alt="Screenshot 2021-10-08 at 12 46 06" src="https://user-images.githubusercontent.com/647669/136544295-0fad6d29-27d0-4c28-befa-6078620b6010.png"> |


## Documentation Changes

n/a

## Dependant PRs

n/a