### PR TITLE
Chore: Update composer config to allow composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
## Description

This pull request updates the composer config file to set `allow-plugins` with `dealerdirect/phpcodesniffer-composer-installer`. This change will be needed for a future version of composer that will prevent any plugins from working unless specifically allowed. See [allow-plugins](https://getcomposer.org/doc/06-config.md#allow-plugins).