### PR TITLE
MTKA-1116: Add the ability to edit entry slugs

### DIFF
--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -613,22 +613,6 @@ final class FormEditingExperience {
 	}
 
 	/**
-	 * Hides the “Screen Options” drop-down on post types registered by this plugin.
-	 *
-	 * @param bool       $show_screen The current state of the screen options dropdown.
-	 * @param \WP_Screen $screen Information about the current screen.
-	 *
-	 * @return bool The new state of the screen options dropdown. (False to disable.)
-	 */
-	public function hide_screen_options( bool $show_screen, $screen ): bool {
-		if ( in_array( $screen->post_type, array_keys( $this->models ), true ) ) {
-			return false;
-		}
-
-		return $show_screen;
-	}
-
-	/**
 	 * Moves the meta boxes to the sidebar.
 	 *
 	 * Improves usability by moving the meta box away from the main editor area

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -84,10 +84,9 @@ final class FormEditingExperience {
 		add_filter( 'redirect_post_location', [ $this, 'append_error_to_location' ], 10, 2 );
 		add_action( 'admin_notices', [ $this, 'display_save_post_errors' ] );
 		add_filter( 'the_title', [ $this, 'filter_post_titles' ], 10, 2 );
-		add_filter( 'screen_options_show_screen', [ $this, 'hide_screen_options' ], 10, 2 );
 		add_action( 'load-post.php', [ $this, 'feedback_notice_handler' ] );
 		add_action( 'load-post-new.php', [ $this, 'feedback_notice_handler' ] );
-		add_action( 'do_meta_boxes', [ $this, 'move_author_meta_box' ] );
+		add_action( 'do_meta_boxes', [ $this, 'move_meta_boxes' ] );
 	}
 
 	/**
@@ -630,7 +629,7 @@ final class FormEditingExperience {
 	}
 
 	/**
-	 * Moves the author meta box to the sidebar.
+	 * Moves the meta boxes to the sidebar.
 	 *
 	 * Improves usability by moving the meta box away from the main editor area
 	 * so that it does not appear there before the publisher React application.
@@ -638,18 +637,29 @@ final class FormEditingExperience {
 	 * Users can still override meta box position. Their preference is stored
 	 * in the user meta table under a key named `meta-box-order_[post-slug]`.
 	 */
-	public function move_author_meta_box(): void {
+	public function move_meta_boxes(): void {
 		// Only change placement for post types created by this plugin.
 		if ( ! array_key_exists( $this->screen->post_type, $this->models ) ) {
 			return;
 		}
 
 		remove_meta_box( 'authordiv', null, 'normal' );
+		remove_meta_box( 'slugdiv', null, 'normal' );
 
 		add_meta_box(
 			'authordiv',
 			__( 'Author' ), // phpcs:ignore -- use translation from WordPress Core.
 			'post_author_meta_box',
+			null,
+			'side', // Move to the sidebar.
+			'default',
+			array( '__back_compat_meta_box' => true )
+		);
+
+		add_meta_box(
+			'slugdiv',
+			__( 'Slug' ), // phpcs:ignore -- use translation from WordPress Core.
+			'post_slug_meta_box',
 			null,
 			'side', // Move to the sidebar.
 			'default',

--- a/includes/publisher/scss/_classic-form.scss
+++ b/includes/publisher/scss/_classic-form.scss
@@ -363,9 +363,15 @@ $button-primary: #002838;
 	}
 }
 
-#feedbackBanner.notice {
-	border-left-width: 1px;
-	border-left-color: #c3c4c7;
+#feedbackBanner {
+	@media (min-width: 770px) {
+		margin-top: 30px;
+	}
+
+	&.notice {
+		border-left-width: 1px;
+		border-left-color: #c3c4c7;
+	}
 }
 
 @media (min-width: 1350px) {

--- a/tests/acceptance/PublishModelCest.php
+++ b/tests/acceptance/PublishModelCest.php
@@ -211,6 +211,8 @@ class PublishModelCest {
 		$i->click( 'Add New', '.wrap' );
 		$i->wait( 1 );
 
+		$i->click( '.notice-dismiss', '#feedbackBanner' );
+		$i->wait( 1 );
 		$i->click( 'Screen Options', '#screen-options-link-wrap' );
 		$i->wait( 1 );
 		$i->checkOption( 'slugdiv-hide' );

--- a/tests/acceptance/PublishModelCest.php
+++ b/tests/acceptance/PublishModelCest.php
@@ -3,6 +3,7 @@ use Codeception\Util\Locator;
 class PublishModelCest {
 
 	public function _before( \AcceptanceTester $i ) {
+		$i->resizeWindow( 1024, 1024 );
 		$i->maximizeWindow();
 
 		// First we create a model with fields.

--- a/tests/acceptance/PublishModelCest.php
+++ b/tests/acceptance/PublishModelCest.php
@@ -211,8 +211,6 @@ class PublishModelCest {
 		$i->click( 'Add New', '.wrap' );
 		$i->wait( 1 );
 
-		$i->click( '.notice-dismiss', '#feedbackBanner' );
-		$i->wait( 1 );
 		$i->click( 'Screen Options', '#screen-options-link-wrap' );
 		$i->wait( 1 );
 		$i->checkOption( 'slugdiv-hide' );

--- a/tests/acceptance/PublishModelCest.php
+++ b/tests/acceptance/PublishModelCest.php
@@ -210,8 +210,9 @@ class PublishModelCest {
 		$i->click( 'Add New', '.wrap' );
 		$i->wait( 1 );
 
-		// Check that the author meta box was moved to the sidebar by default.
+		// Check that the meta boxes were moved to the sidebar by default.
 		$i->see( 'Author', '#side-sortables' );
+		$i->see( 'Slug', '#side-sortables' );
 
 		$i->fillField( [ 'name' => 'atlas-content-modeler[goose][color]' ], 'Gray' );
 		$i->fillField( [ 'name' => 'atlas-content-modeler[goose][age]' ], '100' );

--- a/tests/acceptance/PublishModelCest.php
+++ b/tests/acceptance/PublishModelCest.php
@@ -213,6 +213,7 @@ class PublishModelCest {
 		$i->click( 'Screen Options', '#screen-options-link-wrap' );
 		$i->wait( 1 );
 		$i->checkOption( 'slugdiv-hide' );
+		$i->wait( 1 );
 
 		// Check that the meta boxes were moved to the sidebar by default.
 		$i->see( 'Author', '#side-sortables' );

--- a/tests/acceptance/PublishModelCest.php
+++ b/tests/acceptance/PublishModelCest.php
@@ -210,6 +210,10 @@ class PublishModelCest {
 		$i->click( 'Add New', '.wrap' );
 		$i->wait( 1 );
 
+		$i->click( 'Screen Options', '#screen-options-link-wrap' );
+		$i->wait( 1 );
+		$i->checkOption( 'slugdiv-hide' );
+
 		// Check that the meta boxes were moved to the sidebar by default.
 		$i->see( 'Author', '#side-sortables' );
 		$i->see( 'Slug', '#side-sortables' );


### PR DESCRIPTION
## Description
Enable slug editing for publisher.

## Testing
1. Create model
2. Go to publisher
3. Make sure screen options is displaying
4. Open screen options and enable "slug"
5. You should see the slug metabox in the sidebar

## Screenshots
![Screen Shot 2021-11-11 at 11 05 16 AM](https://user-images.githubusercontent.com/1815200/141339157-ca2547c0-d855-4173-baa3-1eb5a23abd7e.png)
