### PR TITLE
MTKA-1339: fix: add hr.wp-header-end element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Atlas Content Modeler Changelog
+## Unreleased
+### Fixed
+- Improved display of admin notices on pages in the Content Modeler admin menu.
 
 ## 0.11.0 - 2021-12-01
 ### Added

--- a/includes/settings/views/admin-menu-page.php
+++ b/includes/settings/views/admin-menu-page.php
@@ -30,5 +30,6 @@ namespace WPE\AtlasContentModeler\Settings;
 			</div>
 		</div>
 	</header>
+	<hr class="wp-header-end">
 	<div id="root"></div>
 </div>


### PR DESCRIPTION
## Description

* Fixes issue where admin notices are displayed poorly
on the ACM admin page at `/wp-admin/admin.php?page=atlas-content-modeler`.

https://wpengine.atlassian.net/browse/MTKA-1339

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/1254870/145072412-7e0c713d-c4a7-4a0a-87ee-36bdcfaa0058.png)

After:
![image](https://user-images.githubusercontent.com/1254870/145072331-f29ef9c6-7466-4153-a15a-739bbaae0d64.png)
