### PR TITLE
[MTKA-1323] Enable post titles in WPGraphQL responses

### DIFF
--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -74,7 +74,8 @@ final class FormEditingExperience {
 		$this->models = get_registered_content_types();
 
 		add_action( 'init', [ $this, 'remove_post_type_supports' ] );
-		add_action( 'rest_api_init', [ $this, 'support_title_in_rest_responses' ] );
+		add_action( 'rest_api_init', [ $this, 'support_title_in_api_responses' ] );
+		add_action( 'graphql_process_http_request', [ $this, 'support_title_in_api_responses' ] );
 		add_action( 'rest_api_init', [ $this, 'add_related_posts_to_rest_responses' ] );
 		add_filter( 'use_block_editor_for_post_type', [ $this, 'disable_block_editor' ], 10, 2 );
 		add_action( 'current_screen', [ $this, 'current_screen' ] );
@@ -115,9 +116,9 @@ final class FormEditingExperience {
 	}
 
 	/**
-	 * Reinstates the title so that it appears in REST responses.
+	 * Reinstates the title so that it appears in API responses.
 	 */
-	public function support_title_in_rest_responses(): void {
+	public function support_title_in_api_responses(): void {
 		foreach ( $this->models as $model => $info ) {
 			add_post_type_support( $model, 'title' );
 		}

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -75,7 +75,7 @@ final class FormEditingExperience {
 
 		add_action( 'init', [ $this, 'remove_post_type_supports' ] );
 		add_action( 'rest_api_init', [ $this, 'support_title_in_api_responses' ] );
-		add_action( 'graphql_process_http_request', [ $this, 'support_title_in_api_responses' ] );
+		add_action( 'init_graphql_request', [ $this, 'support_title_in_api_responses' ] );
 		add_action( 'rest_api_init', [ $this, 'add_related_posts_to_rest_responses' ] );
 		add_filter( 'use_block_editor_for_post_type', [ $this, 'disable_block_editor' ], 10, 2 );
 		add_action( 'current_screen', [ $this, 'current_screen' ] );

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -24,6 +24,10 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 		// Start each test with a fresh relationships registry.
 		\WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->setup();
 
+		// Initialize the publisher logic, which includes additional filters.
+		$form_editing_experience = new \WPE\AtlasContentModeler\FormEditingExperience();
+		$form_editing_experience->bootstrap();
+
 		// @todo why is this not running automatically?
 		do_action( 'init' );
 
@@ -87,7 +91,7 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 			self::assertArrayHasKey( 'databaseId', $results['data']['publicsFields']['nodes'][0] );
 
 			self::assertArrayHasKey( 'title', $results['data']['publicsFields']['nodes'][0] );
-			self::assertSame( $results['data']['publicsFields']['nodes'][0]['title'], 'Test dog with fields' );
+			self::assertSame( $results['data']['publicsFields']['nodes'][0]['title'], 'This is required single line text' );
 
 			self::assertArrayHasKey( 'richText', $results['data']['publicsFields']['nodes'][0] );
 			self::assertSame( $results['data']['publicsFields']['nodes'][0]['richText'], 'This is a rich text field' );


### PR DESCRIPTION
## Description

Fixes #281 by enabling post title support during GraphQL requests.

https://wpengine.atlassian.net/browse/MTKA-1323

## Testing

Amends an existing PHP unit test to check the title is present and filtered to display the current title field.

### To test manually

1. Create a model with a title field.
1. Add an entry.
1. Run this query in GraphiQL, which should return `title` in the response for all ACM models.

```
{
  contentNodes {
    nodes {
      __typename
      ... on NodeWithTitle {
        title
      }
    }
  }
}
```

## Screenshots

n/a
## Documentation Changes

n/a

## Dependant PRs

n/a