### PR TITLE
chore: fix method param type.

### DIFF
--- a/includes/content-connect/includes/Plugin.php
+++ b/includes/content-connect/includes/Plugin.php
@@ -105,7 +105,7 @@ class Plugin {
 	/**
 	 * Undocumented function
 	 *
-	 * @param array $table Table.
+	 * @param string $table Table.
 	 * @return mixed
 	 */
 	public function get_table( $table ) {


### PR DESCRIPTION
`WPE\AtlasContentModeler\ContentConnect\Plugin::get_table()` accepts a string, but it's documented as an array.
