### PR TITLE
[NOJIRA] Fix failing Content Connect unit tests

### DIFF
--- a/tests/content-connect/integration/ContentConnectTestCase.php
+++ b/tests/content-connect/integration/ContentConnectTestCase.php
@@ -4,7 +4,7 @@ namespace WPE\AtlasContentModeler\ContentConnect\Tests\Integration;
 
 use WPE\AtlasContentModeler\ContentConnect\Relationships\PostToPost;
 
-class ContentConnectTestCase extends \PHPUnit_Framework_TestCase {
+class ContentConnectTestCase extends \PHPUnit\Framework\TestCase {
 
 	public static function setupBeforeClass() {
 		self::insert_dummy_data();

--- a/tests/content-connect/integration/Tables/PostToPostTest.php
+++ b/tests/content-connect/integration/Tables/PostToPostTest.php
@@ -2,7 +2,7 @@
 
 namespace WPE\AtlasContentModeler\ContentConnect\Tests\Integration\Tables;
 
-class PostToPostTest extends \PHPUnit_Framework_TestCase {
+class PostToPostTest extends \PHPUnit\Framework\TestCase {
 
 	public function test_table_is_created() {
 		global $wpdb;


### PR DESCRIPTION
We were seeing this failure in Circle on all branches for the `plugin-test-content-connect` job:

> Fatal error: Uncaught Error: Class 'PHPUnit_Framework_TestCase' not found in /home/circleci/project/atlas-content-modeler/tests/content-connect/integration/ContentConnectTestCase.php:7

This PR uses `extend \PHPUnit\Framework\TestCase` instead of `\PHPUnit_Framework_TestCase` to follow the latest PHPUnit conventions.

Ref: https://stackoverflow.com/questions/6065730/why-fatal-error-class-phpunit-framework-testcase-not-found-in.