### PR TITLE
fix: do not trigger error when model with no changes is saved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - Improved display of admin notices on pages in the Content Modeler admin menu.
+- Saving a model that has no changes no longer causes an error to be displayed.
 
 ## 0.11.0 - 2021-12-01
 ### Added

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -176,6 +176,15 @@ function update_model( string $post_type_slug, array $args ) {
 	// Updating the slug is unsupported.
 	$new_args['slug'] = $post_type_slug;
 
+	/**
+	 * If no changes, return true.
+	 * Why? update_option returns false and does not update
+	 * when the new values match the old values.
+	 */
+	if ( $content_types[ $post_type_slug ] === $new_args ) {
+		return true;
+	}
+
 	$content_types[ $post_type_slug ] = $new_args;
 
 	$updated = update_registered_content_types( $content_types );


### PR DESCRIPTION
Fixes #155

## Description
Returns `true` if a model is saved when no changes are made.

## Testing
Edit existing model, make no changes, save it, see no errors. Compare this behavior to `main` branch.
