### PR TITLE
[NOJIRA] Disallow console.log in commits

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
 	// add your custom rules here
 	ignorePatterns: ["**/dist", "**/includes/settings/scss/bootstrap"],
 	rules: {
+		"no-console": ["error", { allow: ["warn", "error"] }],
 		"react/prop-types": 0,
 		"react/no-unescaped-entities": 0,
 		"react/no-children-prop": 0,


### PR DESCRIPTION
## Description

- To prevent console.log debug statements sneaking into commits.
- To reduce the need to manually check for and comment on console.log use during PR review.

`console.warn` and `console.error` are still fine but should only be used for actual user-facing console messages.

## Testing

Add a `console.log()` statement to any JS file in `includes/` and run `npm run lint`. The lint should fail. This will also block commits due to our pre-commit hook running eslint.

## Screenshots

In the editor (VS Code with [Error Lens](https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens), which adds the error at the end of the bad line, instead of just showing red squiggles):

<img width="756" alt="Screenshot 2021-11-04 at 12 27 28" src="https://user-images.githubusercontent.com/647669/140306439-022a2da1-1280-4d36-951e-33b460ec8d29.png">

Attempting to commit code containing console.log fails:

<img width="1077" alt="Screenshot 2021-11-04 at 12 29 16" src="https://user-images.githubusercontent.com/647669/140306507-4ffe34fb-d99e-4a69-a187-1893f74b3ce7.png">

## Documentation Changes

n/a

## Dependant PRs

n/a