### PR TITLE
MTKA-1364: Flush rewrite rules when adding/removing models

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -403,7 +403,13 @@ function get_registered_content_types(): array {
  * @return bool
  */
 function update_registered_content_types( array $args ): bool {
-	return update_option( 'atlas_content_modeler_post_types', $args );
+	$updated = update_option( 'atlas_content_modeler_post_types', $args );
+
+	if ( $updated ) {
+		flush_rewrite_rules();
+	}
+
+	return $updated;
 }
 
 /**

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -406,7 +406,7 @@ function update_registered_content_types( array $args ): bool {
 	$updated = update_option( 'atlas_content_modeler_post_types', $args );
 
 	if ( $updated ) {
-		flush_rewrite_rules();
+		flush_rewrite_rules( false );
 	}
 
 	return $updated;

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -170,4 +170,15 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 	public function test_model_supports_author(): void {
 		self::assertTrue( post_type_supports( 'public', 'author' ) );
 	}
+
+	public function test_flush_rewrite_rules_called_after_updating_model(): void {
+		global $wp_rewrite;
+
+		$wp_rewrite = $this->createMock( WP_Rewrite::class );
+		$wp_rewrite->expects( $this->once() )
+			->method( 'flush_rules' )
+			->with( true );
+
+		update_registered_content_types( [] );
+	}
 }

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -177,7 +177,7 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 		$wp_rewrite = $this->createMock( WP_Rewrite::class );
 		$wp_rewrite->expects( $this->once() )
 			->method( 'flush_rules' )
-			->with( true );
+			->with( false );
 
 		update_registered_content_types( [] );
 	}


### PR DESCRIPTION
## Description

If a Content Model was `public` and entries were created, they could not be viewed on the front-end due to rewrite rules not being flushed. This pull request adds [flush_rewrite_rules()](https://developer.wordpress.org/reference/functions/flush_rewrite_rules/) when a Content Model is created, deleted, or updated.
