### PR TITLE
MTKA-1333: replace deprecated CircleCI Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@
 version: 2.1
 orbs:
   wp-product-orb: wpengine/wp-product-orb@1.3.0
-  php: cimg/php@7.4.26
-  node: cimg/node@16.13.1
+  php: cimg/php:7.4.26
+  node: cimg/node:16.13.1
 
 commands:
   set_version_variable:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
           name: Install MySQL PHP extension
           command: |
             sudo apt-get update -yq
-            sudo docker-php-ext-install mysqli zip pdo_mysql
+            sudo apt-get install docker-php-ext-install mysqli zip pdo_mysql
 
       - run:
           # Our primary container isn't MYSQL so run a sleep command until it's ready.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,7 @@ jobs:
       - run:
           name: Install mysql_client
           command: |
+            sudo apt-get update -yq
             sudo apt-get install default-mysql-client
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 orbs:
   wp-product-orb: wpengine/wp-product-orb@1.3.0
   php: cimg/php@7.4
-  node: cimg/node@16.13
+  node: cimg/node@16.13.1
 
 commands:
   set_version_variable:
@@ -391,7 +391,7 @@ jobs:
 
   plugin-test-unit:
     docker:
-      - image: cimg/php:7.4
+      - image: cimg/php:7.4.26
       - image: cimg/mysql:5.7
         environment:
           MYSQL_DATABASE: wp_database
@@ -422,7 +422,7 @@ jobs:
 
   plugin-test-content-connect:
     docker:
-      - image: cimg/php:7.4
+      - image: cimg/php:7.4.26
       - image: circleci/mysql:5.7
         environment:
           MYSQL_DATABASE: wp_database

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@
 version: 2.1
 orbs:
   wp-product-orb: wpengine/wp-product-orb@1.3.0
-  php: cimg/php:7.4
-  node: cimg/node:16.13
+  php: circleci/php@1.1.0
+  node: circleci/node@4.9.0
 
 commands:
   set_version_variable:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@
 version: 2.1
 orbs:
   wp-product-orb: wpengine/wp-product-orb@1.3.0
-  php: circleci/php@1.1.0
-  node: circleci/node@4.1.0
+  php: cimg/php@7.4
+  node: cimg/node@16.13
 
 commands:
   set_version_variable:
@@ -217,8 +217,8 @@ jobs:
 
   plugin-test-e2e:
     docker:
-      - image: circleci/php:7.4-node-browsers
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/php:7.4-browsers
+      - image: cimg/mysql:5.7
         environment:
           MYSQL_ROOT_PASSWORD: wordpress
           MYSQL_DATABASE: wordpress
@@ -392,7 +392,7 @@ jobs:
   plugin-test-unit:
     docker:
       - image: cimg/php:7.4
-      - image: circleci/mysql:5.7
+      - image: cimg/mysql:5.7
         environment:
           MYSQL_DATABASE: wp_database
           MYSQL_USER: wp_user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@
 version: 2.1
 orbs:
   wp-product-orb: wpengine/wp-product-orb@1.3.0
-  php: cimg/php:7.4.26
-  node: cimg/node:16.13.1
+  php: cimg/php:7.4
+  node: cimg/node:16.13
 
 commands:
   set_version_variable:
@@ -391,7 +391,7 @@ jobs:
 
   plugin-test-unit:
     docker:
-      - image: cimg/php:7.4.26
+      - image: cimg/php:7.4
       - image: cimg/mysql:5.7
         environment:
           MYSQL_DATABASE: wp_database
@@ -422,7 +422,7 @@ jobs:
 
   plugin-test-content-connect:
     docker:
-      - image: cimg/php:7.4.26
+      - image: cimg/php:7.4
       - image: circleci/mysql:5.7
         environment:
           MYSQL_DATABASE: wp_database

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
       - run:
           name: Install mysql_client
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
   plugin-test-content-connect:
     docker:
       - image: cimg/php:7.4
-      - image: circleci/mysql:5.7
+      - image: cimg/mysql:5.7
         environment:
           MYSQL_DATABASE: wp_database
           MYSQL_USER: wp_user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,9 @@ jobs:
 
       - run:
           name: Install MySQL PHP extension
-          command: sudo docker-php-ext-install mysqli zip pdo_mysql
+          command: |
+            sudo apt-get update -yq
+            sudo docker-php-ext-install mysqli zip pdo_mysql
 
       - run:
           # Our primary container isn't MYSQL so run a sleep command until it's ready.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ orbs:
   wp-product-orb: wpengine/wp-product-orb@1.3.0
   php: circleci/php@1.1.0
   node: circleci/node@4.9.0
+  browser-tools: circleci/browser-tools@1.2.3
 
 commands:
   set_version_variable:
@@ -228,6 +229,7 @@ jobs:
       - attach_workspace:
           at: .
 
+      - browser-tools/install-browser-tools
       - run:
           name: Install mysql_client
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 orbs:
   wp-product-orb: wpengine/wp-product-orb@1.3.0
-  php: cimg/php@7.4
+  php: cimg/php@7.4.26
   node: cimg/node@16.13.1
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,13 +233,6 @@ jobs:
           command: |
             sudo apt-get update -yq
             sudo apt-get install default-mysql-client
-
-      - run:
-          name: Install MySQL PHP extension
-          command: |
-            sudo apt-get update -yq
-            sudo apt-get install docker-php-ext-install mysqli zip pdo_mysql
-
       - run:
           # Our primary container isn't MYSQL so run a sleep command until it's ready.
           name: Waiting for MySQL to be ready


### PR DESCRIPTION
## Description
Replaces the legacy CircleCI Docker images with the latest supported versions.

CircleCI is deprecating some existing Docker images and replaced them with newer, faster images. Legacy convenience images with the prefix `circleci/` will be deprecated on Dec. 31, 2021.

https://wpengine.atlassian.net/browse/MTKA-1333

## Testing
Verify that CircleCI tests still run and pass as expected.
