### PR TITLE
[NOJIRA] Fix publisher description text color

### DIFF
--- a/includes/publisher/scss/_classic-form.scss
+++ b/includes/publisher/scss/_classic-form.scss
@@ -1,3 +1,4 @@
+$color-gray-mid: #405e6a;
 $form-purple: #7e5cef;
 $form-default-border-gray: #9db7d1;
 $error-red: #d21b46;
@@ -330,8 +331,12 @@ $button-primary: #002838;
 			margin-right: 8px;
 		}
 
+		.help {
+			color: $color-gray-mid;
+		}
+
 		.required {
-			color: #405e6a;
+			color: $color-gray-mid;
 			font-size: 12px;
 			margin-bottom: 0;
 		}


### PR DESCRIPTION
## Description

A styling tweak to address feedback from @mindctrl at https://github.com/wpengine/atlas-content-modeler/pull/323#pullrequestreview-780028594.

## Testing

No automated tests needed.


### Manual testing

1. Add a description to a field.
2. Add an entry and check the description text appears using the expected `#405E6A` color from Figma.

## Screenshots

<img width="1379" alt="Screenshot 2021-10-15 at 10 42 33" src="https://user-images.githubusercontent.com/647669/137459074-97858e90-c0d4-4519-ab61-181dcf393181.png">

## Documentation Changes

n/a

## Dependant PRs

n/a