### PR TITLE
[MTKA-1069] Validate integer type where appropriate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ./:/var/www/html/wp-content/plugins/atlas-content-modeler
 
   db:
+    platform: linux/x86_64
     image: mysql:5.7
     restart: always
     ports:

--- a/includes/settings/js/src/components/fields/AdvancedSettings.jsx
+++ b/includes/settings/js/src/components/fields/AdvancedSettings.jsx
@@ -151,6 +151,19 @@ const NumberSettings = ({
 									</span>
 								</span>
 							)}
+							{errors.minValue &&
+								errors.minValue.type ===
+									"isAppropriateType" && (
+									<span className="error">
+										<Icon type="error" />
+										<span role="alert">
+											{__(
+												"The value must be an integer.",
+												"atlas-content-modeler"
+											)}
+										</span>
+									</span>
+								)}
 						</p>
 					</div>
 
@@ -199,6 +212,19 @@ const NumberSettings = ({
 										<span role="alert">
 											{__(
 												"Max must be more than min.",
+												"atlas-content-modeler"
+											)}
+										</span>
+									</span>
+								)}
+							{errors.maxValue &&
+								errors.maxValue.type ===
+									"isAppropriateType" && (
+									<span className="error">
+										<Icon type="error" />
+										<span role="alert">
+											{__(
+												"The value must be an integer.",
 												"atlas-content-modeler"
 											)}
 										</span>
@@ -260,6 +286,18 @@ const NumberSettings = ({
 									<span role="alert">
 										{__(
 											"Min plus Step can't be larger than Max.",
+											"atlas-content-modeler"
+										)}
+									</span>
+								</span>
+							)}
+						{errors.step &&
+							errors.step.type === "isAppropriateType" && (
+								<span className="error">
+									<Icon type="error" />
+									<span role="alert">
+										{__(
+											"The value must be an integer.",
 											"atlas-content-modeler"
 										)}
 									</span>

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -72,6 +72,13 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 		? false
 		: useReservedSlugs(toGraphQLType(models[model]?.singular, true));
 
+	const isAppropriateType = (value) => {
+		if (getValues("numberType") === "integer") {
+			const disallowedCharacters = /[.]/g;
+			return !disallowedCharacters.test(value);
+		}
+	};
+
 	const advancedSettings = {
 		text: {
 			component: TextSettings,
@@ -102,11 +109,15 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 				minValue: {
 					setValueAs: (v) =>
 						v || parseNumber(v) === 0 ? parseNumber(v) : "",
+					validate: {
+						isAppropriateType: (v) => isAppropriateType(v),
+					},
 				},
 				maxValue: {
 					setValueAs: (v) =>
 						v || parseNumber(v) === 0 ? parseNumber(v) : "",
 					validate: {
+						isAppropriateType: (v) => isAppropriateType(v),
 						maxBelowMin: (v) => {
 							const min = parseNumber(getValues("minValue"));
 							const max = parseNumber(v);
@@ -122,6 +133,7 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 					setValueAs: (v) =>
 						v || parseNumber(v) === 0 ? parseNumber(v) : "",
 					validate: {
+						isAppropriateType: (v) => isAppropriateType(v),
 						maxBelowStep: (v) => {
 							if (getValues("maxValue") === "") {
 								return true;

--- a/tests/acceptance/CreateContentModelNumberFieldCest.php
+++ b/tests/acceptance/CreateContentModelNumberFieldCest.php
@@ -35,4 +35,29 @@ class CreateContentModelNumberFieldCest {
 		$i->fillField( [ 'name' => 'step' ], '2' );
 		$i->dontSee( 'Step must be lower than max.', '.error' );
 	}
+
+	public function i_must_use_intergers_for_advanced_interger_field_settings( AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$i->haveContentModel( 'Candy', 'Candies' );
+		$i->wait( 1 );
+
+		$i->click( 'Number', '.field-buttons' );
+		$i->wait( 1 );
+
+		$i->click( 'button.settings' );
+		$i->fillField( [ 'name' => 'minValue' ], '1.2' );
+		$i->see( 'The value must be an integer.', '.error' );
+		$i->fillField( [ 'name' => 'minValue' ], '1' );
+		$i->dontSee( 'The value must be an integer.', '.error' );
+
+		$i->fillField( [ 'name' => 'maxValue' ], '1.2' );
+		$i->see( 'The value must be an integer.', '.error' );
+		$i->fillField( [ 'name' => 'maxValue' ], '1' );
+		$i->dontSee( 'The value must be an integer.', '.error' );
+
+		$i->fillField( [ 'name' => 'step' ], '1.2' );
+		$i->see( 'The value must be an integer.', '.error' );
+		$i->fillField( [ 'name' => 'step' ], '1' );
+		$i->dontSee( 'The value must be an integer.', '.error' );
+	}
 }


### PR DESCRIPTION
## Description

Ensures only integer values can be used for advanced number settings when the field is set to the "integer" type.

https://wpengine.atlassian.net/browse/MTKA-1069

## Testing

Appropriate E2E tests have been added to ensure proper functionality

## Screenshots

![Screen Shot 2021-11-04 at 14 21 41](https://user-images.githubusercontent.com/394675/140398548-5a166ee4-8969-47cb-bad5-9be33daedb53.png)

## Documentation Changes
