### PR TITLE
Updated Getting Started button to use custom component

### DIFF
--- a/includes/settings/js/src/components/ViewContentModelsList.jsx
+++ b/includes/settings/js/src/components/ViewContentModelsList.jsx
@@ -65,7 +65,7 @@ export default function ViewContentModelsList() {
 								"atlas-content-modeler"
 							)}
 						</p>
-						<button
+						<Button
 							onClick={() =>
 								history.push(
 									atlasContentModeler.appPath +
@@ -74,7 +74,7 @@ export default function ViewContentModelsList() {
 							}
 						>
 							{__("Get Started", "atlas-content-modeler")}
-						</button>
+						</Button>
 					</div>
 				)}
 			</section>

--- a/tests/jest/__snapshots__/App.test.js.snap
+++ b/tests/jest/__snapshots__/App.test.js.snap
@@ -27,6 +27,7 @@ exports[`App Renders a matching snapshot 1`] = `
           You currently have no Content Models.
         </p>
         <button
+          className="css-1cfhljd-Button"
           onClick={[Function]}
         >
           Get Started


### PR DESCRIPTION
## Description

This pull request updates the "Getting Started" button to use the custom button component. This fixes the missing styling on the Getting Started button.



## Screenshots

![Screenshot 2022-02-07 at 13-41-50 Models ‹ WordPress Development — WordPress](https://user-images.githubusercontent.com/1128283/152859950-86e1b294-1b54-4620-ae2a-e4632a16f5fa.png)