### PR TITLE
MTKA-1426 adds errors for numerical first letter characters in slug, plural, and singular model ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improved checkbox styling in field settings.
 - Options buttons now use the mouse pointer cursor.
 - The `wp acm blueprint import` command no longer reports “Could not read an acm.json file” if the blueprint zip file was renamed after creation.
+- Fixed issue where it was possible to improperly lead a model ID with a number.
 
 ## 0.14.0 - 2022-02-10
 ### Added

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -60,6 +60,30 @@ function create_model( string $post_type_slug, array $args ) {
 		);
 	}
 
+	if ( is_numeric( substr( $args['singular'], 0, 1 ) ) ) {
+		return new WP_Error(
+			'acm_singular_leading_number',
+			esc_html__( 'The singular name cannot lead with a number.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	if ( is_numeric( substr( $args['plural'], 0, 1 ) ) ) {
+		return new WP_Error(
+			'acm_plural_leading_number',
+			esc_html__( 'The plural name cannot lead with a number.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	if ( is_numeric( substr( $args['slug'], 0, 1 ) ) ) {
+		return new WP_Error(
+			'acm_slug_leading_number',
+			esc_html__( 'The identifier cannot lead with a number.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
+		);
+	}
+
 	$content_types[ $args['slug'] ] = $args;
 	$created                        = update_registered_content_types( $content_types );
 

--- a/includes/settings/js/src/components/CreateContentModel.jsx
+++ b/includes/settings/js/src/components/CreateContentModel.jsx
@@ -101,6 +101,24 @@ export default function CreateContentModel() {
 						message: err.message,
 					});
 				}
+				if (err.code === "acm_singular_leading_number") {
+					setError("singular", {
+						type: "leadingNumber",
+						message: err.message,
+					});
+				}
+				if (err.code === "acm_plural_leading_number") {
+					setError("plural", {
+						type: "leadingNumber",
+						message: err.message,
+					});
+				}
+				if (err.code === "acm_slug_leading_number") {
+					setError("slug", {
+						type: "leadingNumber",
+						message: err.message,
+					});
+				}
 			});
 	}
 
@@ -176,6 +194,15 @@ export default function CreateContentModel() {
 										</span>
 									</span>
 								)}
+							{errors.singular &&
+								errors.singular.type === "leadingNumber" && (
+									<span className="error">
+										<Icon type="error" />
+										<span role="alert">
+											{errors.singular.message}
+										</span>
+									</span>
+								)}
 							<span>&nbsp;</span>
 							<span className="count">{singularCount}/50</span>
 						</p>
@@ -235,6 +262,15 @@ export default function CreateContentModel() {
 									</span>
 								</span>
 							)}
+							{errors.plural &&
+								errors.plural.type === "leadingNumber" && (
+									<span className="error">
+										<Icon type="error" />
+										<span role="alert">
+											{errors.plural.message}
+										</span>
+									</span>
+								)}
 							<span>&nbsp;</span>
 							<span className="count">{pluralCount}/50</span>
 						</p>
@@ -291,6 +327,15 @@ export default function CreateContentModel() {
 									</span>
 								</span>
 							)}
+							{errors.slug &&
+								errors.slug.type === "leadingNumber" && (
+									<span className="error">
+										<Icon type="error" />
+										<span role="alert">
+											{errors.slug.message}
+										</span>
+									</span>
+								)}
 							<span>&nbsp;</span>
 						</p>
 					</div>

--- a/tests/acceptance/CreateContentModelCest.php
+++ b/tests/acceptance/CreateContentModelCest.php
@@ -63,6 +63,8 @@ class CreateContentModelCest {
 		$i->fillField( [ 'name' => 'singular' ], 'threeobject' );
 		$i->fillField( [ 'name' => 'plural' ], '3dobjects' ); // Leading plural with a number is not supported and can fatal error a site.
 		$i->fillField( [ 'name' => 'slug' ], 'threeobject' );
+		$i->click( 'button[data-testid="create-model-button"]' );
+		$i->wait( 1 );
 
 		$i->see( 'The plural name cannot lead with a number', '.card-content' );
 	}

--- a/tests/acceptance/CreateContentModelCest.php
+++ b/tests/acceptance/CreateContentModelCest.php
@@ -47,6 +47,27 @@ class CreateContentModelCest {
 		$i->see( 'singular name is in use', '.card-content' );
 	}
 
+	public function i_see_a_warning_if_the_model_names_lead_with_numbers( AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$i->amOnWPEngineCreateContentModelPage();
+		$i->wait( 1 );
+
+		$i->fillField( [ 'name' => 'singular' ], '3dobject' ); // Leading singular with a number is not supported and can fatal error a site.
+		$i->fillField( [ 'name' => 'plural' ], '3dobjects' );
+		$i->fillField( [ 'name' => 'slug' ], 'threeobject' );
+		$i->click( 'button[data-testid="create-model-button"]' );
+		$i->wait( 1 );
+
+		$i->see( 'The singular name cannot lead with a number', '.card-content' );
+
+		$i->fillField( [ 'name' => 'singular' ], 'threeobject' );
+		$i->fillField( [ 'name' => 'plural' ], '3dobjects' ); // Leading plural with a number is not supported and can fatal error a site.
+		$i->fillField( [ 'name' => 'slug' ], 'threeobject' );
+
+		$i->see( 'The plural name cannot lead with a number', '.card-content' );
+	}
+
+
 	public function i_see_a_warning_if_the_model_plural_name_is_reserved( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
 		$i->amOnWPEngineCreateContentModelPage();


### PR DESCRIPTION
## Description
@bhardie had the idea of validating leading characters the same way we do it with validating that a model name exists or is empty. This is consistent with our error handling and also prevents the fatal errors introduced when creating a model with a leading numerical character. 