### PR TITLE
[MTKA-1121] Add ability to set featured image using media field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER_RUN       := docker run --rm
-COMPOSER_IMAGE   := -v "$$(pwd):/app" --user $$(id -u):$$(id -g) composer
+COMPOSER_IMAGE   := -v "$$(pwd):/app" --user $$(id -u):$$(id -g) composer:1
 NODE_IMAGE       := -w /home/node/app -v "$$(pwd):/home/node/app" --user node atlascontentmodeler_node_image
 HAS_CHROMEDRIVER := $(shell command -v chromedriver 2> /dev/null)
 CURRENTUSER      := $$(id -u)

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -10,6 +10,7 @@ services:
         - .:/app
 
   phpunitdatabase:
+    platform: linux/x86_64
     image: mysql:5.7
     ports:
       - 3307:3306

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -104,7 +104,7 @@ final class FormEditingExperience {
 				foreach ( $config['fields'] as $field ) {
 					if ( 'media' === $field['type'] && isset( $field['isFeatured'] ) && true === $field['isFeatured'] ) {
 						$remove_thumbnail = false;
-						continue;
+						break;
 					}
 				}
 				if ( $remove_thumbnail ) {

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -416,7 +416,7 @@ final class FormEditingExperience {
 						$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $post->post_type );
 					}
 				} else {
-					delete_post_thumbnail( $post ); // Delete first is innefficient but avoids werid behavior of set which otherwise treats an existing thumbnail as a bug.
+					delete_post_thumbnail( $post ); // Delete first is innefficient but avoids weird behavior of set which otherwise treats an existing thumbnail as a bug.
 					if ( ! set_post_thumbnail( $post, $posted_values[ $slug ] ) ) {
 						/* translators: %s: atlas content modeler field slug */
 						$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $post->post_type );

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -413,13 +413,13 @@ final class FormEditingExperience {
 				if ( '' === $posted_values[ $slug ] ) {
 					if ( ! delete_post_thumbnail( $post ) ) {
 						/* translators: %s: atlas content modeler field slug */
-						$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $post->post_type );
+						$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $posted_values[ $slug ] );
 					}
 				} else {
 					delete_post_thumbnail( $post ); // Delete first is innefficient but avoids weird behavior of set which otherwise treats an existing thumbnail as a bug.
 					if ( ! set_post_thumbnail( $post, $posted_values[ $slug ] ) ) {
 						/* translators: %s: atlas content modeler field slug */
-						$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $post->post_type );
+						$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $posted_values[ $slug ] );
 					}
 				}
 			}

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -401,9 +401,16 @@ final class FormEditingExperience {
 				$this->models[ $post->post_type ]['fields'] ?? []
 			) &&
 			isset( $posted_values[ $slug ] ) ) {
-				if ( ! set_post_thumbnail( $post, $posted_values[ $slug ] ) ) {
-					/* translators: %s: atlas content modeler field slug */
-					$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $key );
+				if ( '' === $posted_values[ $slug ] ) {
+					if ( ! delete_post_thumbnail( $post ) ) {
+						/* translators: %s: atlas content modeler field slug */
+						$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $key );
+					}
+				} else {
+					if ( ! set_post_thumbnail( $post, $posted_values[ $slug ] ) ) {
+						/* translators: %s: atlas content modeler field slug */
+						$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $key );
+					}
 				}
 			}
 		}

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -644,22 +644,6 @@ final class FormEditingExperience {
 	}
 
 	/**
-	 * Hides the “Screen Options” drop-down on post types registered by this plugin.
-	 *
-	 * @param bool       $show_screen The current state of the screen options dropdown.
-	 * @param \WP_Screen $screen Information about the current screen.
-	 *
-	 * @return bool The new state of the screen options dropdown. (False to disable.)
-	 */
-	public function hide_screen_options( bool $show_screen, $screen ): bool {
-		if ( in_array( $screen->post_type, array_keys( $this->models ), true ) ) {
-			return false;
-		}
-
-		return $show_screen;
-	}
-
-	/**
 	 * Removes the featured image meta box.
 	 *
 	 * Adding featured image support to the media field creates a confusing

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -394,6 +394,18 @@ final class FormEditingExperience {
 					}
 				}
 			}
+
+			if ( 'media' === $field_type &&
+			is_field_featured_image(
+				$slug,
+				$this->models[ $post->post_type ]['fields'] ?? []
+			) &&
+			isset( $posted_values[ $slug ] ) ) {
+				if ( ! set_post_thumbnail( $post, $posted_values[ $slug ] ) ) {
+					/* translators: %s: atlas content modeler field slug */
+					$this->error_save_post = sprintf( __( 'There was an error updating the %s field data.', 'atlas-content-modeler' ), $key );
+				}
+			}
 		}
 
 		foreach ( $posted_values as $key => $value ) {

--- a/includes/publisher/js/src/components/MediaUploader.jsx
+++ b/includes/publisher/js/src/components/MediaUploader.jsx
@@ -72,6 +72,16 @@ export default function MediaUploader({ modelSlug, field, required }) {
 		return allowedTypes ? `${allowedTypes.split(",").join(", ")}` : "";
 	}
 
+	function getMediaButtonText(field) {
+		return field?.isFeatured
+			? mediaUrl
+				? __("Change Featured Image", "atlas-content-modeler")
+				: __("Add Featured Image", "atlas-content-modeler")
+			: mediaUrl
+			? __("Change Media", "atlas-content-modeler")
+			: __("Upload Media", "atlas-content-modeler");
+	}
+
 	/**
 	 * Click handler to use wp media uploader
 	 * @param e - event
@@ -89,9 +99,7 @@ export default function MediaUploader({ modelSlug, field, required }) {
 		}
 
 		const getMediaModalTitle = () => {
-			const title = mediaUrl
-				? __("Change Media", "atlas-content-modeler")
-				: __("Upload Media", "atlas-content-modeler");
+			const title = getMediaButtonText(field);
 			if (allowedTypes) {
 				return `${title} (${getAllowedTypesForUi().toUpperCase()})`;
 			}
@@ -173,17 +181,7 @@ export default function MediaUploader({ modelSlug, field, required }) {
 							type="button"
 							className="button button-primary button-large"
 							style={{ marginTop: "5px" }}
-							defaultValue={
-								mediaUrl
-									? __(
-											"Change Media",
-											"atlas-content-modeler"
-									  )
-									: __(
-											"Upload Media",
-											"atlas-content-modeler"
-									  )
-							}
+							defaultValue={getMediaButtonText(field)}
 							onClick={(e) => clickHandler(e)}
 						/>
 
@@ -205,7 +203,12 @@ export default function MediaUploader({ modelSlug, field, required }) {
 							className="btn-delete"
 							onClick={(e) => deleteImage(e)}
 						>
-							{__("Remove Media", "atlas-content-modeler")}
+							{field?.isFeatured
+								? __(
+										"Remove Featured Image",
+										"atlas-content-modeler"
+								  )
+								: __("Remove Media", "atlas-content-modeler")}
 						</a>
 					)}
 				</div>

--- a/includes/publisher/lib/field-functions.php
+++ b/includes/publisher/lib/field-functions.php
@@ -73,6 +73,24 @@ function get_field_type_from_slug( string $slug, array $fields ): string {
 }
 
 /**
+ * Determins if the field is the featured image or not.
+ *
+ * @param string $slug The slug of the field to look for.
+ * @param array  $fields Fields to search for the `$slug`.
+ *
+ * @return bool True if the field is the featured image or false
+ */
+function is_field_featured_image( string $slug, array $fields ): bool {
+	foreach ( $fields as $field ) {
+		if ( $field['slug'] === $slug ) {
+			return isset( $field['isFeatured'] ) ? $field['isFeatured'] : false;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Gets the field from the field slug.
  *
  * @param string $slug The slug of the field to look for.

--- a/includes/publisher/lib/field-functions.php
+++ b/includes/publisher/lib/field-functions.php
@@ -74,7 +74,7 @@ function get_field_from_slug( string $slug, array $models, string $post_type ): 
 }
 
 /**
- * Determins if the field is the featured image or not.
+ * Determines if the field is the featured image or not.
  *
  * @param string $slug The slug of the field to look for.
  * @param array  $fields Fields to search for the `$slug`.

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -488,7 +488,6 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 						model={model}
 					/>
 				)}
-
 				{!["richtext", "multipleChoice"].includes(type) && (
 					<div className="field">
 						<legend>Field Options</legend>
@@ -508,6 +507,34 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 								"atlas-content-modeler"
 							)}
 						</label>
+						{["media"].includes(type) && (
+							<div>
+								<input
+									name="featured-image"
+									type="checkbox"
+									id={`featured-image-${id}`}
+									ref={register}
+									defaultChecked={
+										storedData?.required === true
+									}
+								/>
+								<label
+									htmlFor={`featured-image-${id}`}
+									className="checkbox featured-image"
+								>
+									{__(
+										"Set as featured image",
+										"atlas-content-modeler"
+									)}
+								</label>
+								<p className="help featured-image">
+									{__(
+										"Limits media selection to image types.",
+										"atlas-content-modeler"
+									)}
+								</p>
+							</div>
+						)}
 					</div>
 				)}
 			</div>

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -525,7 +525,7 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 									onChange={(event) => {
 										/**
 										 * Unchecks other fields when checking a field.
-										 * Only one field can be the title field.
+										 * Only one field can be the featured image field.
 										 */
 										if (event.target.checked) {
 											dispatch({
@@ -539,10 +539,10 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 										if (!event.target.checked) {
 											/**
 											 * When unchecking a field that was not the original
-											 * title, restore isTitle on the original title
+											 * media, restore isFeatured on the original media
 											 * field if there is one. Prevents an issue where
-											 * checking “is title” then unchecking it removes
-											 * isTitle from the original.
+											 * checking “is featured image then unchecking it removes
+											 * isFeatured from the original.
 											 */
 											if (
 												originalMediaFieldId.current &&
@@ -561,7 +561,7 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 
 											/**
 											 * At this point we're just unchecking the original
-											 * title field.
+											 * media field.
 											 */
 											dispatch({
 												type: "setFieldProperties",

--- a/includes/settings/js/src/queries.js
+++ b/includes/settings/js/src/queries.js
@@ -116,6 +116,20 @@ export function getTitleFieldId(fields = {}) {
 }
 
 /**
+ * Gets the field the user ticked “use this field as the featured image” for.
+ *
+ * @param {Object} fields Fields to check for the isFeatured property.
+ * @return {String} The id of the featured image field or an empty string.
+ */
+export function getFeaturedFieldId(fields = {}) {
+	const fieldWithFeaturedImage = Object.values(fields).find(
+		(field) => field?.isFeatured === true
+	);
+
+	return fieldWithFeaturedImage ? fieldWithFeaturedImage.id : "";
+}
+
+/**
  * Gives information about the open field.
  *
  * @param {Object} fields Fields to check the open state of.

--- a/includes/settings/js/src/reducer.js
+++ b/includes/settings/js/src/reducer.js
@@ -73,11 +73,14 @@ export function reducer(state, action) {
 			};
 			return { ...state };
 		case "setTitleField":
+		case "setFeaturedImageField":
 			const fields = state[action.model]["fields"];
+			const setType =
+				action.type === "setTitleField" ? "isTitle" : "isFeatured";
 			Object.values(fields).forEach((field) => {
-				state[action.model]["fields"][field.id]["isTitle"] = false;
+				state[action.model]["fields"][field.id][setType] = false;
 			});
-			state[action.model]["fields"][action.id]["isTitle"] = true;
+			state[action.model]["fields"][action.id][setType] = true;
 			return { ...state };
 		case "setFieldProperties":
 			action.properties.forEach((property) => {

--- a/includes/settings/scss/_forms.scss
+++ b/includes/settings/scss/_forms.scss
@@ -201,6 +201,10 @@ input[type="radio"] {
 	color: $color-gray-mid;
 }
 
+.atlas-content-modeler-admin-page .featured-image.help {
+	margin: 0 0 0 27px;
+}
+
 .atlas-content-modeler-admin-page .radio-row {
 	display: flex;
 	align-items: flex-start;

--- a/includes/settings/scss/_forms.scss
+++ b/includes/settings/scss/_forms.scss
@@ -202,7 +202,7 @@ input[type="radio"] {
 }
 
 .atlas-content-modeler-admin-page .featured-image.help {
-	margin: 0 0 0 27px;
+	margin: 5px 0 0 27px;
 }
 
 .atlas-content-modeler-admin-page .radio-row {

--- a/tests/acceptance/CreateContentModelMediaFieldCest.php
+++ b/tests/acceptance/CreateContentModelMediaFieldCest.php
@@ -25,7 +25,7 @@ class CreateContentModelMediaFieldCest {
 	/**
 	 * Ensure a user can add a featured image media field to the model and see it within the list.
 	 */
-	public function i_can_add_a_featured_imagemedia_field_to_a_content_model( AcceptanceTester $i ) {
+	public function i_can_add_a_featured_imag_emedia_field_to_a_content_model( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
 		$i->haveContentModel( 'Candy', 'Candies' );
 		$i->wait( 1 );
@@ -41,5 +41,43 @@ class CreateContentModelMediaFieldCest {
 
 		$i->see( 'Media', '.field-list div.type' );
 		$i->see( 'The Primary Image', '.field-list div.widest' );
+	}
+
+	/**
+	 * Ensure a user can only add one featured image media field to the model.
+	 */
+	public function i_can_only_add_one_featured_image_media_field_to_a_content_model( AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$i->haveContentModel( 'Candy', 'Candies' );
+		$i->wait( 1 );
+
+		$i->click( 'Media', '.field-buttons' );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'name' ], 'The Primary Image' );
+		$i->see( '17/50', 'span.count' );
+		$i->seeInField( '#slug', 'thePrimaryImage' );
+		$i->checkOption( 'isFeatured' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+
+		$i->see( 'Media', '.field-list div.type' );
+		$i->see( 'The Primary Image', '.field-list div.widest' );
+
+		$i->click( '.add-item' );
+		$i->wait( 1 );
+
+		$i->click( 'Media', '.field-buttons' );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'name' ], 'The Second Image' );
+		$i->see( '16/50', 'span.count' );
+		$i->seeInField( '#slug', 'theSecondImage' );
+		$i->checkOption( 'isFeatured' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+
+		$i->clickWithLeftButton( '.field-list button.edit', -5, -5 );
+		$i->wait( 1 );
+		$i->seeInField( '#slug', 'thePrimaryImage' );
+		$i->dontSeeCheckboxIsChecked( 'isFeatured ' );
 	}
 }

--- a/tests/acceptance/CreateContentModelMediaFieldCest.php
+++ b/tests/acceptance/CreateContentModelMediaFieldCest.php
@@ -25,7 +25,7 @@ class CreateContentModelMediaFieldCest {
 	/**
 	 * Ensure a user can add a featured image media field to the model and see it within the list.
 	 */
-	public function i_can_add_a_featured_imag_emedia_field_to_a_content_model( AcceptanceTester $i ) {
+	public function i_can_add_a_featured_image_media_field_to_a_content_model( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
 		$i->haveContentModel( 'Candy', 'Candies' );
 		$i->wait( 1 );

--- a/tests/acceptance/CreateContentModelMediaFieldCest.php
+++ b/tests/acceptance/CreateContentModelMediaFieldCest.php
@@ -80,4 +80,30 @@ class CreateContentModelMediaFieldCest {
 		$i->seeInField( '#slug', 'thePrimaryImage' );
 		$i->dontSeeCheckboxIsChecked( 'isFeatured ' );
 	}
+
+	/**
+	 * Ensure a featured image field is properly denoted in publisher.
+	 */
+	public function i_can_denote_a_featured_image_field_in_publisher( AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$i->haveContentModel( 'Candy', 'Candies' );
+		$i->wait( 1 );
+
+		$i->click( 'Media', '.field-buttons' );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'name' ], 'The Primary Image' );
+		$i->see( '17/50', 'span.count' );
+		$i->seeInField( '#slug', 'thePrimaryImage' );
+		$i->checkOption( 'isFeatured' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+
+		$i->see( 'Media', '.field-list div.type' );
+		$i->see( 'The Primary Image', '.field-list div.widest' );
+
+		$i->amOnPage( '/wp-admin/edit.php?post_type=candy' );
+		$i->click( 'Add New', '.wrap' );
+		$i->wait( 1 );
+		$i->seeInField( '.button-primary', 'Add Featured Image' );
+	}
 }

--- a/tests/acceptance/CreateContentModelMediaFieldCest.php
+++ b/tests/acceptance/CreateContentModelMediaFieldCest.php
@@ -21,4 +21,25 @@ class CreateContentModelMediaFieldCest {
 		$i->see( 'Media', '.field-list div.type' );
 		$i->see( 'Product Photo', '.field-list div.widest' );
 	}
+
+	/**
+	 * Ensure a user can add a featured image media field to the model and see it within the list.
+	 */
+	public function i_can_add_a_featured_imagemedia_field_to_a_content_model( AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$i->haveContentModel( 'Candy', 'Candies' );
+		$i->wait( 1 );
+
+		$i->click( 'Media', '.field-buttons' );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'name' ], 'The Primary Image' );
+		$i->see( '17/50', 'span.count' );
+		$i->seeInField( '#slug', 'thePrimaryImage' );
+		$i->checkOption( 'isFeatured' );
+		$i->click( '.open-field button.primary' );
+		$i->wait( 1 );
+
+		$i->see( 'Media', '.field-list div.type' );
+		$i->see( 'The Primary Image', '.field-list div.widest' );
+	}
 }

--- a/tests/integration/api-validation/test-data/fields.php
+++ b/tests/integration/api-validation/test-data/fields.php
@@ -269,5 +269,19 @@ function get_test_fields() {
 			'reverseName'     => 'PPosts',
 			'reverseSlug'     => 'pposts' . random_int( 0, PHP_INT_MAX ),
 		),
+		'1637243600'    => array(
+			'show_in_rest'    => true,
+			'show_in_graphql' => true,
+			'type'            => 'media',
+			'id'              => '1637243600',
+			'position'        => '190000',
+			'name'            => 'Media-Featured',
+			'slug'            => 'mediaFeatured',
+			'required'        => false,
+			'minChars'        => '',
+			'maxChars'        => '',
+			'allowedTypes'    => '',
+			'isFeatured'      => true,
+		),
 	);
 }

--- a/tests/integration/api-validation/test-data/posts.php
+++ b/tests/integration/api-validation/test-data/posts.php
@@ -90,6 +90,8 @@ function populate_post( $post_id, $model, $test_class ) {
 	update_post_meta( $post_id, 'mediaPDF', $ids[ $model . '_pdf_id' ] );
 	update_post_meta( $post_id, 'boolean', 'false' );
 	update_post_meta( $post_id, 'booleanRequired', 'true' );
+	update_post_meta( $post_id, 'featured', $ids[ $model . '_image_id' ] );
+	update_post_meta( $post_id, '_thumbnail_id', $ids[ $model . '_image_id' ] );
 
 	$image_meta = array(
 		'width'  => 1000,

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -60,6 +60,9 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
                             numberIntergerRequired
                             dateRequired
                             booleanRequired
+							featuredImage
+							featuredImageDatabaseId
+							featuredImageId
 							manytoManyRelationship {
 								nodes {
 									id
@@ -98,8 +101,6 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 
 			self::assertArrayHasKey( 'booleanRequired', $results['data']['publicsFields']['nodes'][0] );
 			self::assertTrue( $results['data']['publicsFields']['nodes'][0]['booleanRequired'] );
-
-			var_dump( $results['data']['publicsFields']['nodes'][0] ); // phpcs:ignore
 
 			self::assertArrayHasKey( 'featuredImageId', $results['data']['publicsFields']['nodes'][0] );
 			self::assertArrayHasKey( 'featuredImageDatabaseId', $results['data']['publicsFields']['nodes'][0] );

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -85,6 +85,8 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 				]
 			);
 
+			var_dump( $results ); // phpcs:ignore
+
 			self::assertArrayHasKey( 'databaseId', $results['data']['publicsFields']['nodes'][0] );
 
 			self::assertArrayHasKey( 'title', $results['data']['publicsFields']['nodes'][0] );

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -60,7 +60,11 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
                             numberIntergerRequired
                             dateRequired
                             booleanRequired
-							featuredImage
+							featuredImage {
+								node {
+									id
+								}
+							}
 							featuredImageDatabaseId
 							featuredImageId
 							manytoManyRelationship {

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -99,6 +99,10 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 			self::assertArrayHasKey( 'booleanRequired', $results['data']['publicsFields']['nodes'][0] );
 			self::assertTrue( $results['data']['publicsFields']['nodes'][0]['booleanRequired'] );
 
+			self::assertArrayHasKey( 'featuredImageId', $results['data']['publicsFields']['nodes'][0] );
+			self::assertArrayHasKey( 'featuredImageDatabaseId', $results['data']['publicsFields']['nodes'][0] );
+			self::assertArrayHasKey( 'featuredImage', $results['data']['publicsFields']['nodes'][0] );
+
 			self::assertArrayHasKey( 'manytoManyRelationship', $results['data']['publicsFields']['nodes'][0] );
 			self::assertIsArray( $results['data']['publicsFields']['nodes'][0]['manytoManyRelationship'] );
 

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -60,11 +60,6 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
                             numberIntergerRequired
                             dateRequired
                             booleanRequired
-							featuredImage {
-								node {
-									id
-								}
-							}
 							featuredImageDatabaseId
 							featuredImageId
 							manytoManyRelationship {

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -84,8 +84,6 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 				]
 			);
 
-			var_dump( $results ); // phpcs:ignore
-
 			self::assertArrayHasKey( 'databaseId', $results['data']['publicsFields']['nodes'][0] );
 
 			self::assertArrayHasKey( 'title', $results['data']['publicsFields']['nodes'][0] );
@@ -105,7 +103,6 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 
 			self::assertArrayHasKey( 'featuredImageId', $results['data']['publicsFields']['nodes'][0] );
 			self::assertArrayHasKey( 'featuredImageDatabaseId', $results['data']['publicsFields']['nodes'][0] );
-			self::assertArrayHasKey( 'featuredImage', $results['data']['publicsFields']['nodes'][0] );
 
 			self::assertArrayHasKey( 'manytoManyRelationship', $results['data']['publicsFields']['nodes'][0] );
 			self::assertIsArray( $results['data']['publicsFields']['nodes'][0]['manytoManyRelationship'] );

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -99,6 +99,8 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 			self::assertArrayHasKey( 'booleanRequired', $results['data']['publicsFields']['nodes'][0] );
 			self::assertTrue( $results['data']['publicsFields']['nodes'][0]['booleanRequired'] );
 
+			var_dump( $results['data']['publicsFields']['nodes'][0] ); // phpcs:ignore
+
 			self::assertArrayHasKey( 'featuredImageId', $results['data']['publicsFields']['nodes'][0] );
 			self::assertArrayHasKey( 'featuredImageDatabaseId', $results['data']['publicsFields']['nodes'][0] );
 			self::assertArrayHasKey( 'featuredImage', $results['data']['publicsFields']['nodes'][0] );

--- a/tests/integration/api-validation/test-rest-model-data.php
+++ b/tests/integration/api-validation/test-rest-model-data.php
@@ -89,6 +89,8 @@ class RestModelDataTests extends WP_UnitTestCase {
 
 		self::assertArrayHasKey( 'mediaRequired', $response_data['acm_fields'] );
 		self::assertArrayHasKey( 'mediaPDF', $response_data['acm_fields'] );
+		self::assertArrayHasKey( 'mediaFeatured', $response_data['acm_fields'] );
+		self::assertArrayHasKey( 'featured_media', $response_data );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Adds the ability to denote a media field as a "featured image"

Only one featured image can be selected per model and featured images are shown in REST, GraphQL and through other APIs in the same manner as they're done with standard content types like "post."

https://wpengine.atlassian.net/browse/MTKA-1121

## Testing

Appropriate testing has been included in both the phpunit and codeception suites.