### PR TITLE
MTKA-1332: model/taxonomy label check for collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Fixed
 - Prevent PHP fatal errors on sites running < PHP 7.4 under certain conditions when no models exist.
+- Prevent model and taxonomy creation and updates if singular or plural labels conflict with existing WPGraphQL fields.
 
 ## 0.12.0 - 2021-12-15
 ### Added

--- a/includes/rest-api/graphql.php
+++ b/includes/rest-api/graphql.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * GraphQL introspection queries used in REST API callbacks.
+ *
+ * @package AtlasContentModeler
+ */
+
+declare(strict_types=1);
+
+namespace WPE\AtlasContentModeler\REST_API\GraphQL;
+
+use function WPE\AtlasContentModeler\ContentRegistration\camelcase;
+
+/**
+ * Types that should not be used for model or taxonomy labels in case they
+ * cause conflicts when the WPGraphQL plugin is activated later.
+ *
+ * Sourced from running this query in GraphiQL with no other plugins active
+ * and no ACM models or taxonomies present:
+ *
+ * {
+ *   __type(name: "RootQuery") {
+ *     fields {
+ *       name
+ *     }
+ *   }
+ * }
+ */
+const ACM_DEFAULT_GRAPHQL_ROOT_FIELDS = [
+	'allSettings',
+	'categories',
+	'category',
+	'comment',
+	'comments',
+	'contentNode',
+	'contentNodes',
+	'contentType',
+	'contentTypes',
+	'discussionSettings',
+	'generalSettings',
+	'mediaItem',
+	'mediaItems',
+	'menu',
+	'menuItem',
+	'menuItems',
+	'menus',
+	'node',
+	'nodeByUri',
+	'page',
+	'pages',
+	'plugin',
+	'plugins',
+	'post',
+	'postFormat',
+	'postFormats',
+	'posts',
+	'readingSettings',
+	'registeredScripts',
+	'registeredStylesheets',
+	'revisions',
+	'tag',
+	'tags',
+	'taxonomies',
+	'taxonomy',
+	'termNode',
+	'terms',
+	'theme',
+	'themes',
+	'user',
+	'userRole',
+	'userRoles',
+	'users',
+	'viewer',
+	'writingSettings',
+];
+
+/**
+ * Determines if the passed `$name` already exists in the root
+ * WPGraphQL namespace.
+ *
+ * @param string $name Model or taxonomy singular or plural name.
+ * @return bool True if there is a name collision.
+ */
+function root_type_exists( string $name = '' ): bool {
+	$root_fields = get_registered_root_fields();
+
+	return in_array( camelcase( $name ), $root_fields, true );
+}
+
+/**
+ * Gets WPGraphQL field names registered at the root level.
+ *
+ * Used to reject new models and taxonomies that a user wishes to create
+ * if they would conflict with existing GraphQL types when registered.
+ *
+ * WPGraphQL registers many types at the root level, so the namespace for
+ * models, taxonomies and more is shared. For example:
+ *
+ * - A model can not be named 'plugin' or 'plugins' because WPGraphQL already
+ *   registers 'plugin' and 'plugins' types.
+ * - A taxonomy can not have a plural label named 'camels' if a model already
+ *   exists with a plural label of 'camels', because WPGraphQL registers a type
+ *   for the singular and plural names of models and taxonomies at the root.
+ *
+ * @return array
+ */
+function get_registered_root_fields(): array {
+	if ( ! function_exists( 'graphql' ) ) {
+		// The WPGraphQL plugin is not active. Fall back to default types.
+		return ACM_DEFAULT_GRAPHQL_ROOT_FIELDS;
+	}
+
+	$root_fields = graphql(
+		[
+			'query' => '{
+						__type(name: "RootQuery") {
+							fields {
+								name
+							}
+						}
+					}',
+		]
+	);
+
+	$field_names = array_column(
+		$root_fields['data']['__type']['fields'] ?? [],
+		'name'
+	);
+
+	return is_array( $field_names ) ? $field_names : [];
+}

--- a/includes/rest-api/init-rest-api.php
+++ b/includes/rest-api/init-rest-api.php
@@ -18,6 +18,7 @@ add_action( 'init', __NAMESPACE__ . '\atlas_content_modeler_rest_init' );
 function atlas_content_modeler_rest_init(): void {
 	$rest_files = array(
 		// Business logic to manipulate models, fields and taxonomies.
+		'graphql.php',
 		'models.php',
 		'fields.php',
 		'taxonomies.php',

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -47,7 +47,7 @@ function create_model( string $post_type_slug, array $args ) {
 	if ( root_type_exists( $args['singular'] ?? '' ) ) {
 		return new WP_Error(
 			'acm_singular_label_exists',
-			esc_html__( 'The singular label is already in use.', 'atlas-content-modeler' ),
+			esc_html__( 'The singular name is already in use.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -55,7 +55,7 @@ function create_model( string $post_type_slug, array $args ) {
 	if ( root_type_exists( $args['plural'] ?? '' ) ) {
 		return new WP_Error(
 			'acm_plural_label_exists',
-			esc_html__( 'The plural label is already in use.', 'atlas-content-modeler' ),
+			esc_html__( 'The plural name is already in use.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -109,8 +109,8 @@ function create_models( array $models ) {
 		if ( root_type_exists( $args['singular'] ?? '' ) ) {
 			return new WP_Error(
 				'acm_singular_label_exists',
-				// translators: singular label of the model, such as "cat".
-				sprintf( esc_html__( 'A singular label of “%s” is already in use.', 'atlas-content-modeler' ), $args['singular'] ),
+				// translators: singular name of the model, such as "cat".
+				sprintf( esc_html__( 'A singular name of “%s” is already in use.', 'atlas-content-modeler' ), $args['singular'] ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -118,8 +118,8 @@ function create_models( array $models ) {
 		if ( root_type_exists( $args['plural'] ?? '' ) ) {
 			return new WP_Error(
 				'acm_plural_label_exists',
-				// translators: plural label of the model, such as "cats".
-				sprintf( esc_html__( 'A plural label of “%s” is already in use.', 'atlas-content-modeler' ), $args['plural'] ),
+				// translators: plural name of the model, such as "cats".
+				sprintf( esc_html__( 'A plural name of “%s” is already in use.', 'atlas-content-modeler' ), $args['plural'] ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -210,7 +210,7 @@ function update_model( string $post_type_slug, array $args ) {
 	) {
 		return new WP_Error(
 			'acm_singular_label_exists',
-			__( 'The singular label is already in use.', 'atlas-content-modeler' ),
+			__( 'The singular name is already in use.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -221,7 +221,7 @@ function update_model( string $post_type_slug, array $args ) {
 	) {
 		return new WP_Error(
 			'acm_plural_label_exists',
-			__( 'The plural label is already in use.', 'atlas-content-modeler' ),
+			__( 'The plural name is already in use.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -326,7 +326,7 @@ function delete_model( string $post_type_slug ) {
  * Determines if a new model property value differs from the old one.
  *
  * Used for extra validation against modified properties, such as checking that
- * an updated singular label does not conflict with root GraphQL fields.
+ * an updated singular name does not conflict with root GraphQL fields.
  *
  * @param string $slug The model ID.
  * @param string $property The property to check.

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -47,7 +47,7 @@ function create_model( string $post_type_slug, array $args ) {
 	if ( root_type_exists( $args['singular'] ?? '' ) ) {
 		return new WP_Error(
 			'acm_singular_label_exists',
-			esc_html__( 'The singular name is already in use.', 'atlas-content-modeler' ),
+			esc_html__( 'The singular name is in use.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -55,7 +55,7 @@ function create_model( string $post_type_slug, array $args ) {
 	if ( root_type_exists( $args['plural'] ?? '' ) ) {
 		return new WP_Error(
 			'acm_plural_label_exists',
-			esc_html__( 'The plural name is already in use.', 'atlas-content-modeler' ),
+			esc_html__( 'The plural name is in use.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -110,7 +110,7 @@ function create_models( array $models ) {
 			return new WP_Error(
 				'acm_singular_label_exists',
 				// translators: singular name of the model, such as "cat".
-				sprintf( esc_html__( 'A singular name of “%s” is already in use.', 'atlas-content-modeler' ), $args['singular'] ),
+				sprintf( esc_html__( 'A singular name of “%s” is in use.', 'atlas-content-modeler' ), $args['singular'] ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -119,7 +119,7 @@ function create_models( array $models ) {
 			return new WP_Error(
 				'acm_plural_label_exists',
 				// translators: plural name of the model, such as "cats".
-				sprintf( esc_html__( 'A plural name of “%s” is already in use.', 'atlas-content-modeler' ), $args['plural'] ),
+				sprintf( esc_html__( 'A plural name of “%s” is in use.', 'atlas-content-modeler' ), $args['plural'] ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -210,7 +210,7 @@ function update_model( string $post_type_slug, array $args ) {
 	) {
 		return new WP_Error(
 			'acm_singular_label_exists',
-			__( 'The singular name is already in use.', 'atlas-content-modeler' ),
+			__( 'The singular name is in use.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -221,7 +221,7 @@ function update_model( string $post_type_slug, array $args ) {
 	) {
 		return new WP_Error(
 			'acm_plural_label_exists',
-			__( 'The plural name is already in use.', 'atlas-content-modeler' ),
+			__( 'The plural name is in use.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -32,10 +32,20 @@ function create_model( string $post_type_slug, array $args ) {
 	$existing_content_types = get_post_types();
 	$content_types          = get_registered_content_types();
 
+	// Check for slug conflicts.
 	if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) ) {
 		return new WP_Error(
 			'acm_model_exists',
 			__( 'A content model with this Model ID already exists.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	// Check for label conflicts.
+	if ( ( ! empty( $content_types[ $args['singular'] ] ) || array_key_exists( $args['singular'], $existing_content_types ) ) || ( ! empty( $content_types[ $args['plural'] ] ) || array_key_exists( $args['plural'], $existing_content_types ) ) ) {
+		return new WP_Error(
+			'acm_model_exists',
+			__( 'A content model with this Model Label already exists.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -172,7 +172,8 @@ function get_model_args( string $post_type_slug, array $args ) {
  * @return bool|WP_Error
  */
 function update_model( string $post_type_slug, array $args ) {
-	$taxonomies = get_acm_taxonomies();
+	$taxonomies    = get_acm_taxonomies();
+	$content_types = get_registered_content_types();
 
 	if ( empty( $post_type_slug ) ) {
 		return new WP_Error(
@@ -185,6 +186,16 @@ function update_model( string $post_type_slug, array $args ) {
 		return new WP_Error(
 			'acm_invalid_labels',
 			__( 'Please provide singular and plural labels when creating a content model.', 'atlas-content-modeler' )
+		);
+	}
+
+	// Check for collisions of labels in taxonomies and models for update.
+	if ( ( array_key_exists( $args['singular'], $content_types ) ) || ( array_key_exists( $args['plural'], $content_types ) ) || ( array_key_exists( $args['singular'], $taxonomies ) || array_key_exists( $args['plural'], $taxonomies ) ) ) {
+		return new WP_Error(
+			'acm_model_exists',
+			// translators: The name of the model.
+			__( 'A model with that label already exists.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
 		);
 	}
 

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -31,6 +31,7 @@ function create_model( string $post_type_slug, array $args ) {
 
 	$existing_content_types = get_post_types();
 	$content_types          = get_registered_content_types();
+	$taxonomies             = get_acm_taxonomies();
 
 	// Check for slug conflicts.
 	if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) ) {
@@ -72,6 +73,7 @@ function create_model( string $post_type_slug, array $args ) {
 function create_models( array $models ) {
 	$existing_content_types = get_post_types();
 	$content_types          = get_registered_content_types();
+	$taxonomies             = get_acm_taxonomies();
 
 	foreach ( $models as $model ) {
 		if ( ! is_array( $model ) ) {
@@ -159,6 +161,8 @@ function get_model_args( string $post_type_slug, array $args ) {
  * @return bool|WP_Error
  */
 function update_model( string $post_type_slug, array $args ) {
+	$taxonomies = get_acm_taxonomies();
+
 	if ( empty( $post_type_slug ) ) {
 		return new WP_Error(
 			'acm_invalid_content_model_id',

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -86,11 +86,22 @@ function create_models( array $models ) {
 			return $args;
 		}
 
-		if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) ) {
+		// Check for slug collisions in taxonomies and models.
+		if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) || array_key_exists( $args['slug'], $taxonomies ) ) {
 			return new WP_Error(
 				'acm_model_exists',
 				// translators: The name of the model.
 				sprintf( __( 'A model with slug ‘%s’ already exists.', 'atlas-content-modeler' ), $args['slug'] ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// Check for collisions of labels in taxonomies and models.
+		if ( ( ! empty( $content_types[ $args['singular'] ] ) || array_key_exists( $args['singular'], $existing_content_types ) ) || ( ! empty( $content_types[ $args['plural'] ] ) || array_key_exists( $args['plural'], $existing_content_types ) ) || ( array_key_exists( $args['singular'], $taxonomies ) || array_key_exists( $args['plural'], $taxonomies ) ) ) {
+			return new WP_Error(
+				'acm_model_exists',
+				// translators: The name of the model.
+				__( 'A model with that label already exists.', 'atlas-content-modeler' ),
 				[ 'status' => 400 ]
 			);
 		}

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -33,8 +33,8 @@ function create_model( string $post_type_slug, array $args ) {
 	$content_types          = get_registered_content_types();
 	$taxonomies             = get_acm_taxonomies();
 
-	// Check for slug conflicts.
-	if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) ) {
+	// Check for slug conflicts in models and taxonomies.
+	if ( ! empty( $content_types[ $args['slug'] ] ) || array_key_exists( $args['slug'], $existing_content_types ) || array_key_exists( $args['slug'], $taxonomies ) ) {
 		return new WP_Error(
 			'acm_model_exists',
 			__( 'A content model with this Model ID already exists.', 'atlas-content-modeler' ),
@@ -42,8 +42,8 @@ function create_model( string $post_type_slug, array $args ) {
 		);
 	}
 
-	// Check for label conflicts.
-	if ( ( ! empty( $content_types[ $args['singular'] ] ) || array_key_exists( $args['singular'], $existing_content_types ) ) || ( ! empty( $content_types[ $args['plural'] ] ) || array_key_exists( $args['plural'], $existing_content_types ) ) ) {
+	// Check for label conflicts in models and taxonomies.
+	if ( ( ! empty( $content_types[ $args['singular'] ] ) || array_key_exists( $args['singular'], $existing_content_types ) ) || ( ! empty( $content_types[ $args['plural'] ] ) || array_key_exists( $args['plural'], $existing_content_types ) ) || ( array_key_exists( $args['singular'], $taxonomies ) || array_key_exists( $args['plural'], $taxonomies ) ) ) {
 		return new WP_Error(
 			'acm_model_exists',
 			__( 'A content model with this Model Label already exists.', 'atlas-content-modeler' ),

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -23,8 +23,6 @@ use function WPE\AtlasContentModeler\REST_API\GraphQL\root_type_exists;
 function save_taxonomy( array $params, bool $is_update ) {
 	// Sanitize key allows hyphens, but it's close enough to register_taxonomy() requirements.
 	$params['slug']     = isset( $params['slug'] ) ? sanitize_key( $params['slug'] ) : '';
-	$params['singular'] = isset( $params['singular'] ) ? $params['singular'] : '';
-	$params['plural']   = isset( $params['plural'] ) ? $params['plural'] : '';
 	$reserved_tax_terms = include ATLAS_CONTENT_MODELER_INCLUDES_DIR . 'settings/reserved-taxonomy-terms.php';
 
 	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -39,7 +39,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 	}
 
 	// Prevents use of reserved taxonomy terms as slugs during new taxonomy creation.
-	if ( in_array( $params['slug'], $reserved_tax_terms, true ) || in_array( $params['slug'], $content_types, true ) ) {
+	if ( in_array( $params['slug'], $reserved_tax_terms, true ) ) {
 		return new WP_Error(
 			'acm_reserved_taxonomy_term',
 			__( 'Taxonomy slug is reserved.', 'atlas-content-modeler' ),
@@ -52,7 +52,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 	$non_acm_taxonomies = array_diff( array_keys( $wp_taxonomies ), array_keys( $acm_taxonomies ) );
 
 	// Prevents creation of a taxonomy if one with the same slug exists that was not created in ACM.
-	if ( in_array( $params['slug'], $non_acm_taxonomies, true ) ) {
+	if ( in_array( $params['slug'], $non_acm_taxonomies, true ) || in_array( $params['slug'], $content_types, true ) ) {
 		return new WP_Error(
 			'acm_taxonomy_exists',
 			esc_html__( 'A taxonomy with this Taxonomy ID already exists.', 'atlas-content-modeler' ),
@@ -60,8 +60,8 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
-	// Allows updates of existing ACM taxonomies, but prevents creation of ACM taxonomies with identical slugs.
-	if ( ! $is_update && array_key_exists( $params['slug'], $acm_taxonomies ) ) {
+	// Allows updates of existing ACM taxonomies, but prevents creation of ACM taxonomies with identical slugs and models.
+	if ( ! $is_update && array_key_exists( $params['slug'], $acm_taxonomies ) || in_array( $params['slug'], $content_types, true ) ) {
 		return new WP_Error(
 			'acm_taxonomy_exists',
 			esc_html__( 'A taxonomy with this Taxonomy ID already exists.', 'atlas-content-modeler' ),
@@ -69,7 +69,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
-	// Check for label conflicts.
+	// Check for label conflicts in taxonomies and models.
 	if ( ! $is_update && ( array_key_exists( $params['plural'], $acm_taxonomies ) || array_key_exists( $params['singular'], $acm_taxonomies ) || in_array( $params['singular'], $content_types, true ) || in_array( $params['plural'], $content_types, true ) ) ) {
 		return new WP_Error(
 			'acm_taxonomy_exists',
@@ -78,6 +78,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
+	// Check for required singular and plural params.
 	if ( empty( $params['singular'] ) || empty( $params['plural'] ) ) {
 		return new WP_Error(
 			'acm_invalid_labels',

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -92,7 +92,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 		if ( root_type_exists( $params['plural'] ) ) {
 			return new WP_Error(
 				'acm_plural_label_exists',
-				esc_html__( 'The plural label is in use.', 'atlas-content-modeler' ),
+				esc_html__( 'The plural name is in use.', 'atlas-content-modeler' ),
 				[ 'status' => 400 ]
 			);
 		}

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -79,7 +79,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 		if ( root_type_exists( $params['singular'] ) ) {
 			return new WP_Error(
 				'acm_singular_label_exists',
-				esc_html__( 'The singular name is already in use.', 'atlas-content-modeler' ),
+				esc_html__( 'The singular name is in use.', 'atlas-content-modeler' ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -92,7 +92,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 		if ( root_type_exists( $params['plural'] ) ) {
 			return new WP_Error(
 				'acm_plural_label_exists',
-				esc_html__( 'The plural label is already in use.', 'atlas-content-modeler' ),
+				esc_html__( 'The plural label is in use.', 'atlas-content-modeler' ),
 				[ 'status' => 400 ]
 			);
 		}

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -79,7 +79,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 		if ( root_type_exists( $params['singular'] ) ) {
 			return new WP_Error(
 				'acm_singular_label_exists',
-				esc_html__( 'The singular label is already in use.', 'atlas-content-modeler' ),
+				esc_html__( 'The singular name is already in use.', 'atlas-content-modeler' ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -124,7 +124,7 @@ function save_taxonomy( array $params, bool $is_update ) {
  * Determines if a new taxonomy property value differs from the old one.
  *
  * Used for extra validation against modified properties, such as checking that
- * an updated singular label does not conflict with root GraphQL fields.
+ * an updated singular name does not conflict with root GraphQL fields.
  *
  * @param string $slug The taxonomy ID.
  * @param string $property The property to check.

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -63,6 +63,15 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
+	// Check for label conflicts.
+	if ( ! $is_update && ( array_key_exists( $params['plural'], $acm_taxonomies ) || array_key_exists( $params['singular'], $acm_taxonomies ) ) ) {
+		return new WP_Error(
+			'acm_taxonomy_exists',
+			esc_html__( 'A taxonomy with this Taxonomy label already exists.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
+		);
+	}
+
 	if ( empty( $params['singular'] ) || empty( $params['plural'] ) ) {
 		return new WP_Error(
 			'acm_invalid_labels',

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace WPE\AtlasContentModeler\REST_API\Taxonomies;
 
 use WP_Error;
-use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_types;
+use function WPE\AtlasContentModeler\REST_API\GraphQL\root_type_exists;
 
 /**
  * Saves a taxonomy.
@@ -21,19 +21,24 @@ use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_
  * @since 0.6.0
  */
 function save_taxonomy( array $params, bool $is_update ) {
-	// Get models for checking slug, plural and singular labels.
-	$content_types = get_registered_content_types();
-
 	// Sanitize key allows hyphens, but it's close enough to register_taxonomy() requirements.
 	$params['slug']     = isset( $params['slug'] ) ? sanitize_key( $params['slug'] ) : '';
-	$params['singular'] = isset( $params['singular'] ) ? sanitize_key( $params['singular'] ) : '';
-	$params['plural']   = isset( $params['plural'] ) ? sanitize_key( $params['plural'] ) : '';
+	$params['singular'] = isset( $params['singular'] ) ? $params['singular'] : '';
+	$params['plural']   = isset( $params['plural'] ) ? $params['plural'] : '';
 	$reserved_tax_terms = include ATLAS_CONTENT_MODELER_INCLUDES_DIR . 'settings/reserved-taxonomy-terms.php';
 
 	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {
 		return new WP_Error(
 			'acm_invalid_taxonomy_id',
 			esc_html__( 'Taxonomy slug must be between 1 and 32 characters in length.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	if ( empty( $params['singular'] ) || empty( $params['plural'] ) ) {
+		return new WP_Error(
+			'acm_invalid_labels',
+			esc_html__( 'Please provide singular and plural labels when creating a taxonomy.', 'atlas-content-modeler' ),
 			[ 'status' => 400 ]
 		);
 	}
@@ -52,7 +57,7 @@ function save_taxonomy( array $params, bool $is_update ) {
 	$non_acm_taxonomies = array_diff( array_keys( $wp_taxonomies ), array_keys( $acm_taxonomies ) );
 
 	// Prevents creation of a taxonomy if one with the same slug exists that was not created in ACM.
-	if ( in_array( $params['slug'], $non_acm_taxonomies, true ) || in_array( $params['slug'], $content_types, true ) ) {
+	if ( in_array( $params['slug'], $non_acm_taxonomies, true ) ) {
 		return new WP_Error(
 			'acm_taxonomy_exists',
 			esc_html__( 'A taxonomy with this Taxonomy ID already exists.', 'atlas-content-modeler' ),
@@ -60,8 +65,8 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
-	// Allows updates of existing ACM taxonomies, but prevents creation of ACM taxonomies with identical slugs and models.
-	if ( ! $is_update && array_key_exists( $params['slug'], $acm_taxonomies ) || in_array( $params['slug'], $content_types, true ) ) {
+	// Allows updates of existing ACM taxonomies, but prevents creation of ACM taxonomies with identical slugs.
+	if ( ! $is_update && array_key_exists( $params['slug'], $acm_taxonomies ) ) {
 		return new WP_Error(
 			'acm_taxonomy_exists',
 			esc_html__( 'A taxonomy with this Taxonomy ID already exists.', 'atlas-content-modeler' ),
@@ -69,22 +74,30 @@ function save_taxonomy( array $params, bool $is_update ) {
 		);
 	}
 
-	// Check for label conflicts in taxonomies and models.
-	if ( ! $is_update && ( array_key_exists( $params['plural'], $acm_taxonomies ) || array_key_exists( $params['singular'], $acm_taxonomies ) || in_array( $params['singular'], $content_types, true ) || in_array( $params['plural'], $content_types, true ) ) ) {
-		return new WP_Error(
-			'acm_taxonomy_exists',
-			esc_html__( 'A taxonomy with this Taxonomy label already exists.', 'atlas-content-modeler' ),
-			[ 'status' => 400 ]
-		);
+	if (
+		! $is_update ||
+		( $is_update && taxonomy_property_changed( $params['slug'], 'singular', $params['singular'] ) )
+	) {
+		if ( root_type_exists( $params['singular'] ) ) {
+			return new WP_Error(
+				'acm_singular_label_exists',
+				esc_html__( 'The singular label is already in use.', 'atlas-content-modeler' ),
+				[ 'status' => 400 ]
+			);
+		}
 	}
 
-	// Check for required singular and plural params.
-	if ( empty( $params['singular'] ) || empty( $params['plural'] ) ) {
-		return new WP_Error(
-			'acm_invalid_labels',
-			esc_html__( 'Please provide singular and plural labels when creating a taxonomy.', 'atlas-content-modeler' ),
-			[ 'status' => 400 ]
-		);
+	if (
+		! $is_update ||
+		( $is_update && taxonomy_property_changed( $params['slug'], 'plural', $params['plural'] ) )
+	) {
+		if ( root_type_exists( $params['plural'] ) ) {
+			return new WP_Error(
+				'acm_plural_label_exists',
+				esc_html__( 'The plural label is already in use.', 'atlas-content-modeler' ),
+				[ 'status' => 400 ]
+			);
+		}
 	}
 
 	$defaults = [
@@ -107,4 +120,21 @@ function save_taxonomy( array $params, bool $is_update ) {
 	}
 
 	return $taxonomy;
+}
+
+/**
+ * Determines if a new taxonomy property value differs from the old one.
+ *
+ * Used for extra validation against modified properties, such as checking that
+ * an updated singular label does not conflict with root GraphQL fields.
+ *
+ * @param string $slug The taxonomy ID.
+ * @param string $property The property to check.
+ * @param mixed  $new_value The property's new value.
+ * @return bool
+ */
+function taxonomy_property_changed( string $slug, string $property, $new_value ): bool {
+	$acm_taxonomies = get_option( 'atlas_content_modeler_taxonomies', array() );
+
+	return ( $acm_taxonomies[ $slug ][ $property ] ?? null ) !== $new_value;
 }

--- a/includes/rest-api/taxonomies.php
+++ b/includes/rest-api/taxonomies.php
@@ -22,6 +22,8 @@ use WP_Error;
 function save_taxonomy( array $params, bool $is_update ) {
 	// Sanitize key allows hyphens, but it's close enough to register_taxonomy() requirements.
 	$params['slug']     = isset( $params['slug'] ) ? sanitize_key( $params['slug'] ) : '';
+	$params['singular'] = isset( $params['singular'] ) ? sanitize_key( $params['singular'] ) : '';
+	$params['plural']   = isset( $params['plural'] ) ? sanitize_key( $params['plural'] ) : '';
 	$reserved_tax_terms = include ATLAS_CONTENT_MODELER_INCLUDES_DIR . 'settings/reserved-taxonomy-terms.php';
 
 	if ( empty( $params['slug'] ) || strlen( $params['slug'] ) > 32 ) {

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -78,6 +78,18 @@ export default function CreateContentModel() {
 						message: err.message,
 					});
 				}
+				if (err.code === "acm_singular_label_exists") {
+					setError("singular", {
+						type: "exists",
+						message: err.message,
+					});
+				}
+				if (err.code === "acm_plural_label_exists") {
+					setError("plural", {
+						type: "exists",
+						message: err.message,
+					});
+				}
 			});
 	}
 
@@ -144,6 +156,15 @@ export default function CreateContentModel() {
 										</span>
 									</span>
 								)}
+							{errors.singular &&
+								errors.singular.type === "exists" && (
+									<span className="error">
+										<Icon type="error" />
+										<span role="alert">
+											{errors.singular.message}
+										</span>
+									</span>
+								)}
 							<span>&nbsp;</span>
 							<span className="count">{singularCount}/50</span>
 						</p>
@@ -195,6 +216,14 @@ export default function CreateContentModel() {
 										</span>
 									</span>
 								)}
+							{errors.plural && errors.plural.type === "exists" && (
+								<span className="error">
+									<Icon type="error" />
+									<span role="alert">
+										{errors.plural.message}
+									</span>
+								</span>
+							)}
 							<span>&nbsp;</span>
 							<span className="count">{pluralCount}/50</span>
 						</p>

--- a/includes/settings/js/src/components/TaxonomiesForm.jsx
+++ b/includes/settings/js/src/components/TaxonomiesForm.jsx
@@ -146,6 +146,18 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 						message: err.message,
 					});
 				}
+				if (err.code === "acm_singular_label_exists") {
+					setError("singular", {
+						type: "exists",
+						message: err.message,
+					});
+				}
+				if (err.code === "acm_plural_label_exists") {
+					setError("plural", {
+						type: "exists",
+						message: err.message,
+					});
+				}
 			});
 	};
 
@@ -209,6 +221,12 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 							</span>
 						</span>
 					)}
+					{errors.singular && errors.singular.type === "exists" && (
+						<span className="error">
+							<Icon type="error" />
+							<span role="alert">{errors.singular.message}</span>
+						</span>
+					)}
 					<span>&nbsp;</span>
 					<span className="count">{singularCount}/50</span>
 				</p>
@@ -260,6 +278,12 @@ const TaxonomiesForm = ({ editingTaxonomy, cancelEditing }) => {
 									"atlas-content-modeler"
 								)}
 							</span>
+						</span>
+					)}
+					{errors.plural && errors.plural.type === "exists" && (
+						<span className="error">
+							<Icon type="error" />
+							<span role="alert">{errors.plural.message}</span>
 						</span>
 					)}
 					<span>&nbsp;</span>

--- a/tests/acceptance/CreateContentModelCest.php
+++ b/tests/acceptance/CreateContentModelCest.php
@@ -32,4 +32,31 @@ class CreateContentModelCest {
 		$i->see( 'Candies', '.model-list' );
 		$i->see( 'My candy content model', '.model-list' );
 	}
+
+	public function i_see_a_warning_if_the_model_singular_name_is_reserved( AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$i->amOnWPEngineCreateContentModelPage();
+		$i->wait( 1 );
+
+		$i->fillField( [ 'name' => 'singular' ], 'Post' ); // 'post' is in use.
+		$i->fillField( [ 'name' => 'plural' ], 'Candies' );
+		$i->fillField( [ 'name' => 'slug' ], 'Candy' );
+		$i->click( '.card-content button.primary' );
+		$i->wait( 1 );
+
+		$i->see( 'singular name is in use', '.card-content' );
+	}
+
+	public function i_see_a_warning_if_the_model_plural_name_is_reserved( AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$i->amOnWPEngineCreateContentModelPage();
+		$i->wait( 1 );
+
+		$i->fillField( [ 'name' => 'singular' ], 'Candy' );
+		$i->fillField( [ 'name' => 'plural' ], 'Posts' ); // 'posts' is in use.
+		$i->click( '.card-content button.primary' );
+		$i->wait( 1 );
+
+		$i->see( 'plural name is in use', '.card-content' );
+	}
 }

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -98,6 +98,31 @@ class CreateTaxonomyCest {
 		$i->see( 'A taxonomy with this Taxonomy ID already exists' );
 	}
 
+	public function i_can_not_create_a_taxonomy_with_a_reserved_singular_name( AcceptanceTester $i ) {
+		$i->amOnTaxonomyListingsPage();
+		$i->wait( 1 );
+
+		$i->fillField( [ 'name' => 'singular' ], 'Post' ); // 'Post' is a reserved name.
+		$i->fillField( [ 'name' => 'plural' ], 'Breeds' );
+		$i->fillField( [ 'name' => 'slug' ], 'breed' );
+		$i->click( '.checklist .checkbox' ); // The “goose” model.
+		$i->click( '.card-content button.primary' );
+		$i->wait( 1 );
+		$i->see( 'singular name is in use' );
+	}
+
+	public function i_can_not_create_a_taxonomy_with_a_reserved_plural_name( AcceptanceTester $i ) {
+		$i->amOnTaxonomyListingsPage();
+		$i->wait( 1 );
+
+		$i->fillField( [ 'name' => 'singular' ], 'Breed' );
+		$i->fillField( [ 'name' => 'plural' ], 'Posts' ); // 'Posts' is a reserved name.
+		$i->click( '.checklist .checkbox' ); // The “goose” model.
+		$i->click( '.card-content button.primary' );
+		$i->wait( 1 );
+		$i->see( 'plural name is in use' );
+	}
+
 	public function i_can_not_create_a_taxonomy_if_the_slug_is_a_reserved_term( AcceptanceTester $i ) {
 		$i->amOnTaxonomyListingsPage();
 		$i->wait( 1 );

--- a/tests/acceptance/EditContentModelCest.php
+++ b/tests/acceptance/EditContentModelCest.php
@@ -2,8 +2,8 @@
 
 class EditContentModelCest {
 
-	public function i_can_update_an_existing_content_model( AcceptanceTester $i ) {
-		$i->resizeWindow( 1024, 1024 );
+	public function _before( \AcceptanceTester $i ) {
+		$i->maximizeWindow();
 		$i->loginAsAdmin();
 
 		// First, create a new model.
@@ -15,7 +15,9 @@ class EditContentModelCest {
 		$i->click( '.model-list button.options' );
 		$i->click( '.dropdown-content a.edit' );
 		$i->see( 'Edit Candies' );
+	}
 
+	public function i_can_update_an_existing_content_model( AcceptanceTester $i ) {
 		// Update the model data.
 		$i->fillField( [ 'name' => 'singular' ], 'Cat' );
 		$i->fillField( [ 'name' => 'plural' ], 'Cats' );
@@ -41,6 +43,23 @@ class EditContentModelCest {
 		// Check the label in the WP admin sidebar was updated without refreshing the page.
 		$menu_label = $i->grabTextFrom( '#menu-posts-candy .wp-menu-name' );
 		$i->assertEquals( 'Cats', $menu_label );
+	}
+
+	public function i_see_a_warning_if_the_model_singular_name_is_reserved( AcceptanceTester $i ) {
+		// Update the model data.
+		$i->fillField( [ 'name' => 'singular' ], 'Post' ); // 'post' is in use.
+		$i->click( 'Save' );
+		$i->wait( 1 );
+
+		$i->see( 'singular name is in use', '.ReactModal__Content' );
+	}
+
+	public function i_see_a_warning_if_the_model_plural_name_is_reserved( AcceptanceTester $i ) {
+		$i->fillField( [ 'name' => 'plural' ], 'Posts' ); // 'posts' is in use.
+		$i->click( 'Save' );
+		$i->wait( 1 );
+
+		$i->see( 'plural name is in use', '.ReactModal__Content' );
 	}
 
 }

--- a/tests/acceptance/EditTaxonomyCest.php
+++ b/tests/acceptance/EditTaxonomyCest.php
@@ -59,4 +59,18 @@ class EditTaxonomyCest {
 		$i->see( 'Add New' );
 		$i->seeInField( '#singular', '' ); // Form is empty.
 	}
+
+	public function i_can_not_update_a_taxonomy_with_a_reserved_singular_name( AcceptanceTester $i ) {
+		$i->fillField( [ 'name' => 'singular' ], 'Post' ); // 'Post' is a reserved name.
+		$i->click( 'Update' );
+		$i->wait( 1 );
+		$i->see( 'singular name is in use' );
+	}
+
+	public function i_can_not_update_a_taxonomy_with_a_reserved_plural_name( AcceptanceTester $i ) {
+		$i->fillField( [ 'name' => 'plural' ], 'Posts' ); // 'Posts' is a reserved name.
+		$i->click( 'Update' );
+		$i->wait( 1 );
+		$i->see( 'plural name is in use' );
+	}
 }

--- a/tests/integration/api-validation/test-rest-model-endpoints.php
+++ b/tests/integration/api-validation/test-rest-model-endpoints.php
@@ -91,6 +91,44 @@ class RestModelEndpointTests extends WP_UnitTestCase {
 		self::assertSame( 'acm_model_exists', $response->data['code'] );
 	}
 
+	public function test_cannot_create_model_if_singular_name_is_reserved(): void {
+		wp_set_current_user( 1 );
+		$model_with_reserved_singular_label = array(
+			'slug'     => 'new',
+			'singular' => 'post', // 'post' is reserved.
+			'plural'   => 'cats',
+		);
+
+		// Attempt to create the model.
+		$request = new WP_REST_Request( 'POST', $this->namespace . $this->route );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $model_with_reserved_singular_label ) );
+		$this->server->dispatch( $request );
+
+		$response = $this->server->dispatch( $request );
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'acm_singular_label_exists', $response->data['code'] );
+	}
+
+	public function test_cannot_create_model_if_plural_name_is_reserved(): void {
+		wp_set_current_user( 1 );
+		$model_with_reserved_singular_label = array(
+			'slug'     => 'new',
+			'singular' => 'cat',
+			'plural'   => 'posts', // 'posts' is reserved.
+		);
+
+		// Attempt to create the model.
+		$request = new WP_REST_Request( 'POST', $this->namespace . $this->route );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $model_with_reserved_singular_label ) );
+		$this->server->dispatch( $request );
+
+		$response = $this->server->dispatch( $request );
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'acm_plural_label_exists', $response->data['code'] );
+	}
+
 	/**
 	 * Tests that a model can be created via the REST API.
 	 *
@@ -190,6 +228,50 @@ class RestModelEndpointTests extends WP_UnitTestCase {
 		self::assertSame( 200, $response->get_status() );
 		self::assertSame( $this->test_models['public']['slug'], $models['public']['slug'] );
 		self::assertSame( $new_model['singular'], $models['public']['singular'] );
+	}
+
+	public function test_cannot_update_model_if_singular_name_is_reserved(): void {
+		wp_set_current_user( 1 );
+
+		$model = 'public'; // Update an existing model.
+
+		$model_with_reserved_singular_label = array(
+			'slug'     => $model,
+			'singular' => 'post', // 'post' is reserved.
+			'plural'   => 'cats',
+		);
+
+		// Attempt to update the model.
+		$request = new WP_REST_Request( 'PATCH', $this->namespace . $this->route . '/' . $model );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $model_with_reserved_singular_label ) );
+		$this->server->dispatch( $request );
+
+		$response = $this->server->dispatch( $request );
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'acm_singular_label_exists', $response->data['code'] );
+	}
+
+	public function test_cannot_update_model_if_plural_name_is_reserved(): void {
+		wp_set_current_user( 1 );
+
+		$model = 'public'; // Update an existing model.
+
+		$model_with_reserved_singular_label = array(
+			'slug'     => $model,
+			'singular' => 'cat',
+			'plural'   => 'posts', // 'posts' is reserved.
+		);
+
+		// Attempt to update the model.
+		$request = new WP_REST_Request( 'PATCH', $this->namespace . $this->route . '/' . $model );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $model_with_reserved_singular_label ) );
+		$this->server->dispatch( $request );
+
+		$response = $this->server->dispatch( $request );
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'acm_plural_label_exists', $response->data['code'] );
 	}
 
 	/**

--- a/tests/integration/api-validation/test-rest-models-endpoints.php
+++ b/tests/integration/api-validation/test-rest-models-endpoints.php
@@ -18,8 +18,8 @@ class RestModelsEndpointTests extends WP_UnitTestCase {
 	private $route     = '/atlas/content-models';
 	private $test_models;
 
-	public function set_up(): void {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 
 		$this->test_models = $this->get_models();
 
@@ -43,8 +43,8 @@ class RestModelsEndpointTests extends WP_UnitTestCase {
 		do_action( 'rest_api_init' );
 	}
 
-	public function tear_down() {
-		parent::tear_down();
+	public function tearDown() {
+		parent::tearDown();
 		wp_set_current_user( null );
 		global $wp_rest_server;
 		$wp_rest_server = null;
@@ -138,5 +138,73 @@ class RestModelsEndpointTests extends WP_UnitTestCase {
 		self::assertArrayHasKey( 'cheeses', $models );
 		self::assertArrayHasKey( 'rabbits', $models );
 		self::assertArrayHasKey( 'bookreviews', $models );
+	}
+
+	public function test_cannot_create_models_if_singular_label_conflicts_with_reserved_names(): void {
+		wp_set_current_user( 1 );
+
+		$test_models = array(
+			// The first model is fine.
+			array(
+				'slug'        => 'bookreviews',
+				'singular'    => 'Book Review 1',
+				'plural'      => 'Book Reviews 1',
+				'description' => 'Reviews of books.',
+			),
+			// But this model contains a singular label conflict.
+			array(
+				'slug'        => 'bad-model',
+				'singular'    => 'Post', // 'Post' is a reserved term. This causes the whole update to fail.
+				'plural'      => 'Tests',
+				'description' => 'Bad model.',
+			),
+		);
+
+		$request = new WP_REST_Request( 'PUT', $this->namespace . $this->route );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $test_models ) );
+		$response = $this->server->dispatch( $request );
+
+		$data   = $response->get_data();
+		$models = get_registered_content_types();
+
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'acm_singular_label_exists', $data['code'] );
+		self::assertSame( 'A singular name of “Post” is in use.', $data['message'] );
+		self::assertArrayNotHasKey( 'bookreviews', $models ); // No models were saved because one from the set was invalid.
+	}
+
+	public function test_cannot_create_models_if_plural_label_conflicts_with_reserved_names(): void {
+		wp_set_current_user( 1 );
+
+		$test_models = array(
+			// The first model is fine.
+			array(
+				'slug'        => 'bookreviews',
+				'singular'    => 'Book Review 1',
+				'plural'      => 'Book Reviews 1',
+				'description' => 'Reviews of books.',
+			),
+			// But this model contains a plural label conflict.
+			array(
+				'slug'        => 'bad-model',
+				'singular'    => 'Test',
+				'plural'      => 'Posts', // 'Posts' is a reserved term. This causes the whole update to fail.
+				'description' => 'Bad model.',
+			),
+		);
+
+		$request = new WP_REST_Request( 'PUT', $this->namespace . $this->route );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $test_models ) );
+		$response = $this->server->dispatch( $request );
+
+		$data   = $response->get_data();
+		$models = get_registered_content_types();
+
+		self::assertSame( 400, $response->get_status() );
+		self::assertSame( 'acm_plural_label_exists', $data['code'] );
+		self::assertSame( 'A plural name of “Posts” is in use.', $data['message'] );
+		self::assertArrayNotHasKey( 'bookreviews', $models ); // No models were saved because one from the set was invalid.
 	}
 }

--- a/tests/integration/api-validation/test-rest-models-endpoints.php
+++ b/tests/integration/api-validation/test-rest-models-endpoints.php
@@ -18,8 +18,8 @@ class RestModelsEndpointTests extends WP_UnitTestCase {
 	private $route     = '/atlas/content-models';
 	private $test_models;
 
-	public function setUp(): void {
-		parent::setUp();
+	public function set_up(): void {
+		parent::set_up();
 
 		$this->test_models = $this->get_models();
 
@@ -43,8 +43,8 @@ class RestModelsEndpointTests extends WP_UnitTestCase {
 		do_action( 'rest_api_init' );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		wp_set_current_user( null );
 		global $wp_rest_server;
 		$wp_rest_server = null;


### PR DESCRIPTION
[Edited by Nick on 11 Jan 2021]

## Description

Ensures that models and taxonomies can not be created or updated if:

- An ACM singular or plural model label collides with another model or taxonomy label. (GraphQL registers them at the top level, so labels must be globally unique.)
- The singular or plural label of the model or taxonomy would collide with a reserved top-level GraphQL “field”, such as 'post', 'posts', 'category', categories', 'plugin', 'plugins' etc. 

<img width="425" alt="Screenshot 2022-01-11 at 14 10 19" src="https://user-images.githubusercontent.com/647669/148948400-ec5affda-3322-447b-be09-f1502c4b5d4e.png">

<img width="429" alt="Screenshot 2022-01-11 at 14 11 19" src="https://user-images.githubusercontent.com/647669/148948537-f2f82ed1-6de9-447e-a291-021dba28da25.png">

Also checks models that are bulk imported via the Import Tool. If any model in the group contains a bad label the full import will be rejected so that the user can correct the file and re-import. (I chose to reject the import in full so the user doesn't have to trim any models from their import file that were correctly imported the first time.)

<img width="1043" alt="Screenshot 2022-01-11 at 13 58 42" src="https://user-images.githubusercontent.com/647669/148947793-66c6277c-b9dc-46f5-9764-2231de3223c0.png">

https://wpengine.atlassian.net/browse/MTKA-1332

## Automated Tests
Includes:
- Unit tests for the REST endpoint updates.
- End-to-end tests to confirm user feedback is provided if an illegal label is used.

## Manual Testing
You should no longer be able to create a model or taxonomy with the same single or plural label as another model or taxonomy. (This requires that WPGraphQL is active.)

You should not be able to create models or taxonomies with a singular or plural label that uses a reserved term such as "post", "posts", "plugin" or "plugins". (This part should work even if WPGraphQL is inactive.)
