### PR TITLE
[BH-1263] Ensure p2p library respects cardinality

### DIFF
--- a/includes/content-connect/includes/Relationships/PostToPost.php
+++ b/includes/content-connect/includes/Relationships/PostToPost.php
@@ -321,21 +321,19 @@ class PostToPost extends Relationship {
 
 		switch ( $this->cardinality ) {
 			case 'one-to-one':
-				foreach ( $forward_relationships as $relationship ) {
-					if ( intval( $relationship ) === $post_id_1 ) {
-						return false;
-					}
-				}
-				foreach ( $reverse_relationships as $relationship ) {
-					if ( intval( $relationship ) === $post_id_2 ) {
-						return false;
-					}
+				if ( ! empty( $forward_relationships ) || ! empty( $reverse_relationships ) ) {
+					return false;
 				}
 				break;
 			case 'many-to-one':
-				return false;
+				if ( ! empty( $forward_relationships ) ) {
+					return false;
+				}
+				break;
 			case 'one-to-many':
-				return false;
+				if ( ! empty( $reverse_relationships ) ) {
+					return false;
+				}
 		};
 
 		return true;

--- a/includes/content-connect/includes/Relationships/PostToPost.php
+++ b/includes/content-connect/includes/Relationships/PostToPost.php
@@ -71,11 +71,10 @@ class PostToPost extends Relationship {
 	 *
 	 * @param int  $post_id Post ID.
 	 * @param bool $order_by_relationship Order By Relationship.
-	 * @param bool $is_reverse Set to true if we're looking for reverse relationships.
 	 *
 	 * @return array
 	 */
-	public function get_related_object_ids( $post_id, $order_by_relationship = false, $is_reverse = false ) {
+	public function get_related_object_ids( $post_id, $order_by_relationship = false ) {
 		// phpcs:ignore
 		/** @var \WPE\AtlasContentModeler\ContentConnect\Tables\PostToPost $table */
 		$table = Plugin::instance()->get_table( 'p2p' );

--- a/includes/content-connect/includes/Relationships/PostToPost.php
+++ b/includes/content-connect/includes/Relationships/PostToPost.php
@@ -310,14 +310,22 @@ class PostToPost extends Relationship {
 	/**
 	 * Checks for cardinality
 	 *
-	 * @param int $post_id_1 Post ID 1.
-	 * @param int $post_id_2 Post ID 2.
+	 * Ensures a given pair of posts would respect the given relationship's cardinality.
 	 *
-	 * @return boolean
+	 * @param int $post_id_1 The first post to add to the relationship.
+	 * @param int $post_id_2 The 2nd post to add to the relationship.
+	 *
+	 * @return boolean True if cardinality is correct or false if the relationship would break cardinality.
 	 */
 	protected function check_cardinality( $post_id_1, $post_id_2 ) {
-		$forward_relationships = $this->get_related_object_ids( $post_id_1 );
-		$reverse_relationships = $this->get_related_object_ids( $post_id_2 );
+		// We need to make sure post_id_1 is always the "from" type of the relationship to ensure cardinality is checked in the correct direction.
+		if ( $this->from === get_post_type( $post_id_1 ) ) {
+			$forward_relationships = $this->get_related_object_ids( $post_id_1 );
+			$reverse_relationships = $this->get_related_object_ids( $post_id_2 );
+		} else {
+			$forward_relationships = $this->get_related_object_ids( $post_id_2 );
+			$reverse_relationships = $this->get_related_object_ids( $post_id_1 );
+		}
 
 		switch ( $this->cardinality ) {
 			case 'one-to-one':

--- a/includes/content-connect/includes/Relationships/Relationship.php
+++ b/includes/content-connect/includes/Relationships/Relationship.php
@@ -122,7 +122,7 @@ abstract class Relationship {
 		$this->enable_to_ui = $args['to']['enable_ui'];
 		$this->to_sortable  = $args['to']['sortable'];
 		$this->to_labels    = $args['to']['labels'];
-		$this->cardinality  = 'one-to-one';
+		$this->cardinality  = 'many-to-many';
 	}
 
 	/**

--- a/includes/content-connect/includes/Relationships/Relationship.php
+++ b/includes/content-connect/includes/Relationships/Relationship.php
@@ -78,6 +78,13 @@ abstract class Relationship {
 	public $is_bidirectional;
 
 	/**
+	 * The relationship cardinality.
+	 *
+	 * @var [type]
+	 */
+	public $cardinality;
+
+	/**
 	 * Undocumented function
 	 *
 	 * @param string $name Name.
@@ -115,6 +122,7 @@ abstract class Relationship {
 		$this->enable_to_ui = $args['to']['enable_ui'];
 		$this->to_sortable  = $args['to']['sortable'];
 		$this->to_labels    = $args['to']['labels'];
+		$this->cardinality  = 'one-to-one';
 	}
 
 	/**

--- a/tests/content-connect/integration/Relationships/PostToPostTest.php
+++ b/tests/content-connect/integration/Relationships/PostToPostTest.php
@@ -291,6 +291,79 @@ class PostToPostTest extends ContentConnectTestCase {
 		$this->assertEquals( 1, $wpdb->get_var( "select count(id1) from {$wpdb->prefix}acm_post_to_post where id1=1 and id2=6 and `name`='basic';" ) );
 	}
 
+	public function test_one_to_one_restriction() {
+		$pp              = new PostToPost( 'post', 'post', 'basic' );
+		$pp->cardinality = 'one-to-one';
 
+		$pairs = array(
+			array( 1, 2 ),
+			array( 1, 5 ),
+			array( 3, 8 ),
+			array( 3, 9 ),
+		);
 
+		$results = array();
+
+		foreach ( $pairs as $pair ) {
+			$results[] = $pp->add_relationship( $pair[0], $pair[1] );
+		}
+
+		$this->assertTrue( $results[0] );
+		$this->assertTrue( $results[2] );
+
+		$this->assertFalse( $results[1] );
+		$this->assertFalse( $results[3] );
+	}
+
+	public function test_one_to_many_restriction() {
+		$pp              = new PostToPost( 'post', 'post', 'basic' );
+		$pp->cardinality = 'one-to-many';
+
+		$pairs = array(
+			array( 1, 2 ),
+			array( 1, 5 ),
+			array( 4, 2 ),
+			array( 3, 8 ),
+			array( 3, 9 ),
+			array( 7, 3 ),
+		);
+
+		$results = array();
+
+		foreach ( $pairs as $pair ) {
+			$results[] = $pp->add_relationship( $pair[0], $pair[1] );
+		}
+
+		$this->assertTrue( $results[0] );
+		$this->assertTrue( $results[1] );
+		$this->assertTrue( $results[3] );
+		$this->assertTrue( $results[4] );
+
+		$this->assertFalse( $results[2] );
+		$this->assertFalse( $results[5] );
+	}
+
+	public function test_many_to_one_restriction() {
+		$pp              = new PostToPost( 'post', 'post', 'basic' );
+		$pp->cardinality = 'many-to-one';
+
+		$pairs = array(
+			array( 1, 2 ),
+			array( 1, 5 ),
+			array( 3, 8 ),
+			array( 3, 9 ),
+		);
+
+		$results = array();
+
+		foreach ( $pairs as $pair ) {
+			$results[] = $pp->add_relationship( $pair[0], $pair[1] );
+		}
+
+		$this->assertTrue( $results[0] );
+		$this->assertTrue( $results[2] );
+
+		$this->assertFalse( $results[1] );
+		$this->assertFalse( $results[3] );
+	}
 }


### PR DESCRIPTION
## Description

Ensures the posts-to-posts library respects cardinality by failing to add new relationships that would violate cardinality by throwing a "false" from the add_relationships menu. This can then be worked into our front-end in BH-1264.

https://wpengine.atlassian.net/browse/BH-1263

## Testing

New unit tests have been added to check each of the cardinality restrictions. Please pay close attention to these in review. I think they're right but, after a while, such logic becomes circular and bugs are too easy to miss.

## Technical notes

There isn't much we can do just with this until we finish BH-1262. This simply applies a method for BH-1262 to use. Note this assumes a `cardinality` param on any relationships object to function.
