### PR TITLE
[MTKA 1291] Enable saving relationships from the reverse side

### DIFF
--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -344,13 +344,8 @@ final class FormEditingExperience {
 
 		// Sanitize field values.
 		foreach ( $posted_values as $field_id => &$field_value ) {
-			$field_id = sanitize_text_field( wp_unslash( $field_id ) ); // retains camelCase.
-
-			$field_type = get_field_type_from_slug(
-				$field_id,
-				$this->models[ $post->post_type ]['fields'] ?? []
-			);
-
+			$field_id    = sanitize_text_field( wp_unslash( $field_id ) ); // retains camelCase.
+			$field_type  = get_field_type_from_slug( $field_id, $this->models, $post->post_type );
 			$field_value = sanitize_field( $field_type, wp_unslash( $field_value ) );
 
 			if ( 'relationship' === $field_type ) {
@@ -372,7 +367,8 @@ final class FormEditingExperience {
 			if ( ! array_key_exists( $slug, $posted_values ) ) {
 				$field_type = get_field_type_from_slug(
 					$slug,
-					$this->models[ $post->post_type ]['fields'] ?? []
+					$this->models,
+					$post->post_type
 				);
 
 				if ( 'relationship' === $field_type ) {
@@ -428,7 +424,8 @@ final class FormEditingExperience {
 	public function save_relationship_field( string $field_id, WP_Post $post, string $field_value ): void {
 		$field = get_field_from_slug(
 			$field_id,
-			$this->models[ $post->post_type ]['fields'] ?? []
+			$this->models,
+			$post->post_type
 		);
 
 		$registry      = ContentConnect::instance()->get_registry();

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -12,6 +12,7 @@ namespace WPE\AtlasContentModeler;
 use WP_Post;
 use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_types;
 use function WPE\AtlasContentModeler\ContentConnect\Helpers\get_related_ids_by_name;
+use function WPE\AtlasContentModeler\append_reverse_relationship_fields;
 use WPE\AtlasContentModeler\ContentConnect\Plugin as ContentConnect;
 
 
@@ -197,32 +198,7 @@ final class FormEditingExperience {
 		wp_enqueue_editor();
 
 		$models = $this->models;
-
-		// Get model fields that have a back reference to current post type.
-		foreach ( $models as $slug => $model ) {
-			if ( empty( $model['fields'] ) ) {
-				continue;
-			}
-
-			foreach ( $model['fields'] as $field ) {
-				if ( $field['type'] !== 'relationship' || ! $field['enableReverse'] ) {
-					continue;
-				}
-
-				if ( $field['reference'] !== $post->post_type ) {
-					continue;
-				}
-
-				/**
-				 *  Fields below are manually adjusted to correctly display labels in UI.
-				 */
-				$models[ $field['reference'] ]['fields'][ $field['id'] ] = $field;
-				// Overriding reference.
-				$models[ $field['reference'] ]['fields'][ $field['id'] ]['reference'] = $slug;
-				// Put reference field name into reverse label.
-				$models[ $field['reference'] ]['fields'][ $field['id'] ]['name'] = $field['reverseName'];
-			}
-		}
+		$models = append_reverse_relationship_fields( $models, $this->screen->post_type );
 
 		// Adds the wp-json rest base for utilizing model data in admin.
 		foreach ( $models as $model => $data ) {

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -197,8 +197,7 @@ final class FormEditingExperience {
 
 		wp_enqueue_editor();
 
-		$models = $this->models;
-		$models = append_reverse_relationship_fields( $models, $this->screen->post_type );
+		$models = append_reverse_relationship_fields( $this->models, $this->screen->post_type );
 
 		// Adds the wp-json rest base for utilizing model data in admin.
 		foreach ( $models as $model => $data ) {

--- a/includes/publisher/lib/field-functions.php
+++ b/includes/publisher/lib/field-functions.php
@@ -52,47 +52,95 @@ function order_fields( array $fields ): array {
 }
 
 /**
- * Gets the field type from the field slug.
+ * Gets all field data for the field with the named $slug.
  *
- * @param string $slug The slug of the field to look for.
- * @param array  $fields Fields to search for the `$slug`.
+ * @param string $slug Field slug to look for.
+ * @param array  $models Models with field properties to search for the `$slug`.
+ * @param string $post_type Current post type on the publisher screen.
  *
- * @return string Field type if found, or 'unknown'.
+ * @return array The field data if found or an empty array.
  */
-function get_field_type_from_slug( string $slug, array $fields ): string {
-	$field_type = 'unknown';
+function get_field_from_slug( string $slug, array $models, string $post_type ): array {
+	$models = append_reverse_relationship_fields( $models, $post_type );
+	$fields = $models[ $post_type ]['fields'] ?? [];
 
 	foreach ( $fields as $field ) {
 		if ( $field['slug'] === $slug ) {
-			$field_type = $field['type'] ?? 'unknown';
-			break;
+			return $field;
 		}
 	}
 
-	return $field_type;
+	return [];
 }
 
 /**
- * Gets the field from the field slug.
+ * Gets the field type from the field $slug.
  *
- * @param string $slug The slug of the field to look for.
- * @param array  $fields Fields to search for the `$slug`.
+ * @param string $slug Field slug to look for the 'type' property.
+ * @param array  $models Models with field properties to search for the `$slug`.
+ * @param string $post_type Current post type on the publisher screen.
  *
- * @return array The field array of the associated slugs or false if not found.
+ * @return string Field type if found, or 'unknown'.
  */
-function get_field_from_slug( string $slug, array $fields ): ?array {
-	$found = false;
+function get_field_type_from_slug( string $slug, array $models, string $post_type ): string {
+	$field = get_field_from_slug( $slug, $models, $post_type );
 
-	foreach ( $fields as $field ) {
-		if ( $field['slug'] === $slug ) {
-			$found = $field;
-			break;
+	return $field['type'] ?? 'unknown';
+}
+
+/**
+ * Appends relationship fields from other models to a model's field list for all
+ * relationship fields with a back reference to the $post_type.
+ *
+ * This ensures that relationship fields appear on the reverse side on
+ * publisher entry screens so they can be edited from either side.
+ *
+ * For example, a relationship field between Left and Right models with
+ * back references enabled is stored with the Left model, but should also appear
+ * in the Right model's list of fields.
+ *
+ * @param array  $models Complete models data.
+ * @param string $post_type Current post type.
+ * @return array Updated list of models with reverse relationship fields.
+ */
+function append_reverse_relationship_fields( array $models, string $post_type ): array {
+	foreach ( $models as $slug => $model ) {
+		if ( empty( $model['fields'] ) ) {
+			continue;
+		}
+
+		foreach ( $model['fields'] as $field ) {
+			if (
+				$slug === $post_type ||
+				( $field['type'] ?? '' ) !== 'relationship' ||
+				( $field['reference'] ?? '' ) !== $post_type ||
+				! $field['enableReverse']
+			) {
+				continue;
+			}
+
+			// Appends the relationship field to display it on the reverse side.
+			$models[ $field['reference'] ]['fields'][ $field['id'] ] = $field;
+
+			/**
+			 * When appearing on the reverse side, relationship fields need to
+			 * display the reverse label and refer to the “from” post type
+			 * instead of their usual “to” reference type.
+			 *
+			 * For example, when a relationship field linking a “Left” post type
+			 * to a “Right” post type appears on Left, its reference is “right”
+			 * and its label might read “Rights” (the value of $field['name']).
+			 * When appending that field to appear on the Right as a back
+			 * reference, its reference needs to be adjusted to “left” and its
+			 * label might read “Lefts” (the value of $field['reverseName']).
+			 */
+			$models[ $field['reference'] ]['fields'][ $field['id'] ]['reference'] = $slug;
+			$models[ $field['reference'] ]['fields'][ $field['id'] ]['name']      = $field['reverseName'] ?? $slug;
 		}
 	}
 
-	return $found;
+	return $models;
 }
-
 
 /**
  * Sanitizes field data based on the field type.

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -146,7 +146,7 @@ class CreateRelationshipFieldEntryCest {
 		$i->see( 'is already linked', '.tooltip-text' ); // Company A is already llinked to Employee 1.
 	}
 
-	public function i_can_create_a_reverse_relationship_and_see_the_fields( AcceptanceTester $i ) {
+	public function i_can_create_a_reverse_relationship_and_update_the_fields( AcceptanceTester $i ) {
 		// Create a model to check the “to”/“B” side of the relationship.
 		$i->haveContentModel( 'Right', 'Rights' );
 
@@ -181,6 +181,10 @@ class CreateRelationshipFieldEntryCest {
 		// Confirm that the forward relationship field button label is correct.
 		$i->see( 'Link Rights', '#field-rights .button-primary' );
 
+		// Publish the “lefts” post.
+		$i->click( 'Publish', '#publishing-action' );
+		$i->wait( 2 );
+
 		// Visit the Rights publisher entry screen.
 		$i->amOnPage( '/wp-admin/post-new.php?post_type=right' );
 
@@ -189,6 +193,34 @@ class CreateRelationshipFieldEntryCest {
 
 		// Confirm that the reverse relationship field button label is correct.
 		$i->see( 'Link Lefts', '#field-rights .button-primary' );
+
+		// Link the right entry to the published “left” entry.
+		$i->click( '#atlas-content-modeler[right][rights]' );
+		$i->see( 'Select Lefts', 'div.ReactModal__Content.ReactModal__Content--after-open h2' );
+		$i->waitForElementVisible( 'td.checkbox input' );
+		$i->click( Locator::elementAt( 'td.checkbox input', 1 ) );
+		$i->click( 'button.action-button' );
+
+		// Confirm the linked entry is visible when closing the modal.
+		$i->waitForElementVisible( 'div.relation-model-card' );
+		$i->see( 'No Title', 'div.relation-model-card' );
+
+		// Confirm the linked entry is visible after publishing the “rights” post.
+		$i->click( 'Publish', '#publishing-action' );
+		$i->wait( 2 );
+		$i->waitForElementVisible( 'div.relation-model-card' );
+		$i->see( 'No Title', 'div.relation-model-card' );
+
+		// Remove the linked entry from the “rights” side and update it.
+		$i->waitForElementVisible( '.dropdown .options' );
+		$i->click( '.dropdown .options' );
+		$i->waitForElementVisible( '.dropdown-content .delete' );
+		$i->click( '.dropdown-content .delete' );
+		$i->waitForElementNotVisible( '.dropdown .options' );
+		$i->dontSee( 'No Title', 'div.relation-model-card' ); // Linked entry was removed.
+		$i->click( 'Update', '#publishing-action' );
+		$i->wait( 2 );
+		$i->dontSee( 'No Title', 'div.relation-model-card' ); // Linked entry still gone after saving the page.
 	}
 
 	/**

--- a/tests/integration/publisher/test-field-functions.php
+++ b/tests/integration/publisher/test-field-functions.php
@@ -6,7 +6,6 @@
  */
 
 use function WPE\AtlasContentModeler\order_fields;
-use function WPE\AtlasContentModeler\get_top_level_fields;
 use function WPE\AtlasContentModeler\get_entry_title_field;
 use function WPE\AtlasContentModeler\sanitize_field;
 use function WPE\AtlasContentModeler\get_field_type_from_slug;


### PR DESCRIPTION
## Description

Allows related entries in a relationship field to be saved from the reverse side.

https://wpengine.atlassian.net/browse/MTKA-1291

## Testing

- Includes PHP unit tests for appending reverse relationship fields to the reference model.
- Extends existing e2e tests to check that entries can be saved from the reverse side, and that labels are correct.

### To test manually

1. Import the models below (you will need to remove the `.txt` extension).

[acm-models-export-2021-11-10-16-36-02.json.txt](https://github.com/wpengine/atlas-content-modeler/files/7514391/acm-models-export-2021-11-10-16-36-02.json.txt)

2. Create two “Left” posts named “Left 1” and “Left 2”, filling only the names.
3. Create a “Right” post named “Right 1” and link it to one or both of the left posts.

You should now see the Right post when you go to edit the Left posts.

You should be able to remove or edit the connections from either side.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

Targets #337 and should be merged into that first before it reaches main.

## Notes
Enforcing many-to-one and one-to-one from the reverse side will be tested and patched separately if required.