### PR TITLE
chore: fix button text on model edit modal

### DIFF
--- a/includes/settings/js/src/components/EditModelModal.jsx
+++ b/includes/settings/js/src/components/EditModelModal.jsx
@@ -414,7 +414,7 @@ export function EditModelModal({ model, isOpen, setIsOpen }) {
 					className="first"
 					data-testid="edit-model-save-button"
 				>
-					{__("Saves", "atlas-content-modeler")}
+					{__("Save", "atlas-content-modeler")}
 				</Button>
 				<TertiaryButton
 					href="#"


### PR DESCRIPTION
## Description
Reverts text change introduced in #420 where the button text was changed from Save to Saves.

