### PR TITLE
MTKA-1338: Show GraphQL debug info on unauthenticated requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Atlas Content Modeler Changelog
 ## Unreleased
 ### Added
-- Debug info is now added to GraphQL responses when GraphQL Debug Mode is enabled and a request for Private models is made as an unautheticated user.
+- Debug info is now added to GraphQL responses when GraphQL Debug Mode is enabled and a request for Private models is made as an unauthenticated user.
 
 ### Fixed
 - Improved display of admin notices on pages in the Content Modeler admin menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Atlas Content Modeler Changelog
 ## Unreleased
+### Added
+- Debug info is now added to GraphQL responses when GraphQL Debug Mode is enabled and a request for Private models is made as an unautheticated user.
+
 ### Fixed
 - Improved display of admin notices on pages in the Content Modeler admin menu.
 

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -571,6 +571,15 @@ function graphql_data_is_private( bool $is_private, string $model_name, $post, $
 		$is_private = ! user_can( $current_user, $post_type->cap->read_post, $post->ID );
 	}
 
+	if ( $is_private && empty( $current_user->ID ) ) {
+		graphql_debug(
+			esc_html__( 'The request was unauthenticated, but this site contains private Atlas Content Modeler models. If you see empty results, try authenticating the request or making your ACM models public.', 'atlas-content-modeler' ),
+			[
+				'type' => 'ACM_UNAUTHORIZED_REQUEST',
+			]
+		);
+	}
+
 	return $is_private;
 }
 

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -566,7 +566,12 @@ function graphql_data_is_private( bool $is_private, string $model_name, $post, $
 	}
 
 	$models = get_registered_content_types();
-	if ( array_key_exists( $post->post_type, $models ) && isset( $models[ $post->post_type ]['api_visibility'] ) && 'private' === $models[ $post->post_type ]['api_visibility'] ) {
+	if ( ! array_key_exists( $post->post_type, $models ) ) {
+		// Return early if not an ACM model.
+		return $is_private;
+	}
+
+	if ( isset( $models[ $post->post_type ]['api_visibility'] ) && 'private' === $models[ $post->post_type ]['api_visibility'] ) {
 		$post_type  = get_post_type_object( $post->post_type );
 		$is_private = ! user_can( $current_user, $post_type->cap->read_post, $post->ID );
 	}

--- a/tests/integration/api-validation/test-graphql-endpoints.php
+++ b/tests/integration/api-validation/test-graphql-endpoints.php
@@ -50,6 +50,9 @@ class GraphQLEndpointTests extends WP_UnitTestCase {
 	 * Ensure a private model's data is not publicly queryable in GraphQL
 	 */
 	public function test_post_type_with_private_api_visibility_cannot_be_read_via_graphql_when_not_authenticated(): void {
+		$graphql_settings                       = get_option( 'graphql_general_settings', [] );
+		$graphql_settings['debug_mode_enabled'] = 'on';
+		update_option( 'graphql_general_settings', $graphql_settings );
 		try {
 			$results = graphql(
 				[
@@ -66,6 +69,7 @@ class GraphQLEndpointTests extends WP_UnitTestCase {
 			);
 
 			self::assertEmpty( $results['data']['privatesFields']['nodes'] );
+			self::assertSame( $results['extensions']['debug'][0]['type'], 'ACM_UNAUTHORIZED_REQUEST' );
 		} catch ( Exception $exception ) {
 			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
 		}


### PR DESCRIPTION
## Description
Adds debug info to GraphQL responses when the Debug Mode is enabled and a request for private models is unauthenticated.

https://wpengine.atlassian.net/browse/MTKA-1388

## Testing
1. Check the Enable GraphQL Debug Mode setting under GraphQL > Settings
2. Make a model with the API Visibility set to Private
3. Query the model as a logged out user and see debug info in response
4. Query the model as a logged in user and see **no** debug info in response
5. Disable GraphQL debug mode
6. Query the model as a logged out user and see **no** debug info in response 

## Screenshots

![image](https://user-images.githubusercontent.com/1254870/145590369-657733c4-9151-4d83-b5fb-57a2789bddfa.png)

