### PR TITLE
Release for 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Atlas Content Modeler Changelog
-## Unreleased
+
+## 0.12.0 - 2021-12-15
 ### Added
 - Debug info is now added to GraphQL responses when GraphQL Debug Mode is enabled and a request for Private models is made as an unauthenticated user.
 

--- a/atlas-content-modeler.php
+++ b/atlas-content-modeler.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpengine.com/
  * Text Domain: atlas-content-modeler
  * Domain Path: /languages
- * Version: 0.11.0
+ * Version: 0.12.0
  * Requires at least: 5.7
  * Requires PHP: 7.2
  * License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-content-modeler",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "",
   "targets": {
     "settings": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Atlas Content Modeler ===
 Requires at least: 5.7
-Tested up to: 5.8
+Tested up to: 5.8.2
 Requires PHP: 7.2
-Stable tag: 0.11.0
+Stable tag: 0.12.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Author: WP Engine
@@ -52,6 +52,12 @@ ACM is primarily intended for headless WordPress applications. For that reason, 
 = Where can I submit bug reports and feature requests? =
 You can submit feature requests and open bug reports in our [GitHub repo](https://github.com/wpengine/atlas-content-modeler).
 == Changelog ==
+
+= 0.12.0 - 2021-12-15 =
+
+* **Added:** Debug info is now added to GraphQL responses when GraphQL Debug Mode is enabled and a request for Private models is made as an unauthenticated user.
+* **Fixed:** Improved display of admin notices on pages in the Content Modeler admin menu.
+* **Fixed:** Saving a model that has no changes no longer causes an error to be displayed.
 
 = 0.11.0 - 2021-12-01 =
 


### PR DESCRIPTION
## Description
Release 0.12.0

## 0.12.0 - 2021-12-15
### Added
- Debug info is now added to GraphQL responses when GraphQL Debug Mode is enabled and a request for Private models is made as an unauthenticated user.

### Fixed
- Improved display of admin notices on pages in the Content Modeler admin menu.
- Saving a model that has no changes no longer causes an error to be displayed.

