### PR TITLE
[NO JIRA] test: lock relationship table before drop operation

### DIFF
--- a/tests/integration/content-registration/test-relationships-db.php
+++ b/tests/integration/content-registration/test-relationships-db.php
@@ -6,6 +6,7 @@ class TestRelationshipsDB extends WP_UnitTestCase {
 		global $wpdb;
 		parent::tear_down();
 		$table = $wpdb->prefix . 'acm_post_to_post';
+		$wpdb->query( "LOCK TABLES $table WRITE" );
 		$wpdb->query( "DROP TABLE IF EXISTS $table" );
 	}
 


### PR DESCRIPTION
## Description
Locks the relationship table before dropping it. A [recent test run failed](https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/2341/workflows/7d64e0aa-cfce-406a-b0f1-25ff2ae0d350/jobs/24040) with the following error: 
```
[ModuleException] Db: SQLSTATE[HY000]: General error: 1100 Table 'wp_acm_post_to_post' was not locked with LOCK TABLES
SQL query being executed: 
DROP TABLE IF EXISTS `wp_acm_post_to_post`
```

Not sure if an upstream change caused this, or if re-running the failed test would pass, but it seems like a decent change either way.

## Testing
Existing test suite passes with no other changes.
