### PR TITLE
[NOJIRA]: Fix broken ACM_UNAUTHORIZED_REQUEST test

### DIFF
--- a/tests/integration/api-validation/test-graphql-endpoints.php
+++ b/tests/integration/api-validation/test-graphql-endpoints.php
@@ -69,7 +69,7 @@ class GraphQLEndpointTests extends WP_UnitTestCase {
 			);
 
 			self::assertEmpty( $results['data']['privatesFields']['nodes'] );
-			self::assertSame( $results['extensions']['debug'][0]['type'], 'ACM_UNAUTHORIZED_REQUEST' );
+			self::assertContains( 'ACM_UNAUTHORIZED_REQUEST', array_column( $results['extensions']['debug'], 'type' ) );
 		} catch ( Exception $exception ) {
 			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
 		}


### PR DESCRIPTION
Adjusts test assertion so that other debug messages that happen to be output before the `ACM_UNAUTHORIZED_REQUEST` message do not affect this test.

Tests were failing on main because our assertion previously assumed that `ACM_UNAUTHORIZED_REQUEST` was the first debug message.

## Testing

Confirm tests now pass in CircleCI.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

n/a