### PR TITLE
[NOJIRA] Add publicly_queryable to post type registration

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -325,6 +325,7 @@ function generate_custom_post_type_args( array $args ): array {
 		'singular_name'         => ucfirst( $singular ),
 		'description'           => $args['description'] ?? '',
 		'public'                => $args['public'] ?? false,
+		'publicly_queryable'    => ( $args['api_visibility'] ?? 'private' ) === 'public',
 		'show_ui'               => $args['show_ui'] ?? true,
 		'show_in_rest'          => $args['show_in_rest'] ?? true,
 		'rest_base'             => $args['rest_base'] ?? sanitize_key( $plural ),

--- a/tests/integration/api-validation/test-data/fields.php
+++ b/tests/integration/api-validation/test-data/fields.php
@@ -141,7 +141,7 @@ function get_test_fields() {
 			'id'              => '1630411384975',
 			'position'        => '90000',
 			'name'            => 'Date',
-			'slug'            => 'date',
+			'slug'            => 'dateNotRequired',
 			'required'        => false,
 			'minChars'        => '',
 			'maxChars'        => '',


### PR DESCRIPTION
## Description

Adds `publicly_queryable` to ACM post type registration.

This is required to address a breaking change in WPGraphQL 1.6.7 that suddenly makes all ACM models registered with API Visibility of “public” inaccessible without authentication. 

- https://github.com/wp-graphql/wp-graphql/issues/2134 (Post types that expect to be queryable without auth now need to register with `publicly_queryable => true`, which we were not doing.)

This was picked up by a sudden test failure in Circle on `main` when I merged PRs this morning after the WPGraphQL update last night.

This PR also fixes a pre-existing WPGraphQL error I noticed when SSHing into CircleCI ("You cannot register duplicate fields on the same Type. The field 'date' already exists on the type 'publicFields'. Make sure to give the field a unique name.") This was just due to a reserved slug used in our test data.

## Testing

Confirm existing GraphQL tests now pass again in Circle.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

n/a