### PR TITLE
[MTKA-1403] Merge blueprint core taxonomy import/export to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Atlas Content Modeler Changelog
 
 ## Unreleased
+### Changed
+- The `wp acm blueprint export` and `wp acm blueprint import` commands now include category and post_tag taxonomy terms for the WordPress core 'post' type.
+
 ### Fixed
 - The delete model prompt no longer shows “undefined” in its title during model deletion.
 

--- a/docs/blueprints/index.md
+++ b/docs/blueprints/index.md
@@ -37,7 +37,6 @@ ACM blueprints do not yet export or import:
 - **Post authors:** All posts are assigned to the current user on import.
 - **WordPress options:** No entries from `wp_options` are stored or restored at this time.
 - **Installed plugins:** ACM does not yet install or activate plugins.
-- **Tags and categories for core post and page types:** ACM imports taxonomies and tags relating to ACM entries only at this time.
 
 If you'd like to see support for these please [open or add to a discussion](https://github.com/wpengine/atlas-content-modeler/discussions).
 

--- a/includes/wp-cli/class-blueprint.php
+++ b/includes/wp-cli/class-blueprint.php
@@ -138,9 +138,9 @@ class Blueprint {
 		}
 
 		$term_ids_old_new = [];
-		if ( ! empty( $manifest['terms'] ?? [] ) ) {
+		if ( ! empty( $manifest['post_terms'] ?? [] ) ) {
 			\WP_CLI::log( 'Importing terms.' );
-			$term_ids_old_new = import_terms( $manifest['terms'] );
+			$term_ids_old_new = import_terms( $manifest['post_terms'] );
 
 			if ( is_wp_error( $term_ids_old_new['errors'] ) ) {
 				foreach ( $term_ids_old_new['errors']->get_error_messages() as $message ) {

--- a/includes/wp-cli/class-blueprint.php
+++ b/includes/wp-cli/class-blueprint.php
@@ -39,7 +39,6 @@ use function WPE\AtlasContentModeler\Blueprint\Export\{
 	collect_post_tags,
 	collect_posts,
 	collect_relationships,
-	collect_terms,
 	delete_folder,
 	generate_meta,
 	get_acm_temp_dir,
@@ -259,8 +258,11 @@ class Blueprint {
 		$manifest['taxonomies'] = get_acm_taxonomies();
 
 		\WP_CLI::log( 'Collecting posts.' );
-		$post_types = [];
-		if ( $assoc_args['post-types'] ?? false ) {
+		$post_types = array_merge(
+			array_keys( get_registered_content_types() ),
+			[ 'post', 'page' ]
+		);
+		if ( ! empty( $assoc_args['post-types'] ) ) {
 			$post_types = array_map(
 				'trim',
 				explode( ',', $assoc_args['post-types'] )
@@ -268,18 +270,10 @@ class Blueprint {
 		}
 		$manifest['posts'] = collect_posts( $post_types );
 
-		if ( ! empty( $manifest['taxonomies'] ?? [] ) ) {
-			\WP_CLI::log( 'Collecting terms.' );
-			$manifest['terms'] = collect_terms(
-				array_keys( $manifest['taxonomies'] )
-			);
-		}
-
-		if ( ! empty( $manifest['terms'] ?? [] ) ) {
+		if ( ! empty( $manifest['posts'] ?? [] ) ) {
 			\WP_CLI::log( 'Collecting post tags.' );
 			$manifest['post_terms'] = collect_post_tags(
-				$manifest['posts'] ?? [],
-				wp_list_pluck( $manifest['terms'], 'taxonomy' )
+				$manifest['posts'] ?? []
 			);
 		}
 

--- a/tests/integration/blueprints/test-data/blueprint-bad-terms/acm.json
+++ b/tests/integration/blueprints/test-data/blueprint-bad-terms/acm.json
@@ -84,30 +84,22 @@
       "slug": "breed"
     }
   },
-  "terms": [
-    {
-      "term_id": 4,
-      "name": "Cartoon",
-      "slug": "cartoon",
-      "term_group": 0,
-      "term_taxonomy_id": 4,
-      "taxonomy": "this-taxonomy-does-not-exist",
-      "description": "",
-      "parent": 0,
-      "count": 0,
-      "filter": "raw"
-    },
-    {
-      "term_id": 3,
-      "name": "Human",
-      "slug": "human",
-      "term_group": 0,
-      "term_taxonomy_id": 3,
-      "taxonomy": "this-taxonomy-does-not-exist",
-      "description": "",
-      "parent": 0,
-      "count": 0,
-      "filter": "raw"
-    }
-  ]
+  "post_terms": {
+    "81": [
+      {
+        "term_id": 4,
+        "name": "Cartoon",
+        "slug": "cartoon",
+        "taxonomy": "this-taxonomy-does-not-exist"
+      }
+    ],
+    "82": [
+      {
+        "term_id": 3,
+        "name": "Human",
+        "slug": "human",
+        "taxonomy": "this-taxonomy-does-not-exist"
+      }
+    ]
+  }
 }

--- a/tests/integration/blueprints/test-data/blueprint-good/acm.json
+++ b/tests/integration/blueprints/test-data/blueprint-good/acm.json
@@ -84,32 +84,6 @@
       "slug": "breed"
     }
   },
-  "terms": [
-    {
-      "term_id": 4,
-      "name": "Cartoon",
-      "slug": "cartoon",
-      "term_group": 0,
-      "term_taxonomy_id": 4,
-      "taxonomy": "breed",
-      "description": "",
-      "parent": 0,
-      "count": 0,
-      "filter": "raw"
-    },
-    {
-      "term_id": 3,
-      "name": "Human",
-      "slug": "human",
-      "term_group": 0,
-      "term_taxonomy_id": 3,
-      "taxonomy": "breed",
-      "description": "",
-      "parent": 0,
-      "count": 0,
-      "filter": "raw"
-    }
-  ],
   "posts": {
     "81": {
       "ID": 81,
@@ -160,6 +134,35 @@
       "post_type": "rabbit",
       "post_mime_type": "",
       "comment_count": "0"
+    },
+    "1457": {
+      "ID": 1457,
+      "post_author": "1",
+      "post_date": "2022-02-25 17:21:16",
+      "post_date_gmt": "2022-02-25 17:21:16",
+      "post_content": "",
+      "post_title": "5 Crazy Fan Theories About Fight Club",
+      "post_excerpt": "",
+      "post_status": "publish",
+      "comment_status": "open",
+      "ping_status": "open",
+      "post_password": "",
+      "post_name": "5-crazy-fan-theories-about-fight-club",
+      "to_ping": "",
+      "pinged": "",
+      "post_modified": "2022-03-02 10:59:30",
+      "post_modified_gmt": "2022-03-02 10:59:30",
+      "post_content_filtered": "",
+      "post_parent": 0,
+      "menu_order": 0,
+      "post_type": "post",
+      "post_mime_type": "",
+      "comment_count": "0",
+      "filter": "raw",
+      "ancestors": [],
+      "page_template": "",
+      "post_category": [167],
+      "tags_input": ["dark", "weird"]
     }
   },
   "post_terms": {
@@ -173,6 +176,44 @@
     ],
     "82": [
       { "term_id": 3, "name": "Human", "slug": "human", "taxonomy": "breed" }
+    ],
+    "1457": [
+      {
+        "term_id": 167,
+        "name": "films",
+        "slug": "films",
+        "term_group": 0,
+        "term_taxonomy_id": 167,
+        "taxonomy": "category",
+        "description": "",
+        "parent": 0,
+        "count": 1,
+        "filter": "raw"
+      },
+      {
+        "term_id": 169,
+        "name": "dark",
+        "slug": "dark",
+        "term_group": 0,
+        "term_taxonomy_id": 169,
+        "taxonomy": "post_tag",
+        "description": "",
+        "parent": 0,
+        "count": 1,
+        "filter": "raw"
+      },
+      {
+        "term_id": 168,
+        "name": "weird",
+        "slug": "weird",
+        "term_group": 0,
+        "term_taxonomy_id": 168,
+        "taxonomy": "post_tag",
+        "description": "",
+        "parent": 0,
+        "count": 1,
+        "filter": "raw"
+      }
     ]
   },
   "post_meta": {


### PR DESCRIPTION
## Description

Merges the features from #451 and #452 to main ready for release.

https://wpengine.atlassian.net/browse/MTKA-1403

## Testing

These features have already been tested in the other PRs, but please feel free to review the code in this PR and try them again manually:

### Export testing steps

1. Create a regular WordPress post with one or more categories and one or more tags.
2. Run `wp acm blueprint export --name="Post With Tags" --open --post-types=post` and inspect the generated acm.json file.

You should see category and post_tag terms under the 'post_terms' key.

### Import testing steps

1. Remove existing ACM models and taxonomies: `wp option delete atlas_content_modeler_taxonomies && wp option delete atlas_content_modeler_post_types`
2. Run `wp acm blueprint import http://contentmodel1.wpengine.com/wp-content/uploads/2022/03/post-with-tags.zip`
3. You should see a new post named, “5 Crazy Fan Theories About Fight Club” at Posts → All Posts. It should have one category and two tags.

## Screenshots

n/a

## Documentation Changes

Includes adjustments to docs.

## Dependant PRs

n/a