### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wpengine/blockheads @wpengine/mintaka
+* @wpengine/mintaka


### PR DESCRIPTION
Removes old Blockheads team from CODEOWNERS file. 

For comparison:

Blockheads members - https://github.com/orgs/wpengine/teams/blockheads/members

Mintaka members - https://github.com/orgs/wpengine/teams/mintaka/members
