### PR TITLE
[BH-1283] Fix: ensure imports work with plain WP permalinks

### DIFF
--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -64,6 +64,10 @@ function create_models( array $models ) {
 	$content_types          = get_registered_content_types();
 
 	foreach ( $models as $model ) {
+		if ( ! is_array( $model ) ) {
+			continue;
+		}
+
 		$args = get_model_args( $model['slug'] ?? '', $model );
 
 		if ( is_wp_error( $args ) ) {

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ Publishers get friendly and familiar content entry pages.
 
 - WordPress 5.7 or higher.
 - PHP 7.2 or higher.
+- We recommend that you set Permalinks to a value other than “Plain” in your WordPress dashboard at Settings → Permalinks.
 
 ## Setup
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ It can also be installed manually using a zip file.
 4. Click the **Choose File** button, select the zip file you downloaded in step 1, then click the **Install Now** button.
 5. Click the **Activate Plugin** button.
 
+We recommend that you set Permalinks to a value other than “Plain” in your WordPress dashboard at Settings → Permalinks.
+
 == Screenshots ==
 1. Creating a new content model
 2. Adding a Text field to a content model


### PR DESCRIPTION
Fixes an issue where imports would fail with this message with WP permalinks set to “Plain”:

> Uncaught TypeError:
> WPE\AtlasContentModeler\REST_API\Models\get_model_args():
> Argument #2 ($args) must be of type array, string given,

This is because WP sends additional data with the body of the request
if permalinks are plain:

```
(
    // Unexpected non-array value:
    [rest_route] => /wpe/atlas/content-models
    // Expected data for models starts here:
    [0] => Array
        (
```

When we pass "/wpe/atlas/content-models" to `get_model_args()` it fails because it's not an array of model data.

For https://wpengine.atlassian.net/browse/BH-1283

## Testing

There was no existing import test to extend here. (We opted not to write e2e tests for the import feature for now because the UI is set to change significantly during the upcoming phase 2 of the import work.)

### Manual test

1. In your WordPress dashboard, set Settings → Permalinks to Plain.
2. Export your content models at Atlas Content Modeler → Tools.
3. Delete your content models.
4. Import your models from the exported file at Atlas Content Modeler → Tools.

Remember to set your permalinks back to “Post name” or similar once you're done. :-)

## Documentation

Even though it is no longer essential after this fix, I added a note to docs to recommend pretty permalinks. It will help with general Atlas integration to use something other than plain permalinks.