### PR TITLE
MTKA-1431: Add integer and decimal validation messaging

### DIFF
--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -23,10 +23,6 @@ export default function Field(props) {
 	 * @param {object} field
 	 */
 	function validate(event, field) {
-		if (event.target.validity.valid) {
-			return;
-		}
-
 		let error = defaultError;
 
 		if (field.type === "number") {

--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -8,6 +8,8 @@ import Icon from "acm-icons";
 import { sprintf, __ } from "@wordpress/i18n";
 
 const defaultError = "This field is required";
+const integerRegex = /^[-+]?\d+/g;
+const decimalRegex = /^\-?(\d+\.?\d*|\d*\.?\d+)$/g;
 
 export default function Field(props) {
 	const { field, modelSlug } = props;
@@ -28,6 +30,22 @@ export default function Field(props) {
 		let error = defaultError;
 
 		if (field.type === "number") {
+			if (!integerRegex.test(event.target.value)) {
+				error = sprintf(
+					__("Value must be an integer.", "atlas-content-modeler"),
+					event.target.max.toString()
+				);
+			}
+
+			if (field.numberType === "decimal") {
+				if (!decimalRegex.test(event.target.value)) {
+					error = sprintf(
+						__("Value must be a decimal.", "atlas-content-modeler"),
+						event.target.max.toString()
+					);
+				}
+			}
+
 			if (event.target.validity.rangeOverflow) {
 				error = sprintf(
 					__("Maximum value is %s.", "atlas-content-modeler"),

--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -31,18 +31,20 @@ export default function Field(props) {
 
 		if (field.type === "number") {
 			if (!integerRegex.test(event.target.value)) {
-				error = sprintf(
-					__("Value must be an integer.", "atlas-content-modeler"),
-					event.target.max.toString()
-				);
+				(error = __(
+					"Value must be an integer.",
+					"atlas-content-modeler"
+				)),
+					event.target.max.toString();
 			}
 
 			if (field.numberType === "decimal") {
 				if (!decimalRegex.test(event.target.value)) {
-					error = sprintf(
-						__("Value must be a decimal.", "atlas-content-modeler"),
-						event.target.max.toString()
-					);
+					(error = __(
+						"Value must be a decimal.",
+						"atlas-content-modeler"
+					)),
+						event.target.max.toString();
 				}
 			}
 

--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -31,20 +31,18 @@ export default function Field(props) {
 
 		if (field.type === "number") {
 			if (!integerRegex.test(event.target.value)) {
-				(error = __(
+				error = __(
 					"Value must be an integer.",
 					"atlas-content-modeler"
-				)),
-					event.target.max.toString();
+				);
 			}
 
 			if (field.numberType === "decimal") {
 				if (!decimalRegex.test(event.target.value)) {
-					(error = __(
+					error = __(
 						"Value must be a decimal.",
 						"atlas-content-modeler"
-					)),
-						event.target.max.toString();
+					);
 				}
 			}
 


### PR DESCRIPTION
## Description

This PR is specific to the `integer` and `decimal` type inputs. These inputs have a different user experience based on what browser was being used. For instance, on Chrome the user was unable to enter data that was not a true integer into the `integer` type input. Whereas on browsers such as Safari and Firefox, the user was able to enter data that was not a, integer and attempt to submit the form. This alluded to some confusion for the end-user particularly when entering a number with a comma.

This PR should better propagate validation messages for the end-user so that they know what they need to do to fix the form for publishing.

https://wpengine.atlassian.net/browse/MTKA-1431

## Testing

To test you can create a model with the following inputs : 
- Integer
- Integer that is repeatable
- Decimal
- Decimal that is repeatable

From any browser, particularly Safari/Firefox, attempt to enter data that is not an integer or decimal and submit the form. You should get better validation messaging telling you to correct the problem for each input. (See screenshot for example).

Here are two links that represent the regex that tests the input fields for valid inputs :
- Integer - https://regexr.com/6h5h8
- Decimal - https://regexr.com/6h5gs


## Screenshots

<img width="1098" alt="Screen Shot 2022-03-10 at 4 43 06 PM" src="https://user-images.githubusercontent.com/62450648/157936714-94a18c61-1185-47ff-a498-cf04dba86d0b.png">

