### PR TITLE
fix: add isset check to avoid undefined index notices

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -87,7 +87,7 @@ function register_relationships( $registry ) {
 	}
 
 	foreach ( $models as $model => $args ) {
-		if ( ! $args['fields'] ) {
+		if ( ! isset( $args['fields'] ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
## Description

Adds an `isset()` check to avoid "Undefined index: fields" notices

