### PR TITLE
fix: return early when checking for protected meta if no ACM fields exist yet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Atlas Content Modeler Changelog
+## Unreleased
+### Fixed
+- Prevent PHP fatal errors on sites running < PHP 7.4 under certain conditions when no models exist.
 
 ## 0.12.0 - 2021-12-15
 ### Added

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -755,6 +755,9 @@ function is_protected_meta( bool $protected, string $meta_key, string $meta_type
 	}
 
 	$fields = wp_list_pluck( get_registered_content_types(), 'fields' );
+	if ( empty( $fields ) ) {
+		return $protected;
+	}
 	$fields = array_merge( ...array_values( $fields ) );
 	$slugs  = wp_list_pluck( $fields, 'slug' );
 


### PR DESCRIPTION
## Description
The [callback](https://github.com/wpengine/atlas-content-modeler/blob/3a339bf5945ddefe0b07242e859e363ef8ed9142/includes/content-registration/custom-post-types-registration.php#L747) hooked into the `is_protected_meta` filter assumes fields and models exist on the site. Under certain conditions it's possible for this to cause PHP fatal errors, as reported in #393. This PR checks that fields exist before running the other logic.

Closes #393 

## Testing
I was unable to reproduce this bug, so I'm going off the bug report and what I see in the code.
