### PR TITLE
[MTKA-1407] Use pointer cursor on options buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - The delete model prompt no longer shows “undefined” in its title during model deletion.
+- Options buttons now use the mouse pointer cursor.
 
 ## 0.14.0 - 2022-02-10
 ### Added

--- a/includes/shared-assets/js/components/Dropdown.jsx
+++ b/includes/shared-assets/js/components/Dropdown.jsx
@@ -10,6 +10,10 @@ export function Dropdown(props) {
 			margin-left: -80px;
 		}
 
+		button.options {
+			cursor: pointer;
+		}
+
 		.dropdown-content:not(.hidden) {
 			background: #fff;
 			border-radius: 2px;


### PR DESCRIPTION
## Description

Restores the cursor pointer on options dropdowns.

https://wpengine.atlassian.net/browse/MTKA-1407

## Testing

Check that options dropdowns (the `...` buttons) now have a cursor pointer.

## Screenshots

[  Cursor does not display in macOS screenshots, even with “show cursor” on. :-/   ]

## Documentation Changes

n/a

## Dependant PRs

n/a