### PR TITLE
[NOJIRA] build: add `PARCEL_WORKERS` env variable to build script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "scripts": {
     "build": "npm run build-settings && npm run build-publisher",
-    "build-settings": "parcel build --target=settings --no-source-maps --no-scope-hoist",
-    "build-publisher": "parcel build --target=publisher --no-source-maps --no-scope-hoist",
+    "build-settings": "PARCEL_WORKERS=0 parcel build --target=settings --no-source-maps --no-scope-hoist",
+    "build-publisher": "PARCEL_WORKERS=0 parcel build --target=publisher --no-source-maps --no-scope-hoist",
     "build-readme": "node scripts/buildReadme.js",
     "clean": "rm -rf .parcel-cache/ includes/publisher/dist/ includes/settings/dist/",
     "start": "parcel watch",


### PR DESCRIPTION
## Description
Adds `PARCEL_WORKERS` to build script in an attempt to work around segmentation faults that happen randomly when building assets.

Example fault: https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/2588/workflows/caa53023-ee23-4e78-9f5c-781a28de812b/jobs/27186

[Here are several threads](https://github.com/parcel-bundler/parcel/search?q=fault&type=issues) in the Parcel repo related to segmentation faults.

The fix here was suggested in some of the threads linked above, and several people confirmed it fixed the problem for them. Anecdotally I haven't been able to trigger a fault with this added, whereas before I could trigger the fault fairly easily by doing `npm run clean` and `npm run build` a few times.