### PR TITLE
[BH-1262] Register relationship cardinality from field cardinality property at runtime

### DIFF
--- a/includes/content-connect/includes/Relationships/Relationship.php
+++ b/includes/content-connect/includes/Relationships/Relationship.php
@@ -88,6 +88,7 @@ abstract class Relationship {
 
 		$defaults = array(
 			'is_bidirectional' => true,
+			'cardinality'      => 'many-to-many',
 			'from'             => array(
 				'enable_ui' => true,
 				'sortable'  => false,
@@ -107,6 +108,7 @@ abstract class Relationship {
 		$args = array_replace_recursive( $defaults, $args );
 
 		$this->is_bidirectional = $args['is_bidirectional'];
+		$this->cardinality      = $args['cardinality'];
 
 		$this->enable_from_ui = $args['from']['enable_ui'];
 		$this->from_sortable  = $args['from']['sortable'];

--- a/includes/content-connect/includes/Relationships/Relationship.php
+++ b/includes/content-connect/includes/Relationships/Relationship.php
@@ -78,6 +78,13 @@ abstract class Relationship {
 	public $is_bidirectional;
 
 	/**
+	 * The relationship cardinality, such as "many-to-many".
+	 *
+	 * @var string
+	 */
+	public $cardinality;
+
+	/**
 	 * Undocumented function
 	 *
 	 * @param string $name Name.

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -95,6 +95,7 @@ function register_relationships( $registry ) {
 			if ( $field['type'] === 'relationship' ) {
 				$args = [
 					'is_bidirectional' => true,
+					'cardinality'      => $field['cardinality'],
 					'from'             => [
 						'enable_ui' => true,
 						'sortable'  => false,


### PR DESCRIPTION
## Description

Adjusts `define_post_to_post` to pass the cardinality from the field to the PostToPost constructor.

This is used in the logic introduced in https://github.com/wpengine/atlas-content-modeler/pull/329 to enforce cardinality when adding new relationships.

Jira [BH-1262](https://wpengine.atlassian.net/browse/BH-1262) says:

> Final Cardinality Enforcing define_post_to_post will look like the following: 
>
> $relationship = $registry->define_post_to_post( ‘car’, ‘tire’, [field id], [cardinality] )
> 
> Bidirectional and sortable options (existing args for the libraries options) should be assumed true all other options can be removed from any custom functions.

Because this blocks other work on relationship fields, we talked about breaking this into two stories:

- Limit the scope of BH-1262 to pass the cardinality using the existing `$args` parameter, as in this PR.
- Add a separate story to remove any unused features of the Relationships class and move to backlog. Rationale:
    - Changing the method signature to pass `$cardinality` as the final argument instead of `$args` is a breaking change.
    - The change isn't required to meet the goal of registering cardinality.
    - It requires refactoring tests and all calling code.
    - It presumes we definitely will not need the option to conditionally hide UI later (this may be useful to hide fields for certain user types, for example). I think it may be too early to say for sure that we do not need it.

https://wpengine.atlassian.net/browse/BH-1262

## Testing

Code review only.

Chris's existing tests from https://github.com/wpengine/atlas-content-modeler/pull/329 plus tests we add to show entry status in the relationship modal will cover this added functionality.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

n/a