### PR TITLE
[BH-1168] Ensure we can set a step without a max setting

### DIFF
--- a/includes/settings/js/src/components/fields/AdvancedSettings.jsx
+++ b/includes/settings/js/src/components/fields/AdvancedSettings.jsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import Icon from "../../../../../components/icons";
-import { sprintf, __ } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 
 const MediaSettings = ({
 	errors,

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -117,6 +117,9 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 						v || parseNumber(v) === 0 ? parseNumber(v) : "",
 					validate: {
 						maxBelowStep: (v) => {
+							if (getValues("maxValue") === "") {
+								return true;
+							}
 							const max = parseNumber(
 								Math.abs(getValues("maxValue"))
 							);

--- a/tests/acceptance/CreateContentModelNumberFieldCest.php
+++ b/tests/acceptance/CreateContentModelNumberFieldCest.php
@@ -22,4 +22,20 @@ class CreateContentModelNumberFieldCest
         $I->see('Number', '.field-list div.type');
         $I->see('Count', '.field-list div.widest');
     }
+
+    public function i_can_add_a_step_setting_without_a_max_setting(AcceptanceTester $I)
+    {
+        $I->loginAsAdmin();
+        $I->haveContentModel('Candy', 'Candies');
+        $I->wait(1);
+
+        $I->click('Number', '.field-buttons');
+		$I->wait(1);
+
+        $I->click('button.settings');
+        $I->fillField(['name' => 'minValue'], '1');
+        $I->fillField(['name' => 'step'], '2');
+        $I->dontSee('Step must be lower than max.', '.error');
+
+    }
 }


### PR DESCRIPTION
## Description

Ensures we can set a counting step without a max value.

https://wpengine.atlassian.net/browse/BH-1168

## Testing

Adds appropriate acceptance testing to prevent future regressions.

## Screenshots

<img width="679" alt="Screen Shot 2021-10-07 at 13 05 10" src="https://user-images.githubusercontent.com/394675/136433313-1dd8c62d-cbd2-4ef2-88b7-65bffe055f59.png">

<img width="629" alt="Screen Shot 2021-10-07 at 13 05 25" src="https://user-images.githubusercontent.com/394675/136433327-68768fff-4b1a-4baf-8bde-6696aa3a3024.png">


