### PR TITLE
[MTKA-1404] Make WPGatsby track and invalidate caches for ACM post types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Fixed
+- Gatsby users can now use the “Refresh Data” button in Gatsby GraphiQL or the /__refresh endpoint to update ACM post data.
 - The delete model prompt no longer shows “undefined” in its title during model deletion.
 
 ## 0.14.0 - 2022-02-10

--- a/atlas-content-modeler.php
+++ b/atlas-content-modeler.php
@@ -46,6 +46,7 @@ function atlas_content_modeler_loader(): void {
 		'content-registration/custom-post-types-registration.php',
 		'content-registration/register-taxonomies.php',
 		'content-registration/class-wpe-rest-posts-controller.php',
+		'content-registration/gatsby.php',
 		'rest-api/init-rest-api.php',
 		'publisher/class-publisher-form-editing-experience.php',
 		'updates/version-updates.php',

--- a/includes/content-registration/gatsby.php
+++ b/includes/content-registration/gatsby.php
@@ -18,7 +18,8 @@ use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_
 
 add_filter( 'gatsby_action_monitor_tracked_post_types', __NAMESPACE__ . '\monitor_acm_post_types' );
 /**
- * Extends post types WPGatsby monitors for changes to include ACM models.
+ * Extends post types WPGatsby monitors for changes to include all ACM models
+ * where api_visibility is 'public'.
  *
  * Without this, Gatsby developers have to stop and start their server to see
  * new, updated, or deleted ACM posts reflected in GraphQL responses.
@@ -36,7 +37,15 @@ add_filter( 'gatsby_action_monitor_tracked_post_types', __NAMESPACE__ . '\monito
  * @return array New list of monitored post types with ACM types added.
  */
 function monitor_acm_post_types( array $original_post_types ): array {
-	$acm_post_types = array_keys( get_registered_content_types() );
+	$acm_post_types = array_keys(
+		array_filter(
+			get_registered_content_types(),
+			function( $acm_post_type ) {
+				return $acm_post_type['api_visibility'] === 'public';
+			}
+		)
+	);
+
 	$acm_post_types = array_combine( $acm_post_types, $acm_post_types ); // So that keys match values, as in the array returned from get_post_types().
 
 	return array_merge( $original_post_types, $acm_post_types );

--- a/includes/content-registration/gatsby.php
+++ b/includes/content-registration/gatsby.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Register content for Gatsby.
+ *
+ * So that the WPGatsby plugin invalidates the Gatsby data cache when
+ * ACM entries are created, deleted or modified.
+ *
+ * @link https://wordpress.org/plugins/wp-gatsby/
+ * @link https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/getting-started.md#quick-start
+ * @package AtlasContentModeler
+ */
+
+declare(strict_types=1);
+
+namespace WPE\AtlasContentModeler\ContentRegistration\Gatsby;
+
+use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_types;
+
+add_filter( 'gatsby_action_monitor_tracked_post_types', __NAMESPACE__ . '\monitor_acm_post_types' );
+/**
+ * Extends post types WPGatsby monitors for changes to include ACM models.
+ *
+ * Without this, Gatsby developers have to stop and start their server to see
+ * new, updated, or deleted ACM posts reflected in GraphQL responses.
+ *
+ * With this, they can click “Refresh Data” on the Gatsby GraphiQL page at
+ * http://localhost:8000/___graphql during development to update data, or do
+ * `curl -X POST http://localhost:8000/__refresh`.
+ *
+ * The `ENABLE_GATSBY_REFRESH_ENDPOINT=true` environment variable is required
+ * in `.env.development` before “Refresh Data” or the `/__refresh` endpoint are
+ * available. See:
+ * https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/
+ *
+ * @param array $original_post_types Current list of monitored post types.
+ * @return array New list of monitored post types with ACM types added.
+ */
+function monitor_acm_post_types( array $original_post_types ): array {
+	$acm_post_types = array_keys( get_registered_content_types() );
+	$acm_post_types = array_combine( $acm_post_types, $acm_post_types ); // So that keys match values, as in the array returned from get_post_types().
+
+	return array_merge( $original_post_types, $acm_post_types );
+}

--- a/includes/content-registration/gatsby.php
+++ b/includes/content-registration/gatsby.php
@@ -41,7 +41,7 @@ function monitor_acm_post_types( array $original_post_types ): array {
 		array_filter(
 			get_registered_content_types(),
 			function( $acm_post_type ) {
-				return $acm_post_type['api_visibility'] === 'public';
+				return ( $acm_post_type['api_visibility'] ?? 'private' ) === 'public';
 			}
 		)
 	);

--- a/tests/integration/content-registration/test-gatsby.php
+++ b/tests/integration/content-registration/test-gatsby.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Class TestGatsby
+ *
+ * @package AtlasContentModeler
+ */
+
+use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
+use function WPE\AtlasContentModeler\ContentRegistration\Gatsby\monitor_acm_post_types;
+
+class TestGatsby extends WP_UnitTestCase {
+	private $models;
+
+	public function setUp() {
+		parent::setUp();
+
+		/**
+		 * Reset the WPGraphQL schema before each test.
+		 * Lazy loading types only loads part of the schema,
+		 * so we refresh for each test.
+		 */
+		WPGraphQL::clear_schema();
+
+		// Start each test with a fresh relationships registry.
+		\WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->setup();
+
+		$this->models = $this->get_models();
+
+		update_registered_content_types( $this->models );
+
+		// @todo why is this not running automatically?
+		do_action( 'init' );
+	}
+
+	public function test_wp_gatsby_filter_is_added(): void {
+		$expected_filter_priority = 10;
+
+		self::assertSame(
+			$expected_filter_priority,
+			has_filter(
+				'gatsby_action_monitor_tracked_post_types',
+				'WPE\AtlasContentModeler\ContentRegistration\Gatsby\monitor_acm_post_types'
+			)
+		);
+	}
+
+	public function test_gatsby_filter_adds_only_public_acm_post_types(): void {
+		$original_post_types = [
+			'post'       => 'post',
+			'page'       => 'page',
+			'custom-cpt' => 'custom-cpt',
+		];
+
+		$new_post_types = monitor_acm_post_types( $original_post_types );
+
+		$expected_new_post_types = [
+			'post'          => 'post',
+			'page'          => 'page',
+			'custom-cpt'    => 'custom-cpt',
+			'public'        => 'public',
+			'public-fields' => 'public-fields',
+		];
+
+		// Public models should now appear in the post types list.
+		self::assertSame( $expected_new_post_types, $new_post_types );
+
+		// Models with 'api_visibility' set to 'private' should not appear.
+		self::assertArrayNotHasKey( 'private', $new_post_types ); // 'api_visibility' is private.
+		self::assertArrayNotHasKey( 'private-fields', $new_post_types ); // 'api_visibility' is private.
+	}
+
+	private function get_models() {
+		return include dirname( __DIR__ ) . '/api-validation/test-data/models.php';
+	}
+}


### PR DESCRIPTION
## Description

Resolves a [reported issue](https://github.com/wpengine/atlas-content-modeler/issues/434#issuecomment-1039163057) where Gatsby sites do not show new, deleted, or changed ACM posts until the Gatsby server is restarted.

https://wpengine.atlassian.net/browse/MTKA-1404

## Testing

Includes integration test to confirm the new `monitor_acm_post_types` function behaves as intended.

Testing manually requires:

- A WP site with the WPGraphQL and [WPGatsby](https://wordpress.org/plugins/wp-gatsby/) plugins, as well as a “rabbit” model and “name” field set as the entry title.
- A basic [Gatsby site for WordPress](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/getting-started.md) frontend, which you can set up like this:

1. `npm install -g gatsby-cli`
3. `cd ~/Desktop/` or wherever you want to keep a temporary Gatsby site.
4. `gatsby new my-wordpress-gatsby-site https://github.com/gatsbyjs/gatsby-starter-wordpress-blog`
5. Open `gatsby-starter-wordpress-blog` in your editor.
6. In the `gatsby-config.js` of the starter you just set up, change the `https://wpgatsbydemo.wpengine.com/graphql` url to point to your own WP GraphQL endpoint, such as `https://example.com/graphql` (needs to include the `/graphql`).
7. Add this code to the top of `gatsby-config.js` above the `module.exports` line:
    ```
    require("dotenv").config({
      path: `.env.${process.env.NODE_ENV}`,
    })
    ```
8. Create a file in your gatsby project root named `.env.development` with this content:
    ```
     ENABLE_GATSBY_REFRESH_ENDPOINT=true
    ```
9. Create a file in your gatsby project at `src/pages/test-mtka1404.js` with this content:

    ```js
    import React from "react"
    import { graphql } from "gatsby"
    
    const ComponentName = ({ data }) => <pre>{JSON.stringify(data, null, 4)}</pre>
    
    export const query = graphql`
      {
        allWpRabbit {
          nodes {
            id
            title
          }
        }
      }
    `
    
    export default ComponentName

    ```
10. Almost there! Now you can run `gatsby develop` in your gatsby project root.
11. When gatsby completes its startup process, visit http://localhost:8000/test-mtka1404 and leave that tab open.
12. You should see the result of the rabbits query from your `src/pages/test-mtka1404.js` file.
13. Add, delete, or modify a rabbit.
14. Run `curl -X POST http://localhost:8000/__refresh` in any shell to invalidate the rabbits data, then check the http://localhost:8000/test-mtka1404 page — it should refresh automatically with the new rabbits data.

If you were to do this in the `main` branch, POSTing to `http://localhost:8000/__refresh` would not update the rabbits data. (If you want to try this, be sure to cancel the `gatsby develop` process, then run `gatsby clean && gatsby develop` after switching to `main`. You'll have to repeat this if you want to re-test this branch.)

You can also refresh data by visiting http://localhost:8000/___graphql and clicking the “Refresh Data” button. (It may take a few seconds, and you'll see feedback in the console where you ran `gatsby develop`.)

## Screenshots

https://user-images.githubusercontent.com/647669/154315238-9768b484-bded-4ec4-9c3f-5d4aabed240d.mov

## Documentation Changes

n/a

## Dependant PRs

n/a