### PR TITLE
[MTKA 1089] Standardize error codes

### DIFF
--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -34,7 +34,7 @@ function create_model( string $post_type_slug, array $args ) {
 
 	if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) ) {
 		return new WP_Error(
-			'atlas_content_modeler_already_exists',
+			'acm_already_exists',
 			__( 'A content model with this Model ID already exists.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -76,7 +76,7 @@ function create_models( array $models ) {
 
 		if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) ) {
 			return new WP_Error(
-				'atlas_content_modeler_already_exists',
+				'acm_already_exists',
 				// translators: The name of the model.
 				sprintf( __( 'A model with slug ‘%s’ already exists.', 'atlas-content-modeler' ), $args['slug'] ),
 				[ 'status' => 400 ]
@@ -108,7 +108,7 @@ function get_model_args( string $post_type_slug, array $args ) {
 
 	if ( empty( $post_type_slug ) || strlen( $post_type_slug ) > 20 ) {
 		return new WP_Error(
-			'atlas_content_modeler_invalid_id',
+			'acm_invalid_id',
 			__( 'Please provide a valid Model ID.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -116,7 +116,7 @@ function get_model_args( string $post_type_slug, array $args ) {
 
 	if ( empty( $args['singular'] ) || empty( $args['plural'] ) ) {
 		return new WP_Error(
-			'atlas_content_modeler_invalid_labels',
+			'acm_invalid_labels',
 			__( 'Please provide singular and plural labels when creating a content model.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -202,7 +202,7 @@ function delete_model( string $post_type_slug ) {
 
 	if ( empty( $post_type_slug ) || empty( $content_types[ $post_type_slug ] ) ) {
 		return new WP_Error(
-			'atlas_content_modeler_invalid_id',
+			'acm_invalid_id',
 			__( 'Please provide a valid Model ID.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -229,7 +229,7 @@ function delete_model( string $post_type_slug ) {
 
 		if ( ! $updated ) {
 			return new WP_Error(
-				'atlas_content_modeler_taxonomies_not_updated',
+				'acm_taxonomies_not_updated',
 				__( 'Model deletion aborted. Failed to remove model from associated taxonomies.', 'atlas-content-modeler' )
 			);
 		}
@@ -242,7 +242,7 @@ function delete_model( string $post_type_slug ) {
 
 	if ( ! $updated ) {
 		return new WP_Error(
-			'atlas_content_modeler_model_not_deleted',
+			'acm_model_not_deleted',
 			__( 'Model not deleted. Reason unknown.', 'atlas-content-modeler' )
 		);
 	}

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -151,14 +151,14 @@ function get_model_args( string $post_type_slug, array $args ) {
 function update_model( string $post_type_slug, array $args ) {
 	if ( empty( $post_type_slug ) ) {
 		return new WP_Error(
-			'wpe_invalid_content_model_id',
+			'acm_invalid_content_model_id',
 			__( 'Invalid content model ID.', 'atlas-content-modeler' )
 		);
 	}
 
 	if ( empty( $args['singular'] ) || empty( $args['plural'] ) ) {
 		return new WP_Error(
-			'wpe_invalid_content_model_arguments',
+			'acm_invalid_content_model_arguments',
 			__( 'Please provide singular and plural labels when creating a content model.', 'atlas-content-modeler' )
 		);
 	}
@@ -166,7 +166,7 @@ function update_model( string $post_type_slug, array $args ) {
 	$content_types = get_registered_content_types();
 	if ( empty( $content_types[ $post_type_slug ] ) ) {
 		return new WP_Error(
-			'wpe_invalid_content_model_id',
+			'acm_invalid_content_model_id',
 			__( 'Invalid content model ID.', 'atlas-content-modeler' )
 		);
 	}

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -34,7 +34,7 @@ function create_model( string $post_type_slug, array $args ) {
 
 	if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) ) {
 		return new WP_Error(
-			'acm_already_exists',
+			'acm_model_exists',
 			__( 'A content model with this Model ID already exists.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -76,7 +76,7 @@ function create_models( array $models ) {
 
 		if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) ) {
 			return new WP_Error(
-				'acm_already_exists',
+				'acm_model_exists',
 				// translators: The name of the model.
 				sprintf( __( 'A model with slug ‘%s’ already exists.', 'atlas-content-modeler' ), $args['slug'] ),
 				[ 'status' => 400 ]

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -158,7 +158,7 @@ function update_model( string $post_type_slug, array $args ) {
 
 	if ( empty( $args['singular'] ) || empty( $args['plural'] ) ) {
 		return new WP_Error(
-			'acm_invalid_content_model_arguments',
+			'acm_invalid_labels',
 			__( 'Please provide singular and plural labels when creating a content model.', 'atlas-content-modeler' )
 		);
 	}

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -108,7 +108,7 @@ function get_model_args( string $post_type_slug, array $args ) {
 
 	if ( empty( $post_type_slug ) || strlen( $post_type_slug ) > 20 ) {
 		return new WP_Error(
-			'acm_invalid_id',
+			'acm_invalid_model_id',
 			__( 'Please provide a valid Model ID.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -202,7 +202,7 @@ function delete_model( string $post_type_slug ) {
 
 	if ( empty( $post_type_slug ) || empty( $content_types[ $post_type_slug ] ) ) {
 		return new WP_Error(
-			'acm_invalid_id',
+			'acm_invalid_model_id',
 			__( 'Please provide a valid Model ID.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);

--- a/includes/rest-api/routes/content-model-field.php
+++ b/includes/rest-api/routes/content-model-field.php
@@ -65,7 +65,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 
 	if ( ! isset( $params['model'] ) || empty( $content_types[ $params['model'] ] ) ) {
 		return new WP_Error(
-			'wpe_invalid_content_model',
+			'acm_invalid_content_model',
 			__( 'The specified content model does not exist.', 'atlas-content-modeler' ),
 			array( 'status' => 400 )
 		);
@@ -104,7 +104,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 
 	if ( isset( $params['type'] ) && $params['type'] === 'multipleChoice' && ! $params['choices'] ) {
 		return new WP_Error(
-			'wpe_invalid_multi_options',
+			'acm_invalid_multi_options',
 			__( 'Multiple Choice update failed. Choices need to be created before updating a Multiple Choice field.', 'atlas-content-modeler' ),
 			array( 'status' => 400 )
 		);
@@ -118,7 +118,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		}
 		if ( ! empty( $problem_index ) ) {
 			return new WP_Error(
-				'wpe_option_name_undefined',
+				'acm_option_name_undefined',
 				__( 'Multiple Choice Field update failed, please set a name for your choice before saving.', 'atlas-content-modeler' ),
 				array(
 					'status'       => 400,
@@ -139,7 +139,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		// Check if a choice slug is blank.
 		if ( ! empty( $problem_index ) ) {
 			return new WP_Error(
-				'wpe_option_slug_undefined',
+				'acm_option_slug_undefined',
 				__( 'Multiple Choice Field update failed, please set a slug for your choice before saving.', 'atlas-content-modeler' ),
 				array(
 					'status'       => 400,
@@ -159,7 +159,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		}
 		if ( $problem_name_index ) {
 			return new WP_Error(
-				'wpe_duplicate_content_model_multi_option_id',
+				'acm_duplicate_content_model_multi_option_id',
 				__( 'Another choice in this field has the same name.', 'atlas-content-modeler' ),
 				array(
 					'status'     => 400,
@@ -179,7 +179,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		}
 		if ( $problem_option_slugs ) {
 			return new WP_Error(
-				'wpe_option_slug_duplicate',
+				'acm_option_slug_duplicate',
 				__( 'Another choice in this field has the same API identifier.', 'atlas-content-modeler' ),
 				array(
 					'status'     => 400,
@@ -198,7 +198,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		}
 		if ( $problem_name_index ) {
 			return new WP_Error(
-				'wpe_duplicate_content_model_multi_option_id',
+				'acm_duplicate_content_model_multi_option_id',
 				__( 'Another option in this field has the same API identifier.', 'atlas-content-modeler' ),
 				array(
 					'status'     => 400,
@@ -217,7 +217,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		)
 	) {
 		return new WP_Error(
-			'wpe_duplicate_content_model_field_id',
+			'acm_duplicate_content_model_field_id',
 			__( 'Another field in this model has the same API identifier.', 'atlas-content-modeler' ),
 			array( 'status' => 400 )
 		);
@@ -296,7 +296,7 @@ function dispatch_delete_content_model_field( WP_REST_Request $request ) {
 
 	if ( empty( $model ) || empty( $content_types[ $model ] ) ) {
 		return new WP_Error(
-			'wpe_invalid_content_model',
+			'acm_invalid_content_model',
 			__( 'You must specify a valid model.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -304,7 +304,7 @@ function dispatch_delete_content_model_field( WP_REST_Request $request ) {
 
 	if ( ! isset( $content_types[ $model ]['fields'][ $field_id ] ) ) {
 		return new WP_Error(
-			'wpe_invalid_content_model_field_id',
+			'acm_invalid_content_model_field_id',
 			__( 'Invalid field ID.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);

--- a/includes/rest-api/routes/content-model-field.php
+++ b/includes/rest-api/routes/content-model-field.php
@@ -78,7 +78,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		in_array( $params['slug'], $reserved_field_slugs, true )
 	) {
 		return new WP_Error(
-			'atlas_content_modeler_reserved_field_slug',
+			'acm_reserved_field_slug',
 			__( 'Identifier in use or reserved.', 'atlas-content-modeler' ),
 			array( 'status' => 400 )
 		);
@@ -87,7 +87,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 	if ( isset( $params['type'] ) && $params['type'] === 'relationship' ) {
 		if ( empty( $params['reference'] ) || empty( $params['cardinality'] ) ) {
 			return new WP_Error(
-				'atlas_content_modeler_missing_field_argument',
+				'acm_missing_field_argument',
 				__( 'The relationship field requires a reference and cardinality argument.', 'atlas-content-modeler' ),
 				array( 'status' => 400 )
 			);
@@ -95,7 +95,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 
 		if ( empty( $content_types[ $params['reference'] ] ) ) {
 			return new WP_Error(
-				'atlas_content_modeler_invalid_related_content_model',
+				'acm_invalid_related_content_model',
 				__( 'The related content model no longer exists.', 'atlas-content-modeler' ),
 				array( 'status' => 400 )
 			);
@@ -234,7 +234,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		)
 	) {
 		return new WP_Error(
-			'atlas_content_modeler_reverse_slug_conflict',
+			'acm_reverse_slug_conflict',
 			sprintf(
 				/* translators: %s: reference id of the referenced to field */
 				__( 'A field in the %s model has the same identifier.', 'atlas-content-modeler' ),
@@ -251,7 +251,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 		content_model_reverse_slug_exists( $params )
 	) {
 		return new WP_Error(
-			'atlas_content_modeler_reverse_slug_in_use',
+			'acm_reverse_slug_in_use',
 			__( 'A relationship field in this model has the same identifier.', 'atlas-content-modeler' ),
 			array( 'status' => 400 )
 		);

--- a/includes/rest-api/routes/content-model-fields.php
+++ b/includes/rest-api/routes/content-model-fields.php
@@ -51,7 +51,7 @@ function dispatch_patch_content_model_fields( WP_REST_Request $request ) {
 
 	if ( empty( $params['fields'] ) ) {
 		return new WP_Error(
-			'wpe_missing_fields_data',
+			'acm_missing_fields_data',
 			__( 'Expected a fields key with fields to update.', 'atlas-content-modeler' ),
 			array( 'status' => 400 )
 		);
@@ -61,7 +61,7 @@ function dispatch_patch_content_model_fields( WP_REST_Request $request ) {
 
 	if ( empty( $content_types[ $slug ] ) ) {
 		return new WP_Error(
-			'wpe_invalid_content_model',
+			'acm_invalid_content_model',
 			__( 'The specified content model does not exist.', 'atlas-content-modeler' ),
 			array( 'status' => 400 )
 		);

--- a/includes/rest-api/routes/content-model.php
+++ b/includes/rest-api/routes/content-model.php
@@ -149,7 +149,7 @@ function dispatch_update_content_model( WP_REST_Request $request ) {
 
 	if ( empty( $content_types[ $slug ] ) ) {
 		return new WP_Error(
-			'wpe_invalid_content_model_id',
+			'acm_invalid_content_model_id',
 			__( 'Invalid content model ID.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -26,7 +26,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 
 	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {
 		return new WP_Error(
-			'acm_invalid_id',
+			'acm_invalid_taxonomy_id',
 			esc_html__( 'Taxonomy slug must be between 1 and 32 characters in length.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -26,7 +26,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 
 	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {
 		return new WP_Error(
-			'atlas_content_modeler_invalid_id',
+			'acm_invalid_id',
 			esc_html__( 'Taxonomy slug must be between 1 and 32 characters in length.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -35,7 +35,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 	// Prevents use of reserved taxonomy terms as slugs during new taxonomy creation.
 	if ( in_array( $params['slug'], $reserved_tax_terms, true ) ) {
 		return new WP_Error(
-			'atlas_content_modeler_reserved_taxonomy_term',
+			'acm_reserved_taxonomy_term',
 			__( 'Taxonomy slug is reserved.', 'atlas-content-modeler' ),
 			array( 'status' => 400 )
 		);
@@ -48,7 +48,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 	// Prevents creation of a taxonomy if one with the same slug exists that was not created in ACM.
 	if ( in_array( $params['slug'], $non_acm_taxonomies, true ) ) {
 		return new WP_Error(
-			'atlas_content_modeler_taxonomy_exists',
+			'acm_taxonomy_exists',
 			esc_html__( 'A taxonomy with this Taxonomy ID already exists.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -57,7 +57,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 	// Allows updates of existing ACM taxonomies, but prevents creation of ACM taxonomies with identical slugs.
 	if ( ! $is_update && array_key_exists( $params['slug'], $acm_taxonomies ) ) {
 		return new WP_Error(
-			'atlas_content_modeler_taxonomy_exists',
+			'acm_taxonomy_exists',
 			esc_html__( 'A taxonomy with this Taxonomy ID already exists.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -65,7 +65,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 
 	if ( empty( $params['singular'] ) || empty( $params['plural'] ) ) {
 		return new WP_Error(
-			'atlas_content_modeler_invalid_labels',
+			'acm_invalid_labels',
 			esc_html__( 'Please provide singular and plural labels when creating a taxonomy.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
@@ -85,7 +85,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 
 	if ( ! $created ) {
 		return new WP_Error(
-			'atlas_content_modeler_taxonomy_not_created',
+			'acm_taxonomy_not_created',
 			esc_html__( 'Taxonomy not created. Reason unknown.', 'atlas-content-modeler' )
 		);
 	}

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -72,7 +72,7 @@ export default function CreateContentModel() {
 				}
 			})
 			.catch((err) => {
-				if (err.code === "acm_already_exists") {
+				if (err.code === "acm_model_exists") {
 					setError("slug", {
 						type: "idExists",
 						message: err.message,

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -72,7 +72,7 @@ export default function CreateContentModel() {
 				}
 			})
 			.catch((err) => {
-				if (err.code === "atlas_content_modeler_already_exists") {
+				if (err.code === "acm_already_exists") {
 					setError("slug", {
 						type: "idExists",
 						message: err.message,

--- a/includes/settings/js/src/components/TaxonomiesForm.jsx
+++ b/includes/settings/js/src/components/TaxonomiesForm.jsx
@@ -138,8 +138,8 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 			})
 			.catch((err) => {
 				if (
-					err.code === "atlas_content_modeler_taxonomy_exists" ||
-					err.code === "atlas_content_modeler_reserved_taxonomy_term"
+					err.code === "acm_taxonomy_exists" ||
+					err.code === "acm_reserved_taxonomy_term"
 				) {
 					setError("slug", {
 						type: "invalidSlug",

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -285,27 +285,22 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 						)
 					);
 				}
-				if (
-					err.code ===
-					"atlas_content_modeler_invalid_related_content_model"
-				) {
+				if (err.code === "acm_invalid_related_content_model") {
 					setError("reference", { type: "invalidRelatedModel" });
 				}
-				if (
-					err.code === "atlas_content_modeler_reverse_slug_conflict"
-				) {
+				if (err.code === "acm_reverse_slug_conflict") {
 					setError("reverseSlug", {
 						type: "reverseIdConflicts",
 						message: err.message,
 					});
 				}
-				if (err.code === "atlas_content_modeler_reverse_slug_in_use") {
+				if (err.code === "acm_reverse_slug_in_use") {
 					setError("reverseSlug", {
 						type: "reverseIdInUse",
 						message: err.message,
 					});
 				}
-				if (err.code === "atlas_content_modeler_reserved_field_slug") {
+				if (err.code === "acm_reserved_field_slug") {
 					setError("slug", { type: "nameReserved" });
 				}
 			});

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -241,24 +241,24 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 				hasDirtyField.current = false;
 			})
 			.catch((err) => {
-				if (err.code === "wpe_duplicate_content_model_field_id") {
+				if (err.code === "acm_duplicate_content_model_field_id") {
 					setError("slug", { type: "idExists" });
 				}
-				if (err.code === "wpe_option_name_undefined") {
+				if (err.code === "acm_option_name_undefined") {
 					err.data.problemIndex.map((index) => {
 						setError("multipleChoice" + index, {
 							type: "multipleChoiceNameEmpty" + index,
 						});
 					});
 				}
-				if (err.code === "wpe_option_slug_undefined") {
+				if (err.code === "acm_option_slug_undefined") {
 					err.data.problemIndex.map((index) => {
 						setError("multipleChoice" + index, {
 							type: "multipleChoiceSlugEmpty" + index,
 						});
 					});
 				}
-				if (err.code === "wpe_option_slug_duplicate") {
+				if (err.code === "acm_option_slug_duplicate") {
 					err.data.duplicates.map((index) => {
 						setError("multipleChoice" + index, {
 							type: "multipleChoiceSlugDuplicate" + index,
@@ -266,7 +266,7 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 					});
 				}
 				if (
-					err.code === "wpe_duplicate_content_model_multi_option_id"
+					err.code === "acm_duplicate_content_model_multi_option_id"
 				) {
 					err.data.duplicates.map((index) => {
 						setError("multipleChoiceName" + index, {
@@ -274,10 +274,10 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 						});
 					});
 				}
-				if (err.code === "wpe_invalid_multi_options") {
+				if (err.code === "acm_invalid_multi_options") {
 					setError("multipleChoice", { type: "multipleChoiceEmpty" });
 				}
-				if (err.code === "wpe_invalid_content_model") {
+				if (err.code === "acm_invalid_content_model") {
 					console.error(
 						__(
 							"Attempted to create a field in a model that no longer exists.",

--- a/tests/integration/api-validation/test-rest-field-endpoints.php
+++ b/tests/integration/api-validation/test-rest-field-endpoints.php
@@ -472,7 +472,7 @@ class RestFieldEndpointTests extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		self::assertEquals( 400, $response->get_status() );
-		self::assertSame( 'wpe_invalid_content_model', $response->get_data()['code'] );
+		self::assertSame( 'acm_invalid_content_model', $response->get_data()['code'] );
 	}
 
 	/**

--- a/tests/integration/api-validation/test-rest-field-endpoints.php
+++ b/tests/integration/api-validation/test-rest-field-endpoints.php
@@ -498,7 +498,7 @@ class RestFieldEndpointTests extends WP_UnitTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'atlas_content_modeler_missing_field_argument', $data['code'] );
+		$this->assertEquals( 'acm_missing_field_argument', $data['code'] );
 	}
 
 	/**
@@ -524,7 +524,7 @@ class RestFieldEndpointTests extends WP_UnitTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'atlas_content_modeler_missing_field_argument', $data['code'] );
+		$this->assertEquals( 'acm_missing_field_argument', $data['code'] );
 	}
 
 	/**
@@ -551,7 +551,7 @@ class RestFieldEndpointTests extends WP_UnitTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'atlas_content_modeler_invalid_related_content_model', $data['code'] );
+		$this->assertEquals( 'acm_invalid_related_content_model', $data['code'] );
 	}
 
 	public function test_using_reserved_field_slug_generates_error() {
@@ -573,6 +573,6 @@ class RestFieldEndpointTests extends WP_UnitTestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'atlas_content_modeler_reserved_field_slug', $data['code'] );
+		$this->assertEquals( 'acm_reserved_field_slug', $data['code'] );
 	}
 }

--- a/tests/integration/api-validation/test-rest-model-endpoints.php
+++ b/tests/integration/api-validation/test-rest-model-endpoints.php
@@ -88,7 +88,7 @@ class RestModelEndpointTests extends WP_UnitTestCase {
 
 		$response = $this->server->dispatch( $request );
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'atlas_content_modeler_already_exists', $response->data['code'] );
+		self::assertSame( 'acm_already_exists', $response->data['code'] );
 	}
 
 	/**

--- a/tests/integration/api-validation/test-rest-model-endpoints.php
+++ b/tests/integration/api-validation/test-rest-model-endpoints.php
@@ -88,7 +88,7 @@ class RestModelEndpointTests extends WP_UnitTestCase {
 
 		$response = $this->server->dispatch( $request );
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'acm_already_exists', $response->data['code'] );
+		self::assertSame( 'acm_model_exists', $response->data['code'] );
 	}
 
 	/**

--- a/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
+++ b/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
@@ -156,7 +156,7 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'acm_invalid_id', $response->data['code'] );
+		self::assertSame( 'acm_invalid_taxonomy_id', $response->data['code'] );
 	}
 
 	public function test_cannot_create_taxonomy_without_singular_name(): void {

--- a/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
+++ b/tests/integration/content-registration/test-rest-taxonomy-endpoint.php
@@ -120,7 +120,7 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'atlas_content_modeler_taxonomy_exists', $response->data['code'] );
+		self::assertSame( 'acm_taxonomy_exists', $response->data['code'] );
 	}
 
 	public function test_cannot_create_taxonomy_when_slug_conflicts_with_reserved_taxonomy_term(): void {
@@ -132,7 +132,7 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'atlas_content_modeler_reserved_taxonomy_term', $response->data['code'] );
+		self::assertSame( 'acm_reserved_taxonomy_term', $response->data['code'] );
 	}
 
 	public function test_cannot_create_taxonomy_when_slug_conflicts_with_existing_acm_taxonomy(): void {
@@ -144,7 +144,7 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'atlas_content_modeler_taxonomy_exists', $response->data['code'] );
+		self::assertSame( 'acm_taxonomy_exists', $response->data['code'] );
 	}
 
 	public function test_cannot_create_taxonomy_without_slug(): void {
@@ -156,7 +156,7 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'atlas_content_modeler_invalid_id', $response->data['code'] );
+		self::assertSame( 'acm_invalid_id', $response->data['code'] );
 	}
 
 	public function test_cannot_create_taxonomy_without_singular_name(): void {
@@ -168,7 +168,7 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'atlas_content_modeler_invalid_labels', $response->data['code'] );
+		self::assertSame( 'acm_invalid_labels', $response->data['code'] );
 	}
 
 	public function test_cannot_create_taxonomy_without_plural_name(): void {
@@ -180,7 +180,7 @@ class TestRestTaxonomyEndpoint extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		self::assertSame( 400, $response->get_status() );
-		self::assertSame( 'atlas_content_modeler_invalid_labels', $response->data['code'] );
+		self::assertSame( 'acm_invalid_labels', $response->data['code'] );
 	}
 
 	public function test_can_update_taxonomy_with_put_request(): void {


### PR DESCRIPTION
## Description

Uses the `acm_` prefix for all error codes, instead of a mix of `wpe_` and `atlas_content_modeler_`

https://wpengine.atlassian.net/browse/MTKA-1089

## Testing

Existing tests should pass.

## Screenshots

n/a

## Documentation Changes

It's unlikely that people are using these APIs directly, but we should mention this in our changelog even though it's effectively an internal change.

## Dependant PRs

n/a