### PR TITLE
[NOJIRA] Add data about duplicate multiple choice option slugs to the error directly

### DIFF
--- a/includes/rest-api/routes/content-model-field.php
+++ b/includes/rest-api/routes/content-model-field.php
@@ -166,20 +166,21 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 
 	// Check if a slug name is a duplicate.
 	if ( isset( $params['type'] ) && $params['type'] === 'multipleChoice' && $params['choices'] ) {
-		$problem_option_slug_index = [];
+		$problem_option_slugs = [];
 		foreach ( $params['choices'] as $index => $choice ) {
 			if ( content_model_multi_option_slug_exists( $params['choices'], $choice['slug'], $index ) ) {
-				$problem_option_slug_index[] = $index;
+				$problem_option_slugs[] = $index;
 			}
 		}
-		if ( $problem_option_slug_index ) {
-			$problem_duplicate_slug = new WP_Error(
+		if ( $problem_option_slugs ) {
+			return new WP_Error(
 				'wpe_option_slug_duplicate',
 				__( 'Another choice in this field has the same API identifier.', 'atlas-content-modeler' ),
-				array( 'status' => 400 )
+				array(
+					'status'     => 400,
+					'duplicates' => $problem_option_slugs,
+				)
 			);
-			$problem_duplicate_slug->add( 'problem_option_slug_index', $problem_option_slug_index );
-			return $problem_duplicate_slug;
 		}
 	}
 

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -259,7 +259,7 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 					});
 				}
 				if (err.code === "wpe_option_slug_duplicate") {
-					err.additional_errors[0].message.map((index) => {
+					err.data.duplicates.map((index) => {
 						setError("multipleChoice" + index, {
 							type: "multipleChoiceSlugDuplicate" + index,
 						});


### PR DESCRIPTION
FAO @anthonyburchell.

An example of adding data about the duplicate option slugs to the returned validation error data directly.

This removes the need to call `$error->add()`, which addresses @mindctrl's comment at https://github.com/wpengine/atlas-content-modeler/pull/210#discussion_r752319640.

A similar pattern could be used to replace the other `add()` calls in `includes/rest-api/routes/content-model-field.php`.