### PR TITLE
[MTKA-1428] Blueprints: import categories and post_tags for WP core posts 

### DIFF
--- a/includes/wp-cli/class-blueprint.php
+++ b/includes/wp-cli/class-blueprint.php
@@ -139,9 +139,9 @@ class Blueprint {
 		}
 
 		$term_ids_old_new = [];
-		if ( ! empty( $manifest['terms'] ?? [] ) ) {
+		if ( ! empty( $manifest['post_terms'] ?? [] ) ) {
 			\WP_CLI::log( 'Importing terms.' );
-			$term_ids_old_new = import_terms( $manifest['terms'] );
+			$term_ids_old_new = import_terms( $manifest['post_terms'] );
 
 			if ( is_wp_error( $term_ids_old_new['errors'] ) ) {
 				foreach ( $term_ids_old_new['errors']->get_error_messages() as $message ) {

--- a/tests/integration/blueprints/test-blueprint-import.php
+++ b/tests/integration/blueprints/test-blueprint-import.php
@@ -109,10 +109,10 @@ class BlueprintImportTest extends WP_UnitTestCase {
 
 	public function test_import_terms() {
 		import_taxonomies( $this->manifest['taxonomies'] );
-		$import_result = import_terms( $this->manifest['terms'] );
+		$import_result = import_terms( $this->manifest['post_terms'] );
 
 		$terms               = get_terms( 'breed', [ 'hide_empty' => false ] );
-		$expected_term_count = count( $this->manifest['terms'] );
+		$expected_term_count = 2; // See post_terms in tests/integration/blueprints/test-data/blueprint-good/acm.json.
 
 		self::assertCount( $expected_term_count, $terms );
 		self::assertFalse( $import_result['errors'] );
@@ -121,7 +121,7 @@ class BlueprintImportTest extends WP_UnitTestCase {
 	public function test_import_bad_terms_records_error() {
 		$manifest = get_manifest( __DIR__ . '/test-data/blueprint-bad-terms' );
 		import_taxonomies( $manifest['taxonomies'] );
-		$import_terms = import_terms( $manifest['terms'] );
+		$import_terms = import_terms( $manifest['post_terms'] );
 
 		self::assertInstanceOf( 'WP_Error', $import_terms['errors'] );
 		$errors = $import_terms['errors']->get_error_codes();
@@ -134,7 +134,7 @@ class BlueprintImportTest extends WP_UnitTestCase {
 		import_taxonomies( $this->manifest['taxonomies'] );
 
 		$post_ids_old_new = import_posts( $this->manifest['posts'] );
-		$term_ids_old_new = import_terms( $this->manifest['terms'] )['ids'];
+		$term_ids_old_new = import_terms( $this->manifest['post_terms'] )['ids'];
 
 		tag_posts(
 			$this->manifest['post_terms'],
@@ -158,7 +158,7 @@ class BlueprintImportTest extends WP_UnitTestCase {
 		import_taxonomies( $manifest['taxonomies'] );
 
 		$post_ids_old_new = import_posts( $manifest['posts'] );
-		$term_ids_old_new = import_terms( $manifest['terms'] )['ids'];
+		$term_ids_old_new = import_terms( $manifest['post_terms'] )['ids'];
 
 		$tag_posts = tag_posts(
 			$manifest['post_terms'],

--- a/tests/integration/blueprints/test-blueprint-import.php
+++ b/tests/integration/blueprints/test-blueprint-import.php
@@ -102,7 +102,7 @@ class BlueprintImportTest extends WP_UnitTestCase {
 		import_posts( $this->manifest['posts'] );
 
 		$posts               = get_posts( [ 'post_type' => 'rabbit' ] );
-		$expected_post_count = count( $this->manifest['posts'] );
+		$expected_post_count = 2; // See 'posts' in tests/integration/blueprints/test-data/blueprint-good/acm.json.
 
 		self::assertCount( $expected_post_count, $posts );
 	}
@@ -111,11 +111,19 @@ class BlueprintImportTest extends WP_UnitTestCase {
 		import_taxonomies( $this->manifest['taxonomies'] );
 		$import_result = import_terms( $this->manifest['post_terms'] );
 
-		$terms               = get_terms( 'breed', [ 'hide_empty' => false ] );
-		$expected_term_count = 2; // See post_terms in tests/integration/blueprints/test-data/blueprint-good/acm.json.
+		$breed_terms               = get_terms( 'breed', [ 'hide_empty' => false ] );
+		$expected_breed_term_count = 2; // See 'post_terms' in tests/integration/blueprints/test-data/blueprint-good/acm.json.
 
-		self::assertCount( $expected_term_count, $terms );
+		$category_terms               = get_terms( 'category', [ 'hide_empty' => false ] );
+		$expected_category_term_count = 2; // "Uncategorized" and "films". See 'post_terms' in tests/integration/blueprints/test-data/blueprint-good/acm.json.
+
+		$post_tag_terms               = get_terms( 'post_tag', [ 'hide_empty' => false ] );
+		$expected_post_tag_term_count = 2; // See 'post_terms' in tests/integration/blueprints/test-data/blueprint-good/acm.json.
+
 		self::assertFalse( $import_result['errors'] );
+		self::assertCount( $expected_breed_term_count, $breed_terms );
+		self::assertCount( $expected_category_term_count, $category_terms );
+		self::assertCount( $expected_post_tag_term_count, $post_tag_terms );
 	}
 
 	public function test_import_bad_terms_records_error() {

--- a/tests/integration/blueprints/test-blueprint-import.php
+++ b/tests/integration/blueprints/test-blueprint-import.php
@@ -150,13 +150,31 @@ class BlueprintImportTest extends WP_UnitTestCase {
 			$term_ids_old_new
 		);
 
-		$posts = get_posts( [ 'post_type' => 'rabbit' ] );
+		$rabbits = get_posts( [ 'post_type' => 'rabbit' ] );
 
-		foreach ( $posts as $post ) {
-			$saved_terms        = wp_get_post_terms( $post->ID, 'breed' );
-			$expected_term_name = $this->manifest['post_terms'][ $post_ids_old_new[ $post->ID ] ?? $post->ID ][0]['name'];
+		foreach ( $rabbits as $rabbit ) {
+			$saved_terms        = wp_get_post_terms( $rabbit->ID, 'breed' );
+			$expected_term_name = $this->manifest['post_terms'][ $post_ids_old_new[ $rabbit->ID ] ?? $rabbit->ID ][0]['name'];
 			$actual_term_name   = $saved_terms[0]->name;
 			self::assertSame( $expected_term_name, $actual_term_name );
+		}
+
+		$posts = get_posts( [ 'post_type' => 'post' ] );
+
+		foreach ( $posts as $post ) {
+			$manifest_terms          = $this->manifest['post_terms'][ $post_ids_old_new[ $post->ID ] ?? $post->ID ];
+			$imported_category_terms = wp_get_post_terms( $post->ID, 'category' );
+			$imported_tag_terms      = wp_get_post_terms( $post->ID, 'post_tag' );
+
+			foreach ( $manifest_terms as $post_term ) {
+				if ( $post_term['taxonomy'] === 'post_tag' ) {
+					self::assertContains( $post_term['name'], wp_list_pluck( $imported_tag_terms, 'name' ) );
+				}
+
+				if ( $post_term['taxonomy'] === 'category' ) {
+					self::assertContains( $post_term['name'], wp_list_pluck( $imported_category_terms, 'name' ) );
+				}
+			}
 		}
 	}
 

--- a/tests/integration/blueprints/test-data/blueprint-bad-terms/acm.json
+++ b/tests/integration/blueprints/test-data/blueprint-bad-terms/acm.json
@@ -84,30 +84,22 @@
       "slug": "breed"
     }
   },
-  "terms": [
-    {
-      "term_id": 4,
-      "name": "Cartoon",
-      "slug": "cartoon",
-      "term_group": 0,
-      "term_taxonomy_id": 4,
-      "taxonomy": "this-taxonomy-does-not-exist",
-      "description": "",
-      "parent": 0,
-      "count": 0,
-      "filter": "raw"
-    },
-    {
-      "term_id": 3,
-      "name": "Human",
-      "slug": "human",
-      "term_group": 0,
-      "term_taxonomy_id": 3,
-      "taxonomy": "this-taxonomy-does-not-exist",
-      "description": "",
-      "parent": 0,
-      "count": 0,
-      "filter": "raw"
-    }
-  ]
+  "post_terms": {
+    "81": [
+      {
+        "term_id": 4,
+        "name": "Cartoon",
+        "slug": "cartoon",
+        "taxonomy": "this-taxonomy-does-not-exist"
+      }
+    ],
+    "82": [
+      {
+        "term_id": 3,
+        "name": "Human",
+        "slug": "human",
+        "taxonomy": "this-taxonomy-does-not-exist"
+      }
+    ]
+  }
 }

--- a/tests/integration/blueprints/test-data/blueprint-good/acm.json
+++ b/tests/integration/blueprints/test-data/blueprint-good/acm.json
@@ -84,32 +84,6 @@
       "slug": "breed"
     }
   },
-  "terms": [
-    {
-      "term_id": 4,
-      "name": "Cartoon",
-      "slug": "cartoon",
-      "term_group": 0,
-      "term_taxonomy_id": 4,
-      "taxonomy": "breed",
-      "description": "",
-      "parent": 0,
-      "count": 0,
-      "filter": "raw"
-    },
-    {
-      "term_id": 3,
-      "name": "Human",
-      "slug": "human",
-      "term_group": 0,
-      "term_taxonomy_id": 3,
-      "taxonomy": "breed",
-      "description": "",
-      "parent": 0,
-      "count": 0,
-      "filter": "raw"
-    }
-  ],
   "posts": {
     "81": {
       "ID": 81,

--- a/tests/integration/blueprints/test-data/blueprint-good/acm.json
+++ b/tests/integration/blueprints/test-data/blueprint-good/acm.json
@@ -134,6 +134,35 @@
       "post_type": "rabbit",
       "post_mime_type": "",
       "comment_count": "0"
+    },
+    "1457": {
+      "ID": 1457,
+      "post_author": "1",
+      "post_date": "2022-02-25 17:21:16",
+      "post_date_gmt": "2022-02-25 17:21:16",
+      "post_content": "",
+      "post_title": "5 Crazy Fan Theories About Fight Club",
+      "post_excerpt": "",
+      "post_status": "publish",
+      "comment_status": "open",
+      "ping_status": "open",
+      "post_password": "",
+      "post_name": "5-crazy-fan-theories-about-fight-club",
+      "to_ping": "",
+      "pinged": "",
+      "post_modified": "2022-03-02 10:59:30",
+      "post_modified_gmt": "2022-03-02 10:59:30",
+      "post_content_filtered": "",
+      "post_parent": 0,
+      "menu_order": 0,
+      "post_type": "post",
+      "post_mime_type": "",
+      "comment_count": "0",
+      "filter": "raw",
+      "ancestors": [],
+      "page_template": "",
+      "post_category": [167],
+      "tags_input": ["dark", "weird"]
     }
   },
   "post_terms": {
@@ -147,6 +176,44 @@
     ],
     "82": [
       { "term_id": 3, "name": "Human", "slug": "human", "taxonomy": "breed" }
+    ],
+    "1457": [
+      {
+        "term_id": 167,
+        "name": "films",
+        "slug": "films",
+        "term_group": 0,
+        "term_taxonomy_id": 167,
+        "taxonomy": "category",
+        "description": "",
+        "parent": 0,
+        "count": 1,
+        "filter": "raw"
+      },
+      {
+        "term_id": 169,
+        "name": "dark",
+        "slug": "dark",
+        "term_group": 0,
+        "term_taxonomy_id": 169,
+        "taxonomy": "post_tag",
+        "description": "",
+        "parent": 0,
+        "count": 1,
+        "filter": "raw"
+      },
+      {
+        "term_id": 168,
+        "name": "weird",
+        "slug": "weird",
+        "term_group": 0,
+        "term_taxonomy_id": 168,
+        "taxonomy": "post_tag",
+        "description": "",
+        "parent": 0,
+        "count": 1,
+        "filter": "raw"
+      }
     ]
   },
   "post_meta": {


### PR DESCRIPTION
## Description

Adapts term import logic so that categories and post_tags for the core 'post' type are imported.

https://wpengine.atlassian.net/browse/MTKA-1428

## Testing

Updates existing integration tests to confirm terms are imported for core posts.

To test manually:

1. Remove existing ACM models and taxonomies: `wp option delete atlas_content_modeler_taxonomies && wp option delete atlas_content_modeler_post_types`
2. Run `wp acm blueprint import http://contentmodel1.wpengine.com/wp-content/uploads/2022/03/post-with-tags.zip`
3. You should see a new post named, “5 Crazy Fan Theories About Fight Club” at Posts → All Posts. It should have one category and two tags.


<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

Docs already adjusted in #451.

## Dependant PRs

Targets blueprints/core-taxonomies so that this can be merged to main together with #451.