### PR TITLE
Fix issue where fatal errors happen on leading number model names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The delete model prompt no longer shows “undefined” in its title during model deletion.
 - Improved checkbox styling in field settings.
 - Options buttons now use the mouse pointer cursor.
+- Fixed issue where it was possible to improperly lead a model ID with a number.
 
 ## 0.14.0 - 2022-02-10
 ### Added

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -260,7 +260,6 @@ export default function CreateContentModel() {
 							ref={register({ required: true, maxLength: 20 })}
 							onChange={(event) => {
 								onChangeGeneratedValue(event.target.value);
-								toValidApiId(event.target.value);
 							}}
 						/>
 						<p className="field-messages">

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -5,7 +5,7 @@ import { useHistory } from "react-router-dom";
 import { ModelsContext } from "../ModelsContext";
 import { insertSidebarMenuItem } from "../utils";
 import { useInputGenerator } from "../hooks";
-import { toSanitizedKey } from "../formats";
+import { toSanitizedKey, toValidApiId } from "../formats";
 import { showSuccess } from "../toasts";
 import Icon from "../../../../components/icons";
 import IconPicker from "./IconPicker";
@@ -43,7 +43,7 @@ export default function CreateContentModel() {
 		onChangeGeneratedValue,
 	} = useInputGenerator({
 		setGeneratedValue: (value) => setValue("slug", value),
-		format: toSanitizedKey,
+		format: toValidApiId,
 	});
 
 	function apiCreateModel(data) {
@@ -140,6 +140,7 @@ export default function CreateContentModel() {
 							onChange={(e) => {
 								setInputGeneratorSourceValue(e.target.value);
 								setSingularCount(e.target.value.length);
+								toValidApiId(e.target.value);
 							}}
 						/>
 						<p className="field-messages">
@@ -200,6 +201,7 @@ export default function CreateContentModel() {
 							ref={register({ required: true, maxLength: 50 })}
 							onChange={(event) => {
 								setPluralCount(event.target.value.length);
+								toValidApiId(event.target.value);
 							}}
 						/>
 						<p className="field-messages">
@@ -247,7 +249,7 @@ export default function CreateContentModel() {
 						<br />
 						<p className="help">
 							{__(
-								"Auto-generated and used internally for WordPress to identify the model.",
+								"Auto-generated and used internally for WordPress to identify the model. Leading a model ID with numbers is not supported.",
 								"atlas-content-modeler"
 							)}
 						</p>
@@ -256,9 +258,10 @@ export default function CreateContentModel() {
 							name="slug"
 							className="w-100"
 							ref={register({ required: true, maxLength: 20 })}
-							onChange={(e) =>
-								onChangeGeneratedValue(e.target.value)
-							}
+							onChange={(event) => {
+								onChangeGeneratedValue(event.target.value);
+								toValidApiId(event.target.value);
+							}}
 						/>
 						<p className="field-messages">
 							{errors.slug && errors.slug.type === "required" && (


### PR DESCRIPTION
This PR uses the toValidApiId format for generating a slug. Previously using a leading number in a slug name would cause fatal errors on the site. toValidAPiId factors in this limitation.