### PR TITLE
[BH-1294] Ensure we're properly accounting for underscores and dashes in names

### DIFF
--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useRef, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import Modal from "react-modal";
-import { useLocationSearch, getGraphQLType } from "../../utils";
+import { useLocationSearch } from "../../utils";
 import Icon from "acm-icons";
 import TextFields from "./TextFields";
 import {
@@ -15,7 +15,7 @@ import RelationshipFields from "./RelationshipFields";
 import supportedFields from "./supportedFields";
 import { ModelsContext } from "../../ModelsContext";
 import { useInputGenerator, useReservedSlugs } from "../../hooks";
-import { toValidApiId } from "../../formats";
+import { toValidApiId, toGraphQLType } from "../../formats";
 import { __ } from "@wordpress/i18n";
 
 const { apiFetch } = wp;
@@ -70,7 +70,7 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 	const originalValues = useRef({});
 	const reservedSlugs = editing
 		? false
-		: useReservedSlugs(getGraphQLType(models[model]?.singular));
+		: useReservedSlugs(toGraphQLType(models[model]?.singular));
 
 	const advancedSettings = {
 		text: {

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -70,7 +70,7 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 	const originalValues = useRef({});
 	const reservedSlugs = editing
 		? false
-		: useReservedSlugs(toGraphQLType(models[model]?.singular));
+		: useReservedSlugs(toGraphQLType(models[model]?.singular, true));
 
 	const advancedSettings = {
 		text: {

--- a/includes/settings/js/src/formats/formats.test.js
+++ b/includes/settings/js/src/formats/formats.test.js
@@ -1,4 +1,4 @@
-import { toValidApiId, toSanitizedKey } from ".";
+import { toValidApiId, toSanitizedKey, toGraphQLType } from ".";
 
 describe("toValidApiId", () => {
 	const cases = [
@@ -44,4 +44,32 @@ describe("toSanitizedKey", () => {
 	test("limits character length to a custom value", () => {
 		expect(toSanitizedKey("abcdefghi", 3)).toEqual("abc");
 	});
+});
+
+describe("toGraphQLType", () => {
+	const cases = [
+		[",,,#!!!strip_punctuation???$...", "stripPunctuation", false],
+		["⚠️⚠️⚠️strip_emoji🐇🐇🐇", "stripEmoji", false],
+		["strip accented éîøü", "stripAccented", false],
+		["1strip_leading_number", "stripLeadingNumber", false],
+		["123strip_leading_numbers", "stripLeadingNumbers", false],
+		["     trim_white_space     ", "trimWhiteSpace", false],
+		["Lower_case_initial_capitals", "lowerCaseInitialCapitals", false],
+		["_removes_leading_underscore", "removesLeadingUnderscore", false],
+		["camel case    white    spaces", "camelCaseWhiteSpaces", false],
+		["cap-first-word-with-dashes", "CapFirstWordWithDashes", true],
+		["cap-first-word-with-spaces", "CapFirstWordWithSpaces", true],
+		[
+			"cap-first-word-with-underscores",
+			"CapFirstWordWithUnderscores",
+			true,
+		],
+	];
+
+	test.each(cases)(
+		"toGraphQLType(%s) should be %s",
+		(input, expected, capFirst) => {
+			expect(toGraphQLType(input, capFirst)).toEqual(expected);
+		}
+	);
 });

--- a/includes/settings/js/src/formats/index.js
+++ b/includes/settings/js/src/formats/index.js
@@ -7,6 +7,9 @@
  * @return {string} The valid API ID.
  */
 export function toValidApiId(value) {
+	// Replaces dashes and underscores with spaces for further processing into camelcase later.
+	value = value.replace(/[_\-]/g, " ");
+
 	// Strip all characters not in the range [_0-9A-Za-z ].
 	// Preserve spaces for now to turn “camel case” into “camelCase” later.
 	value = value.replace(/[^_0-9A-Za-z ]/g, "");

--- a/includes/settings/js/src/formats/index.js
+++ b/includes/settings/js/src/formats/index.js
@@ -7,6 +7,33 @@
  * @return {string} The valid API ID.
  */
 export function toValidApiId(value) {
+	// Strip all characters not in the range [_0-9A-Za-z ].
+	// Preserve spaces for now to turn “camel case” into “camelCase” later.
+	value = value.replace(/[^_0-9A-Za-z ]/g, "");
+
+	// Strip leading numbers.
+	value = value.replace(/^[0-9]+/, "");
+
+	// Turn [space character] into the uppercase character.
+	value = value.replace(/ ([a-z])/g, (match) => match.trim().toUpperCase());
+
+	// Strip any remaining spaces.
+	value = value.replace(/\s/g, "");
+
+	// Lowercase the first letter. Not required by the GraphQL spec, but consistent with common usage.
+	value = value.replace(/^[A-Z]/g, (match) => match.toLowerCase());
+
+	return value;
+}
+
+/**
+ * Converts a string to a valid GraphQL type for use in generating GraphQL schema items.
+ *
+ * @param {string} value The string to convert
+ * @param {boolean} capFirst True if first word should be caps or false.
+ * @returns {string} The valid GraphQL type
+ */
+export function toGraphQLType(value, capFirst = false) {
 	// Replaces dashes and underscores with spaces for further processing into camelcase later.
 	value = value.replace(/[_\-]/g, " ");
 
@@ -23,8 +50,13 @@ export function toValidApiId(value) {
 	// Strip any remaining spaces.
 	value = value.replace(/\s/g, "");
 
-	// Lowercase the first letter. Not required by the GraphQL spec, but consistent with common usage.
-	value = value.replace(/^[A-Z]/g, (match) => match.toLowerCase());
+	if (capFirst) {
+		// Uppercase the first letter to match GraphQL expectations.
+		value = value.replace(/^[a-z]/g, (match) => match.toUpperCase());
+	} else {
+		// Lowercase the first letter. Not required by the GraphQL spec, but consistent with common usage.
+		value = value.replace(/^[A-Z]/g, (match) => match.toLowerCase());
+	}
 
 	return value;
 }

--- a/includes/settings/js/src/utils.js
+++ b/includes/settings/js/src/utils.js
@@ -1,6 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { getFieldOrder, sanitizeFields } from "./queries";
-import { toValidApiId } from "./formats";
+import { toGraphQLType } from "./formats";
 import { __ } from "@wordpress/i18n";
 
 /**
@@ -93,19 +93,6 @@ export const maybeCloseDropdown = (setDropdownOpen, timer) => {
 };
 
 /**
- * Generates the GraphQL type name from the model's singular name.
- *
- * GraphQL's "types" have an initial capital.
- *
- * @param {object} singularName The model's singular name.
- * @return {string} The GraphQL type name.
- */
-export const getGraphQLType = (singularName = "") =>
-	toValidApiId(singularName).replace(/^[a-z]/, (match) =>
-		match.toUpperCase()
-	);
-
-/**
  * Generates a link to open WPGraphQL's GraphiQL query editor in WP admin.
  *
  * Prefills the GraphiQL query with a request for the first 10 posts of the
@@ -115,11 +102,11 @@ export const getGraphQLType = (singularName = "") =>
  * @return {string} The GraphiQL URL with query param prefilled.
  */
 export const getGraphiQLLink = (modelData) => {
-	const graphQLType = getGraphQLType(modelData.singular);
+	const graphQLType = toGraphQLType(modelData.singular, true);
 	const fragmentName = `${graphQLType}Fields`;
 	const rootToTypeConnectionFieldName =
 		modelData.singular !== modelData.plural
-			? toValidApiId(modelData.plural)
+			? toGraphQLType(modelData.plural)
 			: "all" + graphQLType;
 
 	const fields = sanitizeFields(modelData?.fields);


### PR DESCRIPTION
## Description

Previously GraphiQL links were broken when a model used a dash or underscore in the model names as we weren't properly accounting for the characters to generate proper GraphQL names (no camelcase). This fixes that by converting those characters to better match the GraphQLi schema.

See the screenshots below to see how sensitive this is in practice.

https://wpengine.atlassian.net/browse/BH-1294


<img width="888" alt="Screen Shot 2021-10-21 at 15 10 57" src="https://user-images.githubusercontent.com/394675/138341969-e93e01e1-f828-40ef-ae3e-809ed2e1188b.png">
<img width="909" alt="Screen Shot 2021-10-21 at 15 11 33" src="https://user-images.githubusercontent.com/394675/138341972-8f8616f5-b45e-4b94-a940-f7d29253a217.png">
<img width="911" alt="Screen Shot 2021-10-21 at 15 11 49" src="https://user-images.githubusercontent.com/394675/138341975-098fcd2e-e804-45f1-8bfa-2497eb0b567b.png">
<img width="861" alt="Screen Shot 2021-10-21 at 15 12 11" src="https://user-images.githubusercontent.com/394675/138341977-6de88e60-403d-4676-ad04-1c11b73040d7.png">

