### PR TITLE
[MTKA-1214] Save post title for new posts as "entry[post id]"

### DIFF
--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -78,7 +78,7 @@ final class FormEditingExperience {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'edit_form_after_title', [ $this, 'render_app_container' ] );
 		add_action( 'save_post', [ $this, 'save_post' ], 10, 2 );
-		add_action( 'wp_insert_post', [ $this, 'set_slug' ], 10, 3 );
+		add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
 		add_filter( 'redirect_post_location', [ $this, 'append_error_to_location' ], 10, 2 );
 		add_action( 'admin_notices', [ $this, 'display_save_post_errors' ] );
 		add_filter( 'the_title', [ $this, 'filter_post_titles' ], 10, 2 );
@@ -247,7 +247,7 @@ final class FormEditingExperience {
 	 * @param bool    $update  Whether this is an existing post being updated.
 	 * @return void
 	 */
-	public function set_slug( int $post_ID, WP_Post $post, bool $update ): void {
+	public function set_post_attributes( int $post_ID, WP_Post $post, bool $update ): void {
 		if ( true === $update ) {
 			// @todo Perhaps check that the slug has not been changed outside of the editor.
 			return;
@@ -264,8 +264,9 @@ final class FormEditingExperience {
 
 		wp_update_post(
 			array(
-				'ID'        => $post_ID,
-				'post_name' => $model_post_slug,
+				'ID'         => $post_ID,
+				'post_name'  => $model_post_slug,
+				'post_title' => 'entry' . $post_ID,
 			)
 		);
 	}

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -5,15 +5,54 @@
  * @package AtlasContentModeler
  */
 
-use function WPE\AtlasContentModeler\FormEditingExperience\set_slug;
+use WPE\AtlasContentModeler\FormEditingExperience;
+use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
 
 /**
  * Class TestContentCreation
  */
 class TestContentCreation extends WP_UnitTestCase {
 
+	private $models;
+	private $post_ids;
+
+	public function setUp() {
+		parent::setUp();
+
+		/**
+		 * Reset the WPGraphQL schema before each test.
+		 * Lazy loading types only loads part of the schema,
+		 * so we refresh for each test.
+		 */
+		WPGraphQL::clear_schema();
+
+		// Start each test with a fresh relationships registry.
+		\WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->setup();
+
+		$this->models = $this->get_models();
+
+		update_registered_content_types( $this->models );
+
+		// @todo why is this not running automatically?
+		do_action( 'init' );
+
+		$this->all_registered_post_types = get_post_types( [], 'objects' );
+
+		$this->post_ids = $this->get_post_ids();
+	}
+
+	private function get_models() {
+		return include dirname( __DIR__ ) . '/api-validation/test-data/models.php';
+	}
+
+	private function get_post_ids() {
+		include_once dirname( __DIR__ ) . '/api-validation/test-data/posts.php';
+
+		return create_test_posts( $this );
+	}
+
 	/**
-	 * Ensure set_slug() does not manipulate slug in post creation.
+	 * Ensure set_post_attributes() does not manipulate slug in post creation.
 	 *
 	 * @return void
 	 */
@@ -32,5 +71,21 @@ class TestContentCreation extends WP_UnitTestCase {
 			$expected,
 			$post->post_name
 		);
+	}
+
+	/**
+	 * Ensure post title is correctly set during post creation.
+	 */
+	public function test_correct_post_title(): void {
+		$form = new FormEditingExperience();
+
+		// Get the initial post.
+		$post = get_post( $this->post_ids['public_post_id'] );
+
+		// Set the post attributes and update the post.
+		$form->set_post_attributes( $this->post_ids['public_post_id'], $post, false );
+		$post = get_post( $this->post_ids['public_post_id'] );
+
+		$this->assertStringStartsWith( 'entry', $post->post_title );
 	}
 }


### PR DESCRIPTION
## Description

Ensures new post titles aren't saved to the posts table as "auto draft" but as "entry[post id]."

https://wpengine.atlassian.net/browse/MTKA-1214

## Testing

Unit tests are included to verify the functionality of the function saving the post information.

## Documentation Changes

I have not, yet, updated documentation. We've been doing changelog at release time though I can do it here if that's appropriate. I could not find a spot in the dev docs to note the change but I am up for suggestions.
