### PR TITLE
[MTKA-1322] Update model name in WP sidebar when edited

### DIFF
--- a/includes/settings/js/src/components/EditModelModal.jsx
+++ b/includes/settings/js/src/components/EditModelModal.jsx
@@ -5,28 +5,8 @@ import { ModelsContext } from "../ModelsContext";
 import Icon from "../../../../components/icons";
 import IconPicker from "./IconPicker";
 import { __ } from "@wordpress/i18n";
-
-const $ = window.jQuery;
+import { updateSidebarMenuItem } from "../utils";
 const { apiFetch } = wp;
-
-/**
- * Update sidebar model item for icon changes
- */
-function updateSidebarMenuItem(model, data) {
-	let { model_icon } = data || "dashicons-admin-post";
-	if (model.model_icon !== model_icon) {
-		// update sidebar icon
-		$(`li#menu-posts-${model.slug}`)
-			.find(".wp-menu-image")
-			.removeClass(function (index, className) {
-				return (className.match(/(^|\s)dashicons-\S+/g) || []).join(
-					" "
-				);
-			})
-			.addClass("dashicons-before")
-			.addClass(`${model_icon}`);
-	}
-}
 
 /**
  * Updates a model via the REST API.
@@ -116,9 +96,9 @@ export function EditModelModal({ model, isOpen, setIsOpen }) {
 			<form
 				onSubmit={handleSubmit(async (data) => {
 					const mergedData = { ...model, ...data };
+					updateSidebarMenuItem(model, data);
 					await updateModel(data.slug, mergedData);
 					dispatch({ type: "updateModel", data: mergedData });
-					updateSidebarMenuItem(model, data);
 					setIsOpen(false);
 				})}
 			>

--- a/includes/settings/js/src/utils.js
+++ b/includes/settings/js/src/utils.js
@@ -41,6 +41,33 @@ export function removeSidebarMenuItem(slug) {
 }
 
 /**
+ * Updates the sidebar post type menu item if the icon or label changed.
+ *
+ * @param {Object} model - The original content model information.
+ * @param {Object} data - The updated content model data posted from the edit form.
+ */
+export function updateSidebarMenuItem(model, data) {
+	const { model_icon = "dashicons-admin-post", plural } = data;
+
+	// Update the post type menu label.
+	if (model.plural !== plural) {
+		document.querySelector(
+			`li#menu-posts-${model.slug} .wp-menu-name`
+		).innerHTML = plural;
+	}
+
+	// Update the post type menu icon.
+	if (model.model_icon !== model_icon) {
+		const menuIcon = document.querySelector(
+			`li#menu-posts-${model.slug} .wp-menu-image`
+		);
+
+		menuIcon.classList.remove(model.model_icon);
+		menuIcon.classList.add(model_icon);
+	}
+}
+
+/**
  * Generates the HTML for the content model menu item.
  *
  * @param {Object} model - The content model.

--- a/tests/acceptance/EditContentModelCest.php
+++ b/tests/acceptance/EditContentModelCest.php
@@ -32,8 +32,12 @@ class EditContentModelCest {
 		$i->see( 'Cats', '.model-list' );
 		$i->see( 'Cats are better than candy.', '.model-list' );
 
-		// Check the icon in the WP admin sidebar was updated.
+		// Check the icon in the WP admin sidebar was updated without refreshing the page.
 		$classes = $i->grabAttributeFrom( '#menu-posts-candy .wp-menu-image', 'class' );
 		$i->assertContains( 'dashicons-admin-media', $classes );
+
+		// Check the label in the WP admin sidebar was updated without refreshing the page.
+		$menu_label = $i->grabTextFrom( '#menu-posts-candy .wp-menu-name' );
+		$i->assertEquals( 'Cats', $menu_label );
 	}
 }


### PR DESCRIPTION
## Description

When editing a model's plural name, the menu item in the WordPress admin sidebar will now update without a page refresh.

https://wpengine.atlassian.net/browse/MTKA-1322

## Testing

Extends an existing e2e test to confirm that the name is updated in the sidebar.

### To test manually.
1. Edit a model's plural name.
2. Check the name updates in the sidebar without a page refresh.

## Screenshots

<img width="512" alt="Screenshot 2021-11-23 at 14 41 40" src="https://user-images.githubusercontent.com/647669/143034862-9fecfd86-e87d-47b3-9e22-d24ee463e637.png">

## Documentation Changes

n/a

## Dependant PRs

n/a