### PR TITLE
[MTKA-1425] Improve read-only input field styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - The delete model prompt no longer shows “undefined” in its title during model deletion.
+- Improved checkbox styling in field settings.
 
 ## 0.14.0 - 2022-02-10
 ### Added

--- a/includes/settings/scss/_field-list.scss
+++ b/includes/settings/scss/_field-list.scss
@@ -73,6 +73,11 @@
 	color: lighten($color-gray, 20%);
 }
 
+.field-list .read-only input,
+.field-list .read-only label {
+	cursor: default;
+}
+
 .field-list .type {
 	align-items: center;
 	display: flex;

--- a/includes/settings/scss/_forms.scss
+++ b/includes/settings/scss/_forms.scss
@@ -61,7 +61,7 @@
 }
 
 .atlas-content-modeler-admin-page input:disabled,
-.atlas-content-modeler-admin-page input:read-only {
+.atlas-content-modeler-admin-page .read-only input {
 	background: #f4f7fa;
 	border: 1px solid #cfdde9;
 	color: #59767f;


### PR DESCRIPTION
## Description

- Checkbox inputs in the Settings app now appear dimmed only if they are disabled/read-only.
- Disabled inputs such as “Make this field repeatable” use the default instead of the pointer mouse cursor.

https://wpengine.atlassian.net/browse/MTKA-1425

## Testing

### Checkbox inputs

Confirm checkbox inputs are no longer dimmed if they're clickable:

| Before | After |
| - | - |
| <img width="280" alt="Screenshot 2022-03-04 at 11 08 31" src="https://user-images.githubusercontent.com/647669/156743571-82874263-2d90-455b-a12c-fecd4df5f539.png"> | <img width="249" alt="Screenshot 2022-03-04 at 11 08 18" src="https://user-images.githubusercontent.com/647669/156743616-95521fe2-35d9-4084-9a5d-4ec68d82106a.png"> |

### Disabled inputs
1. Create a new model. 
2. Add a Text field to the model.
3. Check “Use this field as the entry title”.

Hover your mouse over the disabled “Make this field repeatable” checkbox/label. The cursor should be a regular mouse cursor instead of a pointer.

## Documentation Changes

n/a

## Dependant PRs

n/a