### PR TITLE
[NOJIRA] Ensure rich text fields load consistently for publishers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Fixed
+- Ensure Rich Text fields load for publishers even if WordPress Core editor scripts are slow to execute.
+
 ## 0.12.1 - 2022-01-12
 ### Fixed
 - Prevent PHP fatal errors on sites running < PHP 7.4 under certain conditions when no models exist.

--- a/includes/publisher/js/src/components/RichTextEditor.jsx
+++ b/includes/publisher/js/src/components/RichTextEditor.jsx
@@ -7,32 +7,33 @@ const { wp } = window;
 export default function RichTextEditor({ field, modelSlug, defaultError }) {
 	const fieldId = `atlas-content-modeler-${modelSlug}-${field.slug}`;
 	const editorReadyTimer = useRef(null);
-	const editorReadyTime = 500;
-	const initializeEditorWhenReady = () => {
-		/**
-		 * WP defines getDefaultSettings() in an admin footer script tag after
-		 * admin scripts are enqueued, so we must wait for it to be available.
-		 */
-		if (typeof wp?.oldEditor?.getDefaultSettings === "function") {
-			wp.oldEditor.initialize(fieldId, {
-				...wp.oldEditor.getDefaultSettings(),
-				tinymce: {
-					height: "300",
-					toolbar1:
-						"undo,redo,formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,unlink,wp_add_media",
-				},
-				mediaButtons: true,
-				quicktags: false,
-			});
-		} else {
-			editorReadyTimer.current = setTimeout(
-				initializeEditorWhenReady,
-				editorReadyTime
-			);
-		}
-	};
 
 	useEffect(() => {
+		const editorReadyTime = 500;
+		const initializeEditorWhenReady = () => {
+			/**
+			 * WP defines getDefaultSettings() in an admin footer script tag after
+			 * admin scripts are enqueued, so we must wait for it to be available.
+			 */
+			if (typeof wp?.oldEditor?.getDefaultSettings === "function") {
+				wp.oldEditor.initialize(fieldId, {
+					...wp.oldEditor.getDefaultSettings(),
+					tinymce: {
+						height: "300",
+						toolbar1:
+							"undo,redo,formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,unlink,wp_add_media",
+					},
+					mediaButtons: true,
+					quicktags: false,
+				});
+			} else {
+				editorReadyTimer.current = setTimeout(
+					initializeEditorWhenReady,
+					editorReadyTime
+				);
+			}
+		};
+
 		if (
 			atlasContentModelerFormEditingExperience?.models ||
 			atlasContentModelerFormEditingExperience?.models[
@@ -40,11 +41,11 @@ export default function RichTextEditor({ field, modelSlug, defaultError }) {
 			]
 		) {
 			initializeEditorWhenReady();
-			return () => {
-				clearTimeout(editorReadyTimer.current);
-			};
 		}
-	}, [editorReadyTimer, editorReadyTime, initializeEditorWhenReady]);
+		return () => {
+			clearTimeout(editorReadyTimer.current);
+		};
+	}, [fieldId, editorReadyTimer]);
 
 	return (
 		<>


### PR DESCRIPTION
## Description

Fixes #399 by initializing rich text fields only when the `wp.oldEditor.getDefaultSettings` function is available.

WP adds that function definition as an [inline admin footer script](https://github.com/WordPress/WordPress/blob/0fcde6de17e379c5ee3bf6b32d952bf6be16cece/wp-includes/class-wp-editor.php#L970-L999) _after_ our publisher app JS loads. This causes #399 because — with a slower network speed — our Rich Text field init function can execute before the browser has parsed the `wp.oldEditor.getDefaultSettings` function definition in the inline `script` tag lower down the page.

The fix works by checking that `wp.oldEditor.getDefaultSettings` is a function before running our init code, so that load order of scripts no longer matters.

I chose this over the suggested fix in #399 (changing the enqueued scripts hook priority) because it worked consistently for all network speeds for me. Changing hook priority helped with slightly slower connections but not _really_ slow ones in my tests.

## Testing

To test manually:

1. Create a model with one or more Rich Text fields.
2. Visit the new entry page for that model. The Rich Text fields should still load.
3. Throttle your network speed and refresh (I used “Slow 3G in Chrome”). The Rich Text fields should still load, although it may take a while. (It is expected to see your rich text field content as plain HTML before the Rich Text field is initialized.)

I couldn't find a way to restrict network speed in our automated tests, but we have existing tests in place to check that Rich Text fields load under good network conditions. I don't know that we want to introduce tests that deliberately run slow anyway at this stage.

## Screenshots

n/a

## Documentation Changes

n/a

## Dependant PRs

n/a