### PR TITLE
[MTKA-1321] Use consistent labels in the taxonomies table

### DIFF
--- a/includes/settings/js/src/components/TaxonomiesTable.jsx
+++ b/includes/settings/js/src/components/TaxonomiesTable.jsx
@@ -7,7 +7,7 @@ const TaxonomiesTableHead = () => {
 		<thead>
 			<tr>
 				<th>{__("Name", "atlas-content-modeler")}</th>
-				<th>{__("Slug", "atlas-content-modeler")}</th>
+				<th>{__("ID", "atlas-content-modeler")}</th>
 				<th>{__("Models", "atlas-content-modeler")}</th>
 				<th className="action">
 					{__("Action", "atlas-content-modeler")}


### PR DESCRIPTION
## Description

Changes “Slug” to “ID” for the taxonomies table to match the label in the taxonomy creation form. (We don't use “slug” anywhere else.)

https://wpengine.atlassian.net/browse/MTKA-1321

## Testing

Code review only.

## Screenshots

| Before | After
| - | - |
| <img width="1097" alt="Screenshot 2021-11-23 at 11 59 03" src="https://user-images.githubusercontent.com/647669/143012616-2eb67611-e721-465a-9286-23d0e05b26f1.png"> | <img width="1114" alt="Screenshot 2021-11-23 at 11 59 17" src="https://user-images.githubusercontent.com/647669/143012683-f96490c9-c054-4a87-b50d-2b5da96e054b.png"> |

## Documentation Changes

n/a

## Dependant PRs

n/a