### PR TITLE
NOJIRA: Prevent reverse reference slug conflicting with itself

### DIFF
--- a/includes/rest-api/fields.php
+++ b/includes/rest-api/fields.php
@@ -125,6 +125,39 @@ function content_model_field_exists( string $slug, string $id, string $model_id 
 }
 
 /**
+ * Checks if a relationship field has the same reverse slug as other
+ * relationship fields in the same model.
+ *
+ * @param array $candidate_field The field to check other relationship fields
+ *                               for a reverse slug collision with.
+ * @return bool True if another relationship field has the same reverse slug.
+ */
+function content_model_reverse_slug_exists( $candidate_field ) {
+	$models = get_registered_content_types();
+	$fields = $models[ $candidate_field['model'] ]['fields'] ?? [];
+
+	foreach ( $fields as $current_field ) {
+		$reverse_enabled = $current_field['enableReverse'] ?? false;
+
+		if (
+			$current_field['type'] !== 'relationship' ||
+			$current_field['id'] === $candidate_field['id'] ||
+			! $reverse_enabled
+		) {
+			continue;
+		}
+
+		if (
+			( $current_field['reverseSlug'] ?? '' ) === ( $candidate_field['reverseSlug'] ?? false )
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Checks if a duplicate model identifier (name) exists in the multiple option field.
  *
  * @param array  $names  The available field choice names.

--- a/includes/rest-api/fields.php
+++ b/includes/rest-api/fields.php
@@ -105,31 +105,19 @@ function cleanup_detached_relationship_references( string $slug ) {
  */
 function content_model_field_exists( string $slug, string $id, string $model_id ): bool {
 	$models = get_registered_content_types();
+	$model  = $models[ $model_id ] ?? [];
 
-	foreach ( $models as $current_model => $model ) {
-		if ( ! isset( $model['fields'] ) ) {
+	if ( ! isset( $model['fields'] ) ) {
+		return false;
+	}
+
+	foreach ( $model['fields'] as $field ) {
+		if ( $field['id'] === $id ) {
 			continue;
 		}
 
-		foreach ( $model['fields'] as $field ) {
-			if ( $current_model === $model_id && $field['id'] === $id ) {
-				continue;
-			}
-
-			if ( $model_id === $current_model &&
-			$field['slug'] === $slug ) {
-				return true;
-			}
-
-			if ( 'relationship' === $field['type'] &&
-				$model_id === $field['reference'] &&
-				isset( $field['enableReverse'] ) &&
-				true === $field['enableReverse'] &&
-				isset( $field['reverseSlug'] ) &&
-				$slug === $field['reverseSlug']
-			) {
-				return true;
-			}
+		if ( $field['slug'] === $slug ) {
+			return true;
 		}
 	}
 

--- a/includes/rest-api/fields.php
+++ b/includes/rest-api/fields.php
@@ -130,7 +130,8 @@ function content_model_field_exists( string $slug, string $id, string $model_id 
  *
  * @param array $candidate_field The field to check other relationship fields
  *                               for a reverse slug collision with.
- * @return bool True if another relationship field has the same reverse slug.
+ * @return bool True if another relationship field has the same reverse slug
+ *              and relates to the same model.
  */
 function content_model_reverse_slug_exists( $candidate_field ) {
 	$models = get_registered_content_types();
@@ -148,7 +149,8 @@ function content_model_reverse_slug_exists( $candidate_field ) {
 		}
 
 		if (
-			( $current_field['reverseSlug'] ?? '' ) === ( $candidate_field['reverseSlug'] ?? false )
+			( $current_field['reverseSlug'] ?? '' ) === ( $candidate_field['reverseSlug'] ?? false ) &&
+			( $current_field['reference'] ?? '' ) === ( $candidate_field['reference'] ?? false )
 		) {
 			return true;
 		}

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -264,8 +264,19 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 				) {
 					setError("reference", { type: "invalidRelatedModel" });
 				}
-				if (err.code === "wpe_duplicate_field_reverse_slug") {
-					setError("reverseSlug", { type: "reverseIdExists" });
+				if (
+					err.code === "atlas_content_modeler_reverse_slug_conflict"
+				) {
+					setError("reverseSlug", {
+						type: "reverseIdConflicts",
+						message: err.message,
+					});
+				}
+				if (err.code === "atlas_content_modeler_reverse_slug_in_use") {
+					setError("reverseSlug", {
+						type: "reverseIdInUse",
+						message: err.message,
+					});
 				}
 				if (err.code === "atlas_content_modeler_reserved_field_slug") {
 					setError("slug", { type: "nameReserved" });

--- a/includes/settings/js/src/components/fields/RelationshipFields.jsx
+++ b/includes/settings/js/src/components/fields/RelationshipFields.jsx
@@ -359,14 +359,13 @@ const RelationshipFields = ({
 								</span>
 							)}
 						{errors.reverseSlug &&
-							errors.reverseSlug.type === "reverseIdExists" && (
+							(errors.reverseSlug.type === "reverseIdConflicts" ||
+								errors.reverseSlug.type ===
+									"reverseIdInUse") && (
 								<span className="error">
 									<Icon type="error" />
 									<span role="alert">
-										{__(
-											"A field in the related model has the same API identifier.",
-											"atlas-content-modeler"
-										)}
+										{errors.reverseSlug.message}
 									</span>
 								</span>
 							)}

--- a/tests/acceptance/CreateContentModelRelationFieldCest.php
+++ b/tests/acceptance/CreateContentModelRelationFieldCest.php
@@ -1,4 +1,5 @@
 <?php
+use Codeception\Util\Locator;
 
 class CreateContentModelRelationFieldCest {
 
@@ -6,6 +7,13 @@ class CreateContentModelRelationFieldCest {
 		$i->maximizeWindow();
 		$i->loginAsAdmin();
 		$i->haveContentModel( 'Employee', 'Employees' );
+		$i->wait( 1 );
+		// Create a text field to check for reverse relationship conflicts with a reference model.
+		$i->click( 'Text', '.field-buttons' );
+		$i->fillField( [ 'name' => 'name' ], 'conflictsWithEmployeesSlug' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+
 		$i->haveContentModel( 'Company', 'Companies' );
 		$i->wait( 1 );
 		$i->click( 'Relation', '.field-buttons' );
@@ -104,5 +112,53 @@ class CreateContentModelRelationFieldCest {
 		$i->click( '.open-field button.primary' );
 		$i->wait( 1 );
 		$i->see( 'Exceeds max length' );
+	}
+
+	public function i_can_see_warnings_when_a_reverse_relationship_slug_conflicts( AcceptanceTester $i ) {
+		// Attempt to create a relationship field with a reverse slug that
+		// conflicts with a field slug in the reference model.
+		$i->selectOption( '#reference', 'Employees' );
+		$i->click( '#enable-reverse' );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'reverseName' ], 'conflictsWithEmployeesSlug' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+		$i->see( 'A field in the employee model has the same identifier' );
+
+		// Resolve the reverse slug conflict and save the field.
+		$i->fillField( [ 'name' => 'reverseName' ], 'resolveConflict' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+		$i->see( 'Company Employees', '.field-list div.widest' ); // Field was created successfully.
+
+		// Attempt to create a second relationship field with the same reverse
+		// relationship slug as the relationship field we just saved.
+		$i->click( Locator::lastElement( '.add-item' ) );
+		$i->click( 'Relation', '.field-buttons' );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'name' ], 'Second Relationship' );
+		$i->selectOption( '#reference', 'Employees' );
+		$i->click( '#enable-reverse' );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'reverseName' ], 'resolveConflict' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+		$i->see( 'A relationship field in this model has the same identifier.' );
+
+		// Resolve the reverse slug conflict.
+		$i->fillField( [ 'name' => 'reverseName' ], 'fixedConflict' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+		$i->see( 'Second Relationship', Locator::lastElement( '.field-list div.widest' ) ); // Second field was created successfully.
+
+		// Open and update one of the relationship fields.
+		// To prevent reoccurence of an issue where reverse slugs could conflict
+		// with themselves and stop a relationship field from updating.
+		$i->clickWithLeftButton( '.field-list button.edit', -5, -5 );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'name' ], 'Updated Name' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+		$i->see( 'Updated Name', '.field-list div.widest' );
 	}
 }

--- a/tests/integration/api-validation/test-rest-field-endpoints.php
+++ b/tests/integration/api-validation/test-rest-field-endpoints.php
@@ -204,7 +204,7 @@ class RestFieldEndpointTests extends WP_UnitTestCase {
 
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertArrayHasKey( 'message', $data );
-		$this->assertEquals( 'Another field in the model public-fields model has the same API identifier.', $data['message'] );
+		$this->assertEquals( 'A field in the public-fields model has the same identifier.', $data['message'] );
 
 		// Attempt to create a reverse relationship that would conflict with the slug of an existing reverse relationship from the same model.
 		$field = array(
@@ -226,7 +226,7 @@ class RestFieldEndpointTests extends WP_UnitTestCase {
 
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertArrayHasKey( 'message', $data );
-		$this->assertEquals( 'Another field in the model public-fields model has the same API identifier.', $data['message'] );
+		$this->assertEquals( 'A relationship field in this model has the same identifier.', $data['message'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Adjusts handling of the relationship field reverse reference slug collision check to:

-  Prevent an issue @mindctrl reported in Slack where a relationship field with a reverse reference slug could not be updated, due to its reverse reference slug colliding with itself.
- Separate error handling logic and error messages for the two types of collision. (Previously the same error was reported for both of the cases below, which is fine, but I think it's easier to reason about the code and the errors when they're separate.)
    -  `atlas_content_modeler_reverse_slug_conflict` – the reverse slug conflicts with a field slug in the reference model (the reverse slug is added to the reference model as a field, so it can't clash with existing field slugs there).
    -  `atlas_content_modeler_reverse_slug_in_use` – the reverse slug is in use by a different relationship field's reverse slug from the current model that shares the same reference (two separate relationship fields can't be added to the same reference model if they share a back-reference name).

## Testing

- Adapts existing REST endpoint unit test to check for new error types.
- Adds e2e test to confirm a relationship field with a reverse reference can be updated without conflicting with itself.
- Adds new e2e tests to check for reverse slug conflict messages for the two error cases above.

### Manual testing

#### Test 1

From John's steps to reproduce:

- Create new model
- Add relationship field
- Give it a name
- Select a Model to Reference
- Check Configure Reverse Reference
- Give that a name and Reverse API Identifier
- Save field
- Edit field, make no changes... or add a description if you like.
- Click Update

You should no longer see the error visible on `main`: "A field in the related model has the same API identifier"

#### Test 2

If you attempt to create two relationship fields with the same reverse slug, you should see, “A relationship field in this model has the same identifier.”

#### Test 3

If you attempt to create a relationship field that has a reverse slug of the same name as the slug of any field in the reference model, you should see, “A field in the X model has the same identifier.”

## Screenshots

<img width="685" alt="Screenshot 2021-11-02 at 17 51 06" src="https://user-images.githubusercontent.com/647669/139909921-56326a28-ea9f-4cea-b4fb-3760286baf4a.png">

<img width="776" alt="Screenshot 2021-11-02 at 17 51 31" src="https://user-images.githubusercontent.com/647669/139909928-af4b5bb1-ae79-454e-bc9b-35627186e9cf.png">

## Documentation Changes

n/a

## Dependant PRs

n/a

## Notes
I think we may also need to confirm that reverse slugs do not use any of the reserved terms we added checks for in https://github.com/wpengine/atlas-content-modeler/pull/328, but that seems outside of the scope of this PR.