### PR TITLE
[BH-1219] Ensure max ID size matches model name

### DIFF
--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -106,7 +106,7 @@ function create_models( array $models ) {
 function get_model_args( string $post_type_slug, array $args ) {
 	$post_type_slug = sanitize_key( $post_type_slug );
 
-	if ( empty( $post_type_slug ) || strlen( $post_type_slug ) > 50 ) {
+	if ( empty( $post_type_slug ) || strlen( $post_type_slug ) > 20 ) {
 		return new WP_Error(
 			'atlas_content_modeler_invalid_id',
 			__( 'Please provide a valid Model ID.', 'atlas-content-modeler' ),

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -106,7 +106,7 @@ function create_models( array $models ) {
 function get_model_args( string $post_type_slug, array $args ) {
 	$post_type_slug = sanitize_key( $post_type_slug );
 
-	if ( empty( $post_type_slug ) || strlen( $post_type_slug ) > 20 ) {
+	if ( empty( $post_type_slug ) || strlen( $post_type_slug ) > 50 ) {
 		return new WP_Error(
 			'atlas_content_modeler_invalid_id',
 			__( 'Please provide a valid Model ID.', 'atlas-content-modeler' ),

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -4,7 +4,7 @@ import { Link, useHistory } from "react-router-dom";
 import { ModelsContext } from "../ModelsContext";
 import { insertSidebarMenuItem } from "../utils";
 import { useInputGenerator } from "../hooks";
-import { toPostTypeSlug } from "../formats";
+import { toSanitizedKey } from "../formats";
 import { showSuccess } from "../toasts";
 import Icon from "../../../../components/icons";
 import IconPicker from "./IconPicker";
@@ -37,7 +37,7 @@ export default function CreateContentModel() {
 		onChangeGeneratedValue,
 	} = useInputGenerator({
 		setGeneratedValue: (value) => setValue("slug", value),
-		format: toPostTypeSlug,
+		format: toSanitizedKey,
 	});
 
 	function apiCreateModel(data) {

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -215,7 +215,7 @@ export default function CreateContentModel() {
 							id="slug"
 							name="slug"
 							className="w-100"
-							ref={register({ required: true, maxLength: 20 })}
+							ref={register({ required: true, maxLength: 50 })}
 							onChange={(e) =>
 								onChangeGeneratedValue(e.target.value)
 							}
@@ -237,7 +237,7 @@ export default function CreateContentModel() {
 									<Icon type="error" />
 									<span role="alert">
 										{__(
-											"Exceeds max length of 20.",
+											"Exceeds max length of 50.",
 											"atlas-content-modeler"
 										)}
 									</span>

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -215,7 +215,7 @@ export default function CreateContentModel() {
 							id="slug"
 							name="slug"
 							className="w-100"
-							ref={register({ required: true, maxLength: 50 })}
+							ref={register({ required: true, maxLength: 20 })}
 							onChange={(e) =>
 								onChangeGeneratedValue(e.target.value)
 							}
@@ -237,7 +237,7 @@ export default function CreateContentModel() {
 									<Icon type="error" />
 									<span role="alert">
 										{__(
-											"Exceeds max length of 50.",
+											"Exceeds max length of 20.",
 											"atlas-content-modeler"
 										)}
 									</span>

--- a/includes/settings/js/src/components/TaxonomiesForm.jsx
+++ b/includes/settings/js/src/components/TaxonomiesForm.jsx
@@ -5,7 +5,7 @@ import { ModelsContext } from "../ModelsContext";
 import Icon from "../../../../components/icons";
 import { showSuccess } from "../toasts";
 import { useInputGenerator } from "../hooks";
-import { toPostTypeSlug as toSanitizedKey } from "../formats";
+import { toSanitizedKey } from "../formats";
 
 const { apiFetch } = wp;
 const { isEqual, pick } = lodash;
@@ -28,13 +28,15 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 		},
 	});
 
+	const SLUG_MAX_LENGTH = 32;
+
 	const {
 		setFieldsAreLinked,
 		setInputGeneratorSourceValue,
 		onChangeGeneratedValue,
 	} = useInputGenerator({
 		setGeneratedValue: (value) => setValue("slug", value),
-		format: toSanitizedKey,
+		format: (key) => toSanitizedKey(key, SLUG_MAX_LENGTH),
 	});
 
 	const successMessage = editingTaxonomy
@@ -281,7 +283,7 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 					readOnly={editingTaxonomy !== null}
 					ref={register({
 						required: true,
-						maxLength: 32,
+						maxLength: SLUG_MAX_LENGTH,
 					})}
 					onChange={(e) => {
 						onChangeGeneratedValue(e.target.value);
@@ -303,9 +305,13 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 						<span className="error">
 							<Icon type="error" />
 							<span role="alert">
-								{__(
-									"Exceeds max length of 32",
-									"atlas-content-modeler"
+								{sprintf(
+									__(
+										// Translators: the maximum character length.
+										"Exceeds max length of %d",
+										"atlas-content-modeler"
+									),
+									SLUG_MAX_LENGTH
 								)}
 							</span>
 						</span>

--- a/includes/settings/js/src/formats/formats.test.js
+++ b/includes/settings/js/src/formats/formats.test.js
@@ -29,15 +29,12 @@ describe("toPostTypeSlug", () => {
 		["strip accented éîøü", "stripaccented"],
 		["strips    white    spaces", "stripswhitespaces"],
 		["     trim_white_space     ", "trim_white_space"],
-		["1allow_leading_number", "1allow_leading_number"],
-		["123allow_leading_numbers", "123allow_leading_numbers"],
-		["Lower_case_All_the_THINGS", "lower_case_all_the_things"],
-		["_allows_leading_underscore", "_allows_leading_underscore"],
+		["1allow_leading_number", "1allow_leading_numbe"],
+		["123allow_leading_numbers", "123allow_leading_num"],
+		["Lower_case_All_the_THINGS", "lower_case_all_the_t"],
+		["_allows_leading_underscore", "_allows_leading_unde"],
 		["-Allows-Hypens-", "-allows-hypens-"],
-		[
-			"allow numbers after 1st character123",
-			"allownumbersafter1stcharacter123",
-		],
+		["allow n after 1st c123", "allownafter1stc123"],
 	];
 
 	test.each(cases)("toPostTypeSlug(%s) should be %s", (input, expected) => {

--- a/includes/settings/js/src/formats/formats.test.js
+++ b/includes/settings/js/src/formats/formats.test.js
@@ -1,4 +1,4 @@
-import { toValidApiId, toPostTypeSlug } from ".";
+import { toValidApiId, toSanitizedKey } from ".";
 
 describe("toValidApiId", () => {
 	const cases = [
@@ -22,7 +22,7 @@ describe("toValidApiId", () => {
 	});
 });
 
-describe("toPostTypeSlug", () => {
+describe("toSanitizedKey", () => {
 	const cases = [
 		[",,,#!!!strip_punctuation???$...", "strip_punctuation"],
 		["⚠️⚠️⚠️strip_emoji🐇🐇🐇", "strip_emoji"],
@@ -37,7 +37,11 @@ describe("toPostTypeSlug", () => {
 		["allow n after 1st c123", "allownafter1stc123"],
 	];
 
-	test.each(cases)("toPostTypeSlug(%s) should be %s", (input, expected) => {
-		expect(toPostTypeSlug(input)).toEqual(expected);
+	test.each(cases)("toSanitizedKey(%s) should be %s", (input, expected) => {
+		expect(toSanitizedKey(input)).toEqual(expected);
+	});
+
+	test("limits character length to a custom value", () => {
+		expect(toSanitizedKey("abcdefghi", 3)).toEqual("abc");
 	});
 });

--- a/includes/settings/js/src/formats/index.js
+++ b/includes/settings/js/src/formats/index.js
@@ -27,21 +27,22 @@ export function toValidApiId(value) {
 }
 
 /**
- * Formats a given string to a valid post type slug.
+ * Formats a given string to a valid slug for use in taxonomies or post types.
  *
  * @see https://developer.wordpress.org/reference/functions/sanitize_key/
- * @param {string} value The input value to convert to a valid post type slug.
+ * @param {string} value The input value to convert to a valid slug.
+ * @param {number} length Maximium character length of the returned slug.
  * @returns A valid post type slug.
  */
-export function toPostTypeSlug(value) {
+export function toSanitizedKey(value, length = 20) {
 	// Must be all lower case.
 	value = value.toLowerCase();
 
 	// Strip all characters not in the range [a-z0-9_\-].
 	value = value.replace(/[^a-z0-9_\-]/g, "");
 
-	// Limit the substring we set to 20 chars which is the max for a post type.
-	value = value.substring(0, 20);
+	// Limit the generated value to a maximum length.
+	value = value.substring(0, length);
 
 	return value;
 }

--- a/includes/settings/js/src/formats/index.js
+++ b/includes/settings/js/src/formats/index.js
@@ -40,5 +40,8 @@ export function toPostTypeSlug(value) {
 	// Strip all characters not in the range [a-z0-9_\-].
 	value = value.replace(/[^a-z0-9_\-]/g, "");
 
+	// Limit the substring we set to 20 chars which is the max for a post type.
+	value = value.substring(0, 20);
+
 	return value;
 }


### PR DESCRIPTION
## Description

This modifies the formatter we use for the slug to limit output to 20 characters.

https://wpengine.atlassian.net/browse/BH-1219

## Testing

No additional tests were necessary however the expected values of existing tests were modified to match the expected output.
