### PR TITLE
Chore: Add Emotion CSS-in-JS theme

### DIFF
--- a/includes/publisher/js/src/components/MediaUploader.jsx
+++ b/includes/publisher/js/src/components/MediaUploader.jsx
@@ -200,13 +200,12 @@ export default function MediaUploader({ modelSlug, field, required }) {
 
 					{mediaUrl && (
 						<LinkButton
-							css={css`
-								color: #d21b46;
-								&:focus,
-								&:hover {
-									color: #a51537;
-								}
-							`}
+							css={(theme) => ({
+								color: theme.colors.warning,
+								"&:focus, &:hover": {
+									color: theme.colors.warningHover,
+								},
+							})}
 							href="#"
 							onClick={(e) => deleteImage(e)}
 						>

--- a/includes/publisher/js/src/components/Text/AddRepeatableItemButton.jsx
+++ b/includes/publisher/js/src/components/Text/AddRepeatableItemButton.jsx
@@ -17,15 +17,18 @@ export default function AddRepeatableItemButton({
 	if (isMaxInputs) {
 		return (
 			<div
-				css={css`
-					color: #9db7d1;
-					svg {
-						color: #9db7d1;
-						path {
-							fill: #9db7d1;
-						}
-					}
-				`}
+				css={(theme) => {
+					const { grayLight } = theme.colors;
+					return {
+						color: grayLight,
+						svg: {
+							color: grayLight,
+							path: {
+								fill: grayLight,
+							},
+						},
+					};
+				}}
 				className="d-flex flex-row justify-content-start align-items-center py-4 ps-3"
 			>
 				<AddIcon noCircle />{" "}
@@ -35,9 +38,9 @@ export default function AddRepeatableItemButton({
 						: __(`Add Item`, "atlas-content-modeler")}
 				</strong>
 				<span
-					css={css`
-						color: #d21b46;
-					`}
+					css={(theme) => ({
+						color: theme.colors.grayLight,
+					})}
 				>
 					{values.length}/{field.maxRepeatable} Max Inputs Reached
 				</span>

--- a/includes/publisher/js/src/index.jsx
+++ b/includes/publisher/js/src/index.jsx
@@ -2,8 +2,10 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
+import { ThemeProvider } from "@emotion/react";
 import "./../../scss/index.scss";
 import "../../../settings/scss/index.scss";
+import theme from "../../../shared-assets/js/theme";
 
 const { models, postType } = atlasContentModelerFormEditingExperience;
 const container = document.getElementById("atlas-content-modeler-fields-app");
@@ -13,7 +15,9 @@ if (container && models.hasOwnProperty(postType)) {
 	const urlParams = new URLSearchParams(window.location.search);
 
 	ReactDOM.render(
-		<App model={model} mode={urlParams.get("action")} />,
+		<ThemeProvider theme={theme}>
+			<App model={model} mode={urlParams.get("action")} />
+		</ThemeProvider>,
 		container
 	);
 

--- a/includes/settings/js/src/index.jsx
+++ b/includes/settings/js/src/index.jsx
@@ -2,5 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import "../../scss/index.scss";
+import { ThemeProvider } from "@emotion/react";
+import theme from "../../../shared-assets/js/theme";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+ReactDOM.render(
+	<ThemeProvider theme={theme}>
+		<App />
+	</ThemeProvider>,
+	document.getElementById("root")
+);

--- a/includes/shared-assets/js/components/Buttons.jsx
+++ b/includes/shared-assets/js/components/Buttons.jsx
@@ -1,185 +1,159 @@
 /** @jsx jsx */
 import { jsx, css } from "@emotion/react";
+import styled from "@emotion/styled";
 
-export function Button(props) {
-	const cssAttributes = css`
-		background: #7e5cef;
-		border-radius: 2px;
-		border: 1px solid #7e5cef;
-		color: #fff;
-		cursor: pointer;
-		font-size: 14px;
-		font-weight: 600;
-		height: 52px;
-		line-height: 20px;
-		padding: 14px 24px;
-		&:hover,
-		&:focus {
-			background: #5c43ae;
-			border: 1px solid #5c43ae;
-		}
-		,
-		&:disabled {
-			background: #f4f7fa !important;
-			border-color: #cfdde9 !important;
-			color: #59767f !important;
-			&:hover {
-				background: #f4f7fa !important;
-				border-color: #cfdde9 !important;
-				color: #59767f !important;
-			}
-		}
-	`;
+// TODO-abotz: Add radius variable(s) to theme?
+const borderRadius = "2px";
 
-	return (
-		<button css={cssAttributes} {...props}>
-			{props.children}
-		</button>
-	);
-}
+const addImportantToStyle = (style) => {
+	return `${style} !important`;
+};
 
-export function TertiaryButton(props) {
-	const cssAttributes = css`
-		background: #fff;
-		border: 1px solid #002838;
-		color: #002838;
-		&:hover,
-		&:focus {
-			background: #fff;
-			border: 1px solid #7e5cef;
-			color: #7e5cef;
-		}
-	`;
+export const Button = styled.button((props) => {
+	const {
+		primary,
+		primaryHover,
+		secondary,
+		secondaryLight,
+		grayDisabledText,
+		white,
+	} = props.theme.colors;
 
-	return (
-		<Button css={cssAttributes} {...props}>
-			{props.children}
-		</Button>
-	);
-}
+	return {
+		fontSize: "14px",
+		fontWeight: "600",
+		lineHeight: "20px",
+		background: primary,
+		borderRadius,
+		border: `1px solid ${primary}`,
+		color: white,
+		cursor: "pointer",
+		height: "52px",
+		padding: "14px 20px",
+		"&:hover, &:focus": {
+			background: primaryHover,
+			border: `1px solid ${primaryHover}`,
+		},
+		"&:disabled": {
+			background: addImportantToStyle(secondaryLight),
+			borderColor: addImportantToStyle(secondary),
+			color: addImportantToStyle(grayDisabledText),
+			"&:hover": {
+				background: addImportantToStyle(secondaryLight),
+				borderColor: addImportantToStyle(secondary),
+				color: addImportantToStyle(grayDisabledText),
+			},
+		},
+	};
+});
 
-export function FieldButton({ className = "", active = false, ...props }) {
-	let cssAttributes = css`
-		align-items: center;
-		display: flex;
-		margin-right: 8px;
-		padding: 10px 16px;
+export const TertiaryButton = styled(Button)((props) => {
+	const { white, blueDark, primary } = props.theme.colors;
 
-		&:hover svg path,
-		&:focus svg path {
-			fill: #7e5cef;
-		}
+	return {
+		background: white,
+		border: `1px solid ${blueDark}`,
+		color: blueDark,
+		"&:hover, &:focus": {
+			background: white,
+			border: `1px solid ${primary}`,
+			color: primary,
+		},
+	};
+});
 
-		svg {
-			margin-right: 9px;
-		}
-	`;
+// TODO-abotz: Need to figure out how to add className of active when "active" prop is true
+export const FieldButton = styled(Button)((props) => {
+	const { active = false } = props;
+	const { primary, text, white } = props.theme.colors;
 
 	if (active) {
-		cssAttributes = css`
-			${cssAttributes}
-			background: #002838;
-			color: #fff;
-
-			&:hover,
-			&:focus {
-				background: #002838;
-				border: 1px solid #002838;
-				color: #fff;
-			}
-
-			svg path,
-			&:focus svg path,
-			&:hover svg path {
-				fill: #fff;
-			}
-		`;
-		className += " active";
+		return {
+			background: text,
+			color: white,
+			"&:hover, &:focus": {
+				background: text,
+				border: `1px solid ${text}`,
+				color: white,
+			},
+			"svg path, &:focus svg path, &:hover svg path": {
+				fill: white,
+			},
+		};
 	}
 
-	return (
-		<TertiaryButton css={cssAttributes} className={className} {...props}>
-			{props.children}
-		</TertiaryButton>
-	);
-}
+	return {
+		alignItems: "center",
+		display: "flex",
+		marginRight: "8px",
+		padding: "10px 16px",
+		"&:hover svg path, &:focus svg path": {
+			fill: primary,
+		},
+		svg: {
+			marginRight: "9px",
+		},
+	};
+});
 
-export function LinkButton(props) {
-	const cssAttributes = css`
-		background: transparent;
-		border-color: transparent;
-		color: #7e5cef;
-		margin-left: 20px;
-		padding: 14px 0;
+export const LinkButton = styled(Button)((props) => {
+	const { primary, primaryHover, grayLight } = props.theme.colors;
+	const transparent = "transparent";
 
-		&:active,
-		&:hover,
-		&:focus {
-			background: transparent;
-			border-color: transparent;
-			color: #5c43ae;
+	return {
+		background: transparent,
+		borderColor: transparent,
+		color: primary,
+		marginLeft: "20px",
+		padding: "14px 0",
+		"&:active, &:hover, &:focus": {
+			background: transparent,
+			borderColor: transparent,
+			color: primaryHover,
+			"svg path": {
+				fill: primaryHover,
+			},
+		},
+		"&:disabled": {
+			background: addImportantToStyle(transparent),
+			borderColor: addImportantToStyle(transparent),
+			color: addImportantToStyle(grayLight),
+			"&:hover": {
+				background: addImportantToStyle(transparent),
+				borderColor: addImportantToStyle(transparent),
+				color: addImportantToStyle(grayLight),
+			},
+		},
 
-			svg path {
-				fill: #5c43ae;
-			}
-		}
-		&:disabled {
-			background: transparent !important;
-			border-color: transparent !important;
-			color: #9db7d1 !important;
-			&:hover {
-				background: transparent !important;
-				border-color: transparent !important;
-				color: #9db7d1 !important;
-			}
-		}
+		svg: {
+			marginRight: "10px",
+		},
+	};
+});
 
-		svg {
-			margin-right: 10px;
-		}
-	`;
+export const WarningButton = styled(Button)((props) => {
+	const { warning, warningHover, white } = props.theme.colors;
 
-	return (
-		<Button css={cssAttributes} {...props}>
-			{props.children}
-		</Button>
-	);
-}
+	return {
+		background: warning,
+		border: `1px solid ${warning}`,
+		color: white,
+		"&:hover, &:focus": {
+			background: warningHover,
+			border: `1px solid ${warningHover}`,
+		},
+	};
+});
 
-export function WarningButton(props) {
-	const cssAttributes = css`
-		background: #d21b46;
-		border: 1px solid #d21b46;
-		color: #fff;
-		&:hover,
-		&:focus {
-			background: #991433;
-			border: 1px solid #991433;
-		}
-	`;
-
-	return (
-		<Button css={cssAttributes} {...props}>
-			{props.children}
-		</Button>
-	);
-}
-
-export function DarkButton(props) {
-	const cssAttributes = css`
-		background: #002838;
-		border: 1px solid #002838;
-		color: #fff;
-		&:hover,
-		&:focus {
-			background: #004c6b;
-			border: 1px solid #004c6b;
-		}
-	`;
-
-	return (
-		<Button css={cssAttributes} {...props}>
-			{props.children}
-		</Button>
-	);
-}
+export const DarkButton = styled(Button)((props) => {
+	const { blueDark, blueDarkHover, white } = props.theme.colors;
+	return {
+		background: blueDark,
+		border: `1px solid ${blueDark}`,
+		color: white,
+		"&:hover, &:focus": {
+			background: blueDarkHover,
+			border: `1px solid ${blueDarkHover}`,
+		},
+	};
+});

--- a/includes/shared-assets/js/theme/colors.js
+++ b/includes/shared-assets/js/theme/colors.js
@@ -1,3 +1,4 @@
+// TODO-abotz: Need to verify colors and possible restructure object if makes more sense to do so
 export default {
 	white: "#fff",
 	text: "#002838",
@@ -6,4 +7,9 @@ export default {
 	warning: "#d21b46",
 	warningHover: "#991433",
 	grayLight: "#9db7d1",
+	primary: "#7e5cef",
+	primaryHover: "#5c43ae",
+	grayDisabledText: "#59767f",
+	blueDark: "#002838",
+	blueDarkHover: "#004c6b",
 };

--- a/includes/shared-assets/js/theme/colors.js
+++ b/includes/shared-assets/js/theme/colors.js
@@ -1,0 +1,9 @@
+export default {
+	white: "#fff",
+	text: "#002838",
+	secondary: "#cfdde9",
+	secondaryLight: "#f4f7fa",
+	warning: "#d21b46",
+	warningHover: "#991433",
+	grayLight: "#9db7d1",
+};

--- a/includes/shared-assets/js/theme/index.js
+++ b/includes/shared-assets/js/theme/index.js
@@ -1,0 +1,5 @@
+import colors from "./colors";
+
+export default {
+	colors,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/plugin-syntax-jsx": "^7.12.13",
         "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.8.1",
         "@wordpress/api-fetch": "^3.21.5",
         "@wordpress/data": "6.1.5",
         "bootstrap": "^5.1.3",
@@ -1389,6 +1390,39 @@
         "node": ">=0.1.95"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
+      "integrity": "sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/plugin-syntax-jsx": "^7.12.13",
+        "@babel/runtime": "^7.13.10",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.5",
+        "@emotion/serialize": "^1.0.2",
+        "babel-plugin-macros": "^2.6.1",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.0.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@emotion/cache": {
       "version": "11.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
@@ -1405,6 +1439,14 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.7.4"
+      }
     },
     "node_modules/@emotion/memoize": {
       "version": "0.7.5",
@@ -1454,15 +1496,40 @@
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
       "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
     },
+    "node_modules/@emotion/styled": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.8.1.tgz",
+      "integrity": "sha512-OghEVAYBZMpEquHZwuelXcRjRJQOVayvbmNR0zr174NHdmMgrNkLC6TljKC5h9lZLkN5WGrdUcrKlOJ4phhoTQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/babel-plugin": "^11.7.1",
+        "@emotion/is-prop-valid": "^1.1.2",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/utils": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "node_modules/@emotion/utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
-      "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ=="
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.2.5",
@@ -3937,8 +4004,7 @@
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/prettier": {
       "version": "2.2.3",
@@ -5036,6 +5102,31 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
@@ -5391,7 +5482,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6483,7 +6573,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -7523,6 +7612,11 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -7636,8 +7730,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -7875,7 +7968,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -8178,7 +8270,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -8194,7 +8285,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -8302,8 +8392,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "node_modules/is-bigint": {
       "version": "1.0.1",
@@ -8375,7 +8464,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
       "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -10657,8 +10745,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -10793,8 +10880,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-      "dev": true
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "node_modules/lmdb": {
       "version": "2.2.1",
@@ -11717,7 +11803,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -11729,7 +11814,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -11788,8 +11872,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -11803,7 +11886,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13326,7 +13408,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -15257,7 +15338,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -16398,6 +16478,32 @@
         "minimist": "^1.2.0"
       }
     },
+    "@emotion/babel-plugin": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
+      "integrity": "sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/plugin-syntax-jsx": "^7.12.13",
+        "@babel/runtime": "^7.13.10",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.5",
+        "@emotion/serialize": "^1.0.2",
+        "babel-plugin-macros": "^2.6.1",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.0.13"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
     "@emotion/cache": {
       "version": "11.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
@@ -16414,6 +16520,14 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "requires": {
+        "@emotion/memoize": "^0.7.4"
+      }
     },
     "@emotion/memoize": {
       "version": "0.7.5",
@@ -16451,15 +16565,27 @@
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
       "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
     },
+    "@emotion/styled": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.8.1.tgz",
+      "integrity": "sha512-OghEVAYBZMpEquHZwuelXcRjRJQOVayvbmNR0zr174NHdmMgrNkLC6TljKC5h9lZLkN5WGrdUcrKlOJ4phhoTQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/babel-plugin": "^11.7.1",
+        "@emotion/is-prop-valid": "^1.1.2",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/utils": "^1.1.0"
+      }
+    },
     "@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@emotion/utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
-      "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ=="
     },
     "@emotion/weak-memoize": {
       "version": "0.2.5",
@@ -18218,8 +18344,7 @@
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prettier": {
       "version": "2.2.3",
@@ -19105,6 +19230,30 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        }
+      }
+    },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
@@ -19371,8 +19520,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -20227,7 +20375,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -21017,6 +21164,11 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -21102,8 +21254,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -21288,7 +21439,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -21509,7 +21659,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -21518,8 +21667,7 @@
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         }
       }
     },
@@ -21606,8 +21754,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-bigint": {
       "version": "1.0.1",
@@ -21658,7 +21805,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
       "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -23356,8 +23502,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema": {
       "version": "0.4.0",
@@ -23465,8 +23610,7 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-      "dev": true
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "lmdb": {
       "version": "2.2.1",
@@ -24188,7 +24332,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -24197,7 +24340,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -24238,8 +24380,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -24252,8 +24393,7 @@
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -25369,7 +25509,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -26903,8 +27042,7 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@babel/plugin-syntax-jsx": "^7.12.13",
     "@emotion/react": "^11.7.1",
+    "@emotion/styled": "^11.8.1",
     "@wordpress/api-fetch": "^3.21.5",
     "@wordpress/data": "6.1.5",
     "bootstrap": "^5.1.3",


### PR DESCRIPTION
## Description

This draft PR is for ideation with fellow developers to understand how we can fully take advantage of CSS-in-JS via [Emotion](https://emotion.sh/docs/introduction), particularly focusing on its [theme implementation](https://emotion.sh/docs/theming).

The following are included in this draft PR :

- Added an initial theme with color variables that can be used off the `theme.colors` object
- NPM installed  `@emotion/styled` to the code base and utilized within `Buttons.jsx`
- Showcased css object styling with theme variables within some components, `MediaUploader.jsx` and `AddRepeatableItemButton.jsx` for example.

This draft PR is very rudimentary and has much room for improvement. Please be critical and share any ideas that could make it better. Some things that I would like to add in the future :

- Typography
- Iconography
- Media break point helper functions

https://wpengine.atlassian.net/browse/MTKA-1430


