### PR TITLE
test: run Chrome in headless mode

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -42,4 +42,4 @@ modules:
             window_size: false
             capabilities:
                 chromeOptions:
-                    args: ["disable-gpu"]
+                    args: ["--disable-gpu", "--headless"]


### PR DESCRIPTION
## Description
Updates Codeception's acceptance test config to run Chrome in headless mode when running tests locally.

This does **not** touch the CircleCI pipeline. That uses a different config stored in `tests/acceptance.suite.circleci.yml`

## Testing
Using your preferred method, run e2e tests locally and ensure that Chrome runs in headless mode and that tests still pass.

