### PR TITLE
MTKA-1212: Speed up end-2-end tests using direct database

### DIFF
--- a/tests/acceptance/AdvancedSettingsCest.php
+++ b/tests/acceptance/AdvancedSettingsCest.php
@@ -4,10 +4,9 @@ class AdvancedSettingsCest {
 
 	public function _before( \AcceptanceTester $i ) {
 		$i->maximizeWindow();
-
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'goose', 'geese' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 	}
 
 	public function i_can_set_min_max_character_counts_for_text_fields( \AcceptanceTester $i ) {

--- a/tests/acceptance/CreateContentModelBooleanFieldCest.php
+++ b/tests/acceptance/CreateContentModelBooleanFieldCest.php
@@ -7,8 +7,8 @@ class CreateContentModelBooleanFieldCest {
 	 */
 	public function i_can_create_a_content_model_boolean_field( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Boolean', '.field-buttons' );
 		$i->wait( 1 );

--- a/tests/acceptance/CreateContentModelMediaFieldCest.php
+++ b/tests/acceptance/CreateContentModelMediaFieldCest.php
@@ -2,14 +2,16 @@
 
 class CreateContentModelMediaFieldCest {
 
+	public function _before( \AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
+	}
+
 	/**
 	 * Ensure a user can add a media field to the model and see it within the list.
 	 */
 	public function i_can_add_a_media_field_to_a_content_model( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
-
 		$i->click( 'Media', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'Product Photo' );
@@ -26,10 +28,6 @@ class CreateContentModelMediaFieldCest {
 	 * Ensure a user can add a featured image media field to the model and see it within the list.
 	 */
 	public function i_can_add_a_featured_image_media_field_to_a_content_model( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
-
 		$i->click( 'Media', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'The Primary Image' );
@@ -47,10 +45,6 @@ class CreateContentModelMediaFieldCest {
 	 * Ensure a user can only add one featured image media field to the model.
 	 */
 	public function i_can_only_add_one_featured_image_media_field_to_a_content_model( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
-
 		$i->click( 'Media', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'The Primary Image' );
@@ -85,10 +79,6 @@ class CreateContentModelMediaFieldCest {
 	 * Ensure a featured image field is properly denoted in publisher.
 	 */
 	public function i_can_denote_a_featured_image_field_in_publisher( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
-
 		$i->click( 'Media', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'The Primary Image' );

--- a/tests/acceptance/CreateContentModelMultipleChoiceFieldCest.php
+++ b/tests/acceptance/CreateContentModelMultipleChoiceFieldCest.php
@@ -2,13 +2,16 @@
 
 class CreateContentModelMultipleChoiceFieldCest {
 
+	public function _before( \AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
+	}
+
 	/**
 	 * Ensure a user can add a multile choice field from a model and remove it.
 	 */
 	public function i_can_add_a_multiple_choice_field_to_a_content_model( AcceptanceTester $i ): void {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
 		$i->click( 'Multiple Choice (Beta)', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'Favorite Animal' );
@@ -36,9 +39,6 @@ class CreateContentModelMultipleChoiceFieldCest {
 	 * Ensure a user cannot create two options with the same key value api identifier.
 	 */
 	public function i_cannot_add_a_duplicate_identifier_name_for_two_choices( AcceptanceTester $i ): void {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
 		$i->click( 'Multiple Choice (Beta)', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'Favorite Animal' );
@@ -60,9 +60,6 @@ class CreateContentModelMultipleChoiceFieldCest {
 	 * Ensure a user cannot save a choice with no name or slug.
 	 */
 	public function i_cannot_save_a_blank_choice( AcceptanceTester $i ): void {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
 		$i->click( 'Multiple Choice (Beta)', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'Favorite Animal' );
@@ -82,9 +79,6 @@ class CreateContentModelMultipleChoiceFieldCest {
 	 * Ensure a user cannot create two choices with the same name.
 	 */
 	public function i_cannot_add_a_duplicate_name_for_two_choices( AcceptanceTester $i ): void {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
 		$i->click( 'Multiple Choice (Beta)', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'Favorite Animal' );

--- a/tests/acceptance/CreateContentModelNumberFieldCest.php
+++ b/tests/acceptance/CreateContentModelNumberFieldCest.php
@@ -2,14 +2,16 @@
 
 class CreateContentModelNumberFieldCest {
 
+	public function _before( \AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$content_model = $i->haveContentModel( 'Employee', 'Employees' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
+	}
+
 	/**
 	 * Ensure a user can add a number field to the model and see it within the list.
 	 */
 	public function i_can_add_a_number_field_to_a_content_model( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
-
 		$i->click( 'Number', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'Count' );
@@ -23,10 +25,6 @@ class CreateContentModelNumberFieldCest {
 	}
 
 	public function i_can_add_a_step_setting_without_a_max_setting( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
-
 		$i->click( 'Number', '.field-buttons' );
 		$i->wait( 1 );
 
@@ -37,10 +35,6 @@ class CreateContentModelNumberFieldCest {
 	}
 
 	public function i_must_use_intergers_for_advanced_interger_field_settings( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
-
 		$i->click( 'Number', '.field-buttons' );
 		$i->wait( 1 );
 

--- a/tests/acceptance/CreateContentModelRelationFieldCest.php
+++ b/tests/acceptance/CreateContentModelRelationFieldCest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Codeception\Util\Locator;
 
 class CreateContentModelRelationFieldCest {
@@ -6,15 +7,17 @@ class CreateContentModelRelationFieldCest {
 	public function _before( \AcceptanceTester $i ) {
 		$i->maximizeWindow();
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Employee', 'Employees' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Employee', 'Employees' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
+
 		// Create a text field to check for reverse relationship conflicts with a reference model.
 		$i->click( 'Text', '.field-buttons' );
 		$i->fillField( [ 'name' => 'name' ], 'conflictsWithEmployeesSlug' );
 		$i->click( '.open-field button.primary' );
 		$i->wait( 1 );
 
-		$i->haveContentModel( 'Company', 'Companies' );
+		$content_model = $i->haveContentModel( 'Company', 'Companies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 		$i->wait( 1 );
 		$i->click( 'Relation', '.field-buttons' );
 		$i->wait( 1 );

--- a/tests/acceptance/CreateContentModelTextFieldCest.php
+++ b/tests/acceptance/CreateContentModelTextFieldCest.php
@@ -7,8 +7,8 @@ class CreateContentModelTextFieldCest {
 	 */
 	public function i_can_create_a_content_model_text_field( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );
@@ -25,8 +25,8 @@ class CreateContentModelTextFieldCest {
 
 	public function i_can_create_a_content_model_text_field_as_a_textarea( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );

--- a/tests/acceptance/CreateFieldWithIsTitleCest.php
+++ b/tests/acceptance/CreateFieldWithIsTitleCest.php
@@ -7,8 +7,8 @@ class CreateFieldWithIsTitleCest {
 	 */
 	public function i_can_create_a_content_model_text_field_with_is_title( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );

--- a/tests/acceptance/CreateFieldWithReservedSlugCest.php
+++ b/tests/acceptance/CreateFieldWithReservedSlugCest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Codeception\Util\Locator;
 
 class CreateFieldWithReservedSlugCest {
@@ -9,8 +10,8 @@ class CreateFieldWithReservedSlugCest {
 	 */
 	public function i_can_not_create_a_field_with_a_reserved_default_slug( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );
@@ -34,8 +35,8 @@ class CreateFieldWithReservedSlugCest {
 	 */
 	public function i_can_not_create_a_field_with_a_reserved_dynamic_slug( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->fillField( [ 'name' => 'name' ], 'Color' );

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Codeception\Util\Locator;
 
 class CreateRelationshipFieldEntryCest {
@@ -183,7 +184,8 @@ class CreateRelationshipFieldEntryCest {
 		$i->haveContentModel( 'Right', 'Rights' );
 
 		// Create a model to set up relationship fields linking Left to Right.
-		$i->haveContentModel( 'Left', 'Lefts' );
+		$content_model = $i->haveContentModel( 'Left', 'Lefts' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		// Add a one-to-one relationship field to the Left model that references Right, including a reverse reference.
 		$i->waitForElement( '.field-buttons' );
@@ -281,10 +283,10 @@ class CreateRelationshipFieldEntryCest {
 		$i->haveContentModel( 'Right', 'Rights' );
 
 		// Create a model to check the “from”/“A” side of the relationship.
-		$i->haveContentModel( 'Left', 'Lefts' );
+		$content_model = $i->haveContentModel( 'Left', 'Lefts' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		// Add a relationship field to the Left model that references Right.
-		$i->wait( 1 );
 		$i->click( 'Relationship', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'Rights' );
@@ -363,14 +365,16 @@ class CreateRelationshipFieldEntryCest {
 	 * @return void
 	 */
 	protected function create_company_employee_models( \AcceptanceTester $i ) {
-		$i->haveContentModel( 'Company', 'Companies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Company', 'Companies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
+		$i->wait( 2 );
 		$i->click( 'Text', '.field-buttons' );
 		$i->checkOption( 'input[name="isTitle"]' );
 		$i->fillField( [ 'name' => 'name' ], 'Company' );
 		$i->click( '.open-field button.primary' );
-
-		$i->haveContentModel( 'Employee', 'Employees' );
+		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Employee', 'Employees' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 		$i->wait( 1 );
 		$i->click( 'Relationship', '.field-buttons' );
 		$i->wait( 1 );
@@ -386,7 +390,7 @@ class CreateRelationshipFieldEntryCest {
 		$i->selectOption( '#reference', 'Companies' );
 		$i->click( 'input#many-to-many' );
 		$i->click( '.open-field button.primary' );
-		$i->wait( 1 );
+		$i->wait( 2 );
 	}
 
 	/**

--- a/tests/acceptance/CreateTaxonomyCest.php
+++ b/tests/acceptance/CreateTaxonomyCest.php
@@ -7,7 +7,6 @@ class CreateTaxonomyCest {
 		$i->maximizeWindow();
 		$i->loginAsAdmin();
 		$i->haveContentModel( 'goose', 'geese' );
-		$i->wait( 1 );
 	}
 
 	public function i_can_navigate_to_the_taxonomies_page( AcceptanceTester $i ) {

--- a/tests/acceptance/DeleteContentModelCest.php
+++ b/tests/acceptance/DeleteContentModelCest.php
@@ -34,8 +34,7 @@ class DeleteContentModelCest {
 	 */
 	public function i_see_that_associated_taxonomies_are_updated_when_model_is_deleted( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
-		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose', 'moose' ] );
-		$i->wait( 1 );
+		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'types' => [ 'goose', 'moose' ] ] );
 
 		$i->amOnWPEngineContentModelPage();
 		$i->click( '.model-list button.options' );

--- a/tests/acceptance/DeleteContentModelCest.php
+++ b/tests/acceptance/DeleteContentModelCest.php
@@ -6,9 +6,7 @@ class DeleteContentModelCest {
 		$i->resizeWindow( 1024, 1024 );
 		$i->maximizeWindow();
 		$i->loginAsAdmin();
-		$i->wait( 1 );
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->wait( 1 );
 	}
 
 	/**
@@ -36,7 +34,6 @@ class DeleteContentModelCest {
 	 */
 	public function i_see_that_associated_taxonomies_are_updated_when_model_is_deleted( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
-		$i->wait( 1 );
 		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose', 'moose' ] );
 		$i->wait( 1 );
 
@@ -66,8 +63,8 @@ class DeleteContentModelCest {
 
 	public function i_see_relationship_fields_for_a_deleted_model_are_automatically_removed( AcceptanceTester $i ) {
 		// Create a Mouse model with a “Geese Friends” relationship field.
-		$i->haveContentModel( 'Mouse', 'Mice' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Mouse', 'Mice' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 		$i->click( 'Relation', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'Geese Friends' );

--- a/tests/acceptance/DeleteFieldFromModelCest.php
+++ b/tests/acceptance/DeleteFieldFromModelCest.php
@@ -2,14 +2,13 @@
 
 class DeleteFieldFromModelCest {
 
-
 	/**
 	 * Ensure a user can delete a field from a model.
 	 */
 	public function i_can_delete_a_field_from_a_model( AcceptanceTester $i ): void {
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );
@@ -25,4 +24,5 @@ class DeleteFieldFromModelCest {
 		$i->click( 'Delete', '.atlas-content-modeler-delete-field-modal-container' );
 		$i->see( 'Choose your first field for the content model' );
 	}
+
 }

--- a/tests/acceptance/DeleteTaxonomyCest.php
+++ b/tests/acceptance/DeleteTaxonomyCest.php
@@ -2,19 +2,14 @@
 
 class DeleteTaxonomyCest {
 
-	public function _before( \AcceptanceTester $i ) {
-		$i->maximizeWindow();
-		$i->loginAsAdmin();
-		$content_model = $i->haveContentModel( 'Goose', 'Geese' );
-		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
-	}
-
 	/**
 	 * Ensure a user can delete ACM taxonomies.
 	 */
 	public function i_can_delete_a_taxonomy( AcceptanceTester $i ) {
-		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose' ] );
-		$i->wait( 1 );
+		$i->maximizeWindow();
+		$i->loginAsAdmin();
+		$i->haveContentModel( 'Goose', 'Geese' );
+		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'types' => [ 'goose' ] ] );
 		$i->amOnTaxonomyListingsPage();
 		$i->wait( 1 );
 

--- a/tests/acceptance/DeleteTaxonomyCest.php
+++ b/tests/acceptance/DeleteTaxonomyCest.php
@@ -5,8 +5,8 @@ class DeleteTaxonomyCest {
 	public function _before( \AcceptanceTester $i ) {
 		$i->maximizeWindow();
 		$i->loginAsAdmin();
-		$i->wait( 1 );
-		$i->haveContentModel( 'Goose', 'Geese' );
+		$content_model = $i->haveContentModel( 'Goose', 'Geese' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 	}
 
 	/**

--- a/tests/acceptance/EditContentModelCest.php
+++ b/tests/acceptance/EditContentModelCest.php
@@ -1,12 +1,14 @@
 <?php
+
 class EditContentModelCest {
+
 	public function i_can_update_an_existing_content_model( AcceptanceTester $i ) {
 		$i->resizeWindow( 1024, 1024 );
 		$i->loginAsAdmin();
 
 		// First, create a new model.
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		// Invoke edit mode.
 		$i->amOnWPEngineContentModelPage();
@@ -40,4 +42,5 @@ class EditContentModelCest {
 		$menu_label = $i->grabTextFrom( '#menu-posts-candy .wp-menu-name' );
 		$i->assertEquals( 'Cats', $menu_label );
 	}
+
 }

--- a/tests/acceptance/EditFieldCest.php
+++ b/tests/acceptance/EditFieldCest.php
@@ -7,8 +7,8 @@ class EditFieldCest {
 	 */
 	public function i_cannot_edit_a_field_slug_after_the_field_has_been_created( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'Candy', 'Candies' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );

--- a/tests/acceptance/EditTaxonomyCest.php
+++ b/tests/acceptance/EditTaxonomyCest.php
@@ -5,9 +5,8 @@ class EditTaxonomyCest {
 	public function _before( \AcceptanceTester $i ) {
 		$i->maximizeWindow();
 		$i->loginAsAdmin();
-		$i->wait( 1 );
-		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Goose', 'Geese' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose' ] );
 		$i->wait( 1 );
 		$i->amOnTaxonomyListingsPage();

--- a/tests/acceptance/EditTaxonomyCest.php
+++ b/tests/acceptance/EditTaxonomyCest.php
@@ -7,7 +7,7 @@ class EditTaxonomyCest {
 		$i->loginAsAdmin();
 		$content_model = $i->haveContentModel( 'Goose', 'Geese' );
 		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
-		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose' ] );
+		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'types' => [ 'goose' ] ] );
 		$i->wait( 1 );
 		$i->amOnTaxonomyListingsPage();
 		$i->wait( 1 );

--- a/tests/acceptance/FilterEntryTitlesCest.php
+++ b/tests/acceptance/FilterEntryTitlesCest.php
@@ -1,7 +1,15 @@
 <?php
+
 use Codeception\Util\Locator;
 
 class FilterEntryTitlesCest {
+
+	public function _before( \AcceptanceTester $i ) {
+		$i->maximizeWindow();
+		$i->loginAsAdmin();
+		$content_model = $i->haveContentModel( 'goose', 'geese', [ 'description' => 'Geese go honk' ] );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
+	}
 
 	/**
 	 * If the user specifies a text field to use as the entry title, check that
@@ -10,12 +18,6 @@ class FilterEntryTitlesCest {
 	 * @param AcceptanceTester $i
 	 */
 	public function i_see_the_defined_entry_title_field_value_in_the_entry_list( AcceptanceTester $i ) {
-		$i->maximizeWindow();
-
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese', 'Geese go honk' );
-		$i->wait( 1 );
-
 		$i->click( 'Text', '.field-buttons' );
 		$i->fillField( [ 'name' => 'name' ], 'Fave Foods' );
 		$i->click( '.open-field button.primary' );
@@ -53,12 +55,6 @@ class FilterEntryTitlesCest {
 	 * @param AcceptanceTester $i
 	 */
 	public function i_see_a_fallback_title_if_there_is_no_entry_title_field( AcceptanceTester $i ) {
-		$i->maximizeWindow();
-
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese', 'Geese go honk' );
-		$i->wait( 1 );
-
 		$i->click( 'Text', '.field-buttons' );
 		$i->fillField( [ 'name' => 'name' ], 'Fave Foods' );
 		$i->click( '.open-field button.primary' );
@@ -94,12 +90,6 @@ class FilterEntryTitlesCest {
 	 * @param AcceptanceTester $i
 	 */
 	public function i_see_a_fallback_title_if_the_title_field_is_empty( AcceptanceTester $i ) {
-		$i->maximizeWindow();
-
-		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese', 'Geese go honk' );
-		$i->wait( 1 );
-
 		$i->click( 'Text', '.field-buttons' );
 		$i->fillField( [ 'name' => 'name' ], 'Name' );
 		// Set the 'name' field as the entry title field.

--- a/tests/acceptance/OpenInGraphiQLCest.php
+++ b/tests/acceptance/OpenInGraphiQLCest.php
@@ -11,8 +11,8 @@ class OpenInGraphiQLCest {
 	 * query when the model has no fields.
 	 */
 	public function i_can_open_model_with_no_fields_in_graphiql( AcceptanceTester $i ) {
-		$i->haveContentModel( 'Dog', 'Dogs' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Dog', 'Dogs' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( '.heading .options' ); // Model options button.
 		$i->click( '.show-in-graphiql' );
@@ -29,8 +29,8 @@ class OpenInGraphiQLCest {
 	 * query, including the model's fields.
 	 */
 	public function i_can_open_a_model_with_fields_in_graphiql( AcceptanceTester $i ) {
-		$i->haveContentModel( 'Dog', 'Dogs' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'Dog', 'Dogs' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );
@@ -53,8 +53,8 @@ class OpenInGraphiQLCest {
 	 * query when the model singular and plural names are not capitalized.
 	 */
 	public function i_can_open_model_with_lowercased_model_names_in_graphiql( AcceptanceTester $i ) {
-		$i->haveContentModel( 'cat', 'cats' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'cat', 'cats' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( '.heading .options' ); // Model options button.
 		$i->click( '.show-in-graphiql' );
@@ -71,8 +71,8 @@ class OpenInGraphiQLCest {
 	 * query when the model singular and plural names are identical.
 	 */
 	public function i_can_open_model_with_same_singular_and_plural_name_in_graphiql( AcceptanceTester $i ) {
-		$i->haveContentModel( 'deer', 'deer' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'deer', 'deer' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( '.heading .options' ); // Model options button.
 		$i->click( '.show-in-graphiql' );

--- a/tests/acceptance/PublishModelCest.php
+++ b/tests/acceptance/PublishModelCest.php
@@ -1,15 +1,15 @@
 <?php
+
 use Codeception\Util\Locator;
+
 class PublishModelCest {
 
 	public function _before( \AcceptanceTester $i ) {
 		$i->resizeWindow( 1024, 1024 );
 		$i->maximizeWindow();
-
-		// First we create a model with fields.
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese', 'geese go honk' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'goose', 'geese', [ 'description' => 'Geese go honk' ] );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 	}
 
 	public function i_see_submission_errors_in_number_fields_when_input_is_missing_for_the_number_type( \AcceptanceTester $i ) {

--- a/tests/acceptance/PublishModelSanitizationCest.php
+++ b/tests/acceptance/PublishModelSanitizationCest.php
@@ -1,14 +1,12 @@
 <?php
-use Codeception\Util\Locator;
+
 class PublishModelSanitizationCest {
 
 	public function i_can_publish_a_model_and_fields_are_sanitized( AcceptanceTester $i ) {
 		$i->maximizeWindow();
-
-		// Create a model.
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese', 'Geese go honk' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'goose', 'geese', [ 'description' => 'Geese go honk' ] );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		// Add a text field.
 		$i->click( 'Text', '.field-buttons' );

--- a/tests/acceptance/RequiredFieldsCest.php
+++ b/tests/acceptance/RequiredFieldsCest.php
@@ -1,14 +1,12 @@
 <?php
-use Codeception\Util\Locator;
+
 class RequiredFieldsCest {
 
 	public function i_can_set_required_fields_and_see_submission_errors( AcceptanceTester $i ) {
 		$i->maximizeWindow();
-
-		// Create a model with a required 'name' field.
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'goose', 'geese' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );

--- a/tests/acceptance/SidebarUpdatesCest.php
+++ b/tests/acceptance/SidebarUpdatesCest.php
@@ -16,14 +16,11 @@ class SidebarUpdatesCest {
 	 */
 	public function the_sidebar_adds_new_post_types_upon_creation( AcceptanceTester $i ) {
 		$i->dontSeeElementInDOM( '#menu-posts-goose' );
+		$i->dontSeeElementInDOM( '#menu-posts-moose' );
 
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->wait( 1 );
-
-		$i->seeElementInDOM( '#menu-posts-goose' );
-
 		$i->haveContentModel( 'Moose', 'Moose' );
-		$i->wait( 1 );
+		$i->amOnWPEngineContentModelPage();
 
 		$i->seeElementInDOM( '#menu-posts-goose' );
 		$i->seeElementInDOM( '#menu-posts-moose' );
@@ -35,12 +32,10 @@ class SidebarUpdatesCest {
 	public function the_sidebar_removes_post_types_upon_deletion( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->wait( 1 );
+		$i->amOnWPEngineContentModelPage();
 
 		$i->seeElementInDOM( '#menu-posts-goose' );
 		$i->seeElementInDOM( '#menu-posts-moose' );
-
-		$i->amOnWPEngineContentModelPage();
 
 		// Delete Moose.
 		$i->click( '.model-list button.options' );
@@ -65,8 +60,6 @@ class SidebarUpdatesCest {
 	public function the_sidebar_adds_new_taxonomies_upon_creation( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->wait( 1 );
-
 		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose' ] );
 		$i->wait( 1 );
 
@@ -99,8 +92,6 @@ class SidebarUpdatesCest {
 	public function the_sidebar_updates_taxonomies_upon_editing( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->wait( 1 );
-
 		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose' ] );
 		$i->wait( 1 );
 
@@ -144,8 +135,6 @@ class SidebarUpdatesCest {
 	public function the_sidebar_removes_taxonomies_upon_deletion( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->wait( 1 );
-
 		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose', 'moose' ] );
 		$i->wait( 1 );
 

--- a/tests/acceptance/SidebarUpdatesCest.php
+++ b/tests/acceptance/SidebarUpdatesCest.php
@@ -60,8 +60,8 @@ class SidebarUpdatesCest {
 	public function the_sidebar_adds_new_taxonomies_upon_creation( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose' ] );
-		$i->wait( 1 );
+		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'types' => [ 'goose' ] ] );
+		$i->amOnTaxonomyListingsPage();
 
 		// The new taxonomy is assigned to Goose.
 		$i->seeElementInDOM( '#menu-posts-goose a', [ 'href' => 'edit-tags.php?taxonomy=breed&post_type=goose' ] );
@@ -70,8 +70,8 @@ class SidebarUpdatesCest {
 		// The new taxonomy is not assigned to Moose.
 		$i->dontSeeElementInDOM( '#menu-posts-moose a', [ 'href' => 'edit-tags.php?taxonomy=breed&post_type=moose' ] );
 
-		$i->haveTaxonomy( 'Region', 'Regions', [ 'goose', 'moose' ] );
-		$i->wait( 1 );
+		$i->haveTaxonomy( 'Region', 'Regions', [ 'types' => [ 'goose', 'moose' ] ] );
+		$i->amOnTaxonomyListingsPage();
 
 		// The new taxonomy is added to Goose and existing taxonomies are still present.
 		$i->seeElementInDOM( '#menu-posts-goose a', [ 'href' => 'edit-tags.php?taxonomy=region&post_type=goose' ] );
@@ -92,8 +92,8 @@ class SidebarUpdatesCest {
 	public function the_sidebar_updates_taxonomies_upon_editing( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose' ] );
-		$i->wait( 1 );
+		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'types' => [ 'goose' ] ] );
+		$i->amOnTaxonomyListingsPage();
 
 		$i->moveMouseOver( [ 'css' => '#menu-posts-goose' ] );
 		$i->see( 'Breeds', [ 'css' => '#menu-posts-goose a' ] );
@@ -135,8 +135,8 @@ class SidebarUpdatesCest {
 	public function the_sidebar_removes_taxonomies_upon_deletion( AcceptanceTester $i ) {
 		$i->haveContentModel( 'Moose', 'Moose' );
 		$i->haveContentModel( 'Goose', 'Geese' );
-		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'goose', 'moose' ] );
-		$i->wait( 1 );
+		$i->haveTaxonomy( 'Breed', 'Breeds', [ 'types' => [ 'goose', 'moose' ] ] );
+		$i->amOnTaxonomyListingsPage();
 
 		$i->moveMouseOver( [ 'css' => '#menu-posts-goose' ] );
 		$i->see( 'Breeds', [ 'css' => '#menu-posts-goose a' ] );

--- a/tests/acceptance/TrashEntryCest.php
+++ b/tests/acceptance/TrashEntryCest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Codeception\Util\Locator;
 
 class TrashEntryCest {
@@ -6,10 +7,9 @@ class TrashEntryCest {
 	public function _before( \AcceptanceTester $i ) {
 		$i->maximizeWindow();
 		$i->loginAsAdmin();
-
 		$i->haveContentModel( 'goose', 'geese' );
-		$i->haveContentModel( 'mouse', 'mice' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'mouse', 'mice' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		// Create a relationship field in mouse linking to geese.
 		$i->click( 'Relationship', '.field-buttons' );

--- a/tests/acceptance/UnsavedChangesCest.php
+++ b/tests/acceptance/UnsavedChangesCest.php
@@ -1,14 +1,15 @@
 <?php
+
 use Codeception\Util\Locator;
+
 class UnsavedChangesCest {
 
 	public function _before( \AcceptanceTester $i ) {
 		$i->resizeWindow( 1024, 1024 );
 		$i->maximizeWindow();
-
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'goose', 'geese' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 	}
 
 	public function i_see_an_unsaved_changes_prompt_when_opening_another_field( \AcceptanceTester $i ) {

--- a/tests/acceptance/UpdateExistingModelEntryCest.php
+++ b/tests/acceptance/UpdateExistingModelEntryCest.php
@@ -4,10 +4,9 @@ class UpdateExistingModelEntryCest {
 
 	public function i_can_update_an_existing_model_entry( AcceptanceTester $i ) {
 		$i->maximizeWindow();
-		// First we create a model with fields.
 		$i->loginAsAdmin();
-		$i->haveContentModel( 'goose', 'geese', 'Geese go honk' );
-		$i->wait( 1 );
+		$content_model = $i->haveContentModel( 'goose', 'geese', [ 'description' => 'Geese go honk' ] );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->fillField( [ 'name' => 'name' ], 'Color' );


### PR DESCRIPTION
## Description

This pull request updates the `AcceptanceTester::haveContentModel()` and `AcceptanceTester::haveTaxonomy()` methods to use the database directly when creating content models or content model taxonomies. By using the database directly, it reduces total end-2-end time by about ~5 minutes.

Internal ticket: https://wpengine.atlassian.net/browse/MTKA-1212

## Testing

`make test-e2e`