### PR TITLE
[MTKA-1400] Prevent 'undefined' model title in model deletion modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Fixed
+- The delete model prompt no longer shows “undefined” in its title during model deletion.
+
 ## 0.14.0 - 2022-02-10
 ### Added
 - New `wp acm blueprint import` WP-CLI command to import ACM data programmatically. This prepares for future work to restore ACM blueprints. See `wp help acm blueprint import` for options.

--- a/includes/settings/js/src/components/DeleteModelModal.jsx
+++ b/includes/settings/js/src/components/DeleteModelModal.jsx
@@ -119,9 +119,6 @@ export function DeleteModelModal({ modalIsOpen, setModalIsOpen, model }) {
 				className="first"
 				data-testid="delete-model-button"
 				onClick={async () => {
-					// Optimistically remove the model from the UI.
-					dispatch({ type: "removeModel", slug });
-
 					await deleteModel(slug)
 						.then((res) => {
 							if (res.success) {
@@ -140,9 +137,9 @@ export function DeleteModelModal({ modalIsOpen, setModalIsOpen, model }) {
 										fields: relationships,
 									});
 								}
-							} else {
-								// Restore the model in the UI since deletion failed.
-								dispatch({ type: "addModel", data: model });
+								setModalIsOpen(false);
+								dispatch({ type: "removeModel", slug });
+								history.push(atlasContentModeler.appPath);
 							}
 						})
 						.catch(() => {
@@ -155,11 +152,7 @@ export function DeleteModelModal({ modalIsOpen, setModalIsOpen, model }) {
 									slug
 								)
 							);
-							// Restore the model in the UI since deletion failed.
-							dispatch({ type: "addModel", data: model });
 						});
-
-					history.push(atlasContentModeler.appPath);
 				}}
 			>
 				{__("Delete", "atlas-content-modeler")}


### PR DESCRIPTION
Fixes #433 by removing a model from browser state only when deletion succeeds, instead of optimistically before deletion begins (which was aimed to improve perceived performance, but is less important than removing “undefined” from title text).

https://wpengine.atlassian.net/browse/mtka-1400

## Testing

I couldn't find a way to reliably and quickly automate testing of this, but you can test manually:

1. Create a new model (no fields are required).
2. Throttle your browser network speed to “slow 3G”.
3. Delete the model.

The deletion modal should close and never show “undefined” in the title of the deletion modal.

## Screenshots

### Before

https://user-images.githubusercontent.com/647669/154070002-f0925b40-f1ec-4ee9-a679-9d30742f411d.mov

### After

https://user-images.githubusercontent.com/647669/154070062-b2023ef2-8903-4324-a36a-51fa74a08c50.mov

## Documentation Changes

n/a

## Dependant PRs

n/a