### PR TITLE
[MTKA-1371] Prevent title field changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 - Ensure Rich Text fields load for publishers even if WordPress Core editor scripts are slow to execute.
 
+### Changed
+- The title field of a model can no longer be changed once set, unless you delete the original title field. This prepares upcoming work to save title field data to WordPress post titles, allowing title field content to be searchable.
+
 ## 0.12.1 - 2022-01-12
 ### Fixed
 - Prevent PHP fatal errors on sites running < PHP 7.4 under certain conditions when no models exist.

--- a/includes/settings/js/src/components/fields/TextFields.jsx
+++ b/includes/settings/js/src/components/fields/TextFields.jsx
@@ -1,7 +1,7 @@
 /**
  * Additional form fields for the Text field type.
  */
-import React, { useContext, useRef } from "react";
+import React, { useContext } from "react";
 import { getTitleFieldId } from "../../queries";
 import { ModelsContext } from "../../ModelsContext";
 import { useLocationSearch } from "../../utils";
@@ -12,14 +12,12 @@ const TextFields = ({ register, data, editing, fieldId }) => {
 	const query = useLocationSearch();
 	const currentModel = query.get("id");
 	const fields = models[currentModel]?.fields;
-	const originalTitleFieldId = useRef(getTitleFieldId(fields));
-	const shouldShowTitleField =
-		!originalTitleFieldId.current ||
-		originalTitleFieldId.current === fieldId;
+	const titleFieldId = getTitleFieldId(fields);
+	const showTitleField = !titleFieldId || titleFieldId === fieldId;
 
 	return (
 		<>
-			{shouldShowTitleField && (
+			{showTitleField && (
 				<div className="field">
 					<legend>Title Field</legend>
 					<input
@@ -28,7 +26,7 @@ const TextFields = ({ register, data, editing, fieldId }) => {
 						id={`is-title-${fieldId}`}
 						ref={register}
 						defaultChecked={data?.isTitle === true}
-						disabled={!!originalTitleFieldId.current}
+						disabled={!!titleFieldId}
 					/>
 					<label
 						htmlFor={`is-title-${fieldId}`}

--- a/includes/settings/js/src/components/fields/TextFields.jsx
+++ b/includes/settings/js/src/components/fields/TextFields.jsx
@@ -5,18 +5,21 @@ import React, { useContext, useRef } from "react";
 import { getTitleFieldId } from "../../queries";
 import { ModelsContext } from "../../ModelsContext";
 import { useLocationSearch } from "../../utils";
-import { sprintf, __ } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 
 const TextFields = ({ register, data, editing, fieldId }) => {
-	const { models, dispatch } = useContext(ModelsContext);
+	const { models } = useContext(ModelsContext);
 	const query = useLocationSearch();
 	const currentModel = query.get("id");
 	const fields = models[currentModel]?.fields;
 	const originalTitleFieldId = useRef(getTitleFieldId(fields));
+	const shouldShowTitleField =
+		!originalTitleFieldId.current ||
+		originalTitleFieldId.current === fieldId;
 
 	return (
 		<>
-			{!data?.parent && (
+			{shouldShowTitleField && (
 				<div className="field">
 					<legend>Title Field</legend>
 					<input
@@ -24,55 +27,8 @@ const TextFields = ({ register, data, editing, fieldId }) => {
 						type="checkbox"
 						id={`is-title-${fieldId}`}
 						ref={register}
-						checked={data?.isTitle === true}
-						onChange={(event) => {
-							/**
-							 * Unchecks other fields when checking a field.
-							 * Only one field can be the title field.
-							 */
-							if (event.target.checked) {
-								dispatch({
-									type: "setTitleField",
-									id: fieldId,
-									model: currentModel,
-								});
-								return;
-							}
-
-							if (!event.target.checked) {
-								/**
-								 * When unchecking a field that was not the original
-								 * title, restore isTitle on the original title
-								 * field if there is one. Prevents an issue where
-								 * checking “is title” then unchecking it removes
-								 * isTitle from the original.
-								 */
-								if (
-									originalTitleFieldId.current &&
-									originalTitleFieldId.current !== fieldId
-								) {
-									dispatch({
-										type: "setTitleField",
-										id: originalTitleFieldId.current,
-										model: currentModel,
-									});
-									return;
-								}
-
-								/**
-								 * At this point we're just unchecking the original
-								 * title field.
-								 */
-								dispatch({
-									type: "setFieldProperties",
-									id: fieldId,
-									model: currentModel,
-									properties: [
-										{ name: "isTitle", value: false },
-									],
-								});
-							}
-						}}
+						defaultChecked={data?.isTitle === true}
+						disabled={!!originalTitleFieldId.current}
 					/>
 					<label
 						htmlFor={`is-title-${fieldId}`}

--- a/includes/settings/js/src/reducer.js
+++ b/includes/settings/js/src/reducer.js
@@ -72,13 +72,10 @@ export function reducer(state, action) {
 				editing: false,
 			};
 			return { ...state };
-		case "setTitleField":
 		case "setFeaturedImageField":
 			const fields = state[action.model]["fields"];
-			const setType =
-				action.type === "setTitleField" ? "isTitle" : "isFeatured";
 			Object.values(fields).forEach((field) => {
-				state[action.model]["fields"][field.id][setType] = false;
+				state[action.model]["fields"][field.id]["isFeatured"] = false;
 			});
 			state[action.model]["fields"][action.id][setType] = true;
 			return { ...state };

--- a/includes/settings/js/src/reducer.js
+++ b/includes/settings/js/src/reducer.js
@@ -77,7 +77,7 @@ export function reducer(state, action) {
 			Object.values(fields).forEach((field) => {
 				state[action.model]["fields"][field.id]["isFeatured"] = false;
 			});
-			state[action.model]["fields"][action.id][setType] = true;
+			state[action.model]["fields"][action.id]["isFeatured"] = true;
 			return { ...state };
 		case "setFieldProperties":
 			action.properties.forEach((property) => {

--- a/tests/acceptance/CreateFieldWithIsTitleCest.php
+++ b/tests/acceptance/CreateFieldWithIsTitleCest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Codeception\Util\Locator;
+
 class CreateFieldWithIsTitleCest {
 
 	/**
@@ -21,5 +23,16 @@ class CreateFieldWithIsTitleCest {
 		$i->see( 'Text', '.field-list div.type' );
 		$i->see( 'Name', '.field-list div.widest' );
 		$i->see( 'entry title', '.field-list div.tags' );
+	}
+
+	public function i_can_not_create_a_second_text_field_with_is_title( AcceptanceTester $i ) {
+		$this->i_can_create_a_content_model_text_field_with_is_title( $i );
+
+		// Add a second text field.
+		$i->click( Locator::lastElement( '.add-item' ) );
+		$i->click( 'Text', '.field-buttons' );
+
+		// Should not be possible to set another text field as the title.
+		$i->dontSee( 'Use this field as the entry title', '.field-form' );
 	}
 }


### PR DESCRIPTION
## Description

- Once a Text field on a model is configured as the entry title, that setting can't be changed so that another field becomes the title.
- If the title field is deleted from the model, any Text field on the model can be configured as the title field.

We are making this change now to allow us to copy text title field content to the WordPress post title in a stable way in a future PR. (Changing the title field would invalidate titles stored in the post table, so we've decided to prevent it for now.)

https://wpengine.atlassian.net/browse/MTKA-1371

## Testing

Added an e2e test to confirm that the set title option does not appear on other Text fields once any Text field is set as the title.

### To test manually
1. Create a Text field and set it as the title field.
2. Create another text field. You will not see the “Title Field” option for that field.
3. Delete the first text field.
4. You should be able to now set other fields as the title field.

## Screenshots

n/a

## Documentation Changes

Added changelog entry.

## Dependant PRs

n/a