### PR TITLE
MTKA-1452: Let models override with_front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 - Rich Text fields have a new “make repeatable” option. Enable it on new fields to let publishers enter multiple rows of rich text content.
+- Added a “Use Permalink Base” option on the edit model screen to set the WordPress `with_front` setting (true by default). Untick this to tell WordPress not to prefix your model entry URLs with custom prefixes from your WordPress permalink settings. For example, a site with a permalink structure of `/posts/%postname%/` will have post URLs of `/posts/your-acm-model-name/your-post/` by default. Edit your model and untick “Use Permalink Base” if you prefer a URL structure of `/your-acm-model-name/your-post/`.
 - `wp acm blueprint export` now accepts a `--wp-options` flag to export a comma-separated list of WordPress options from the `wp_options` table. No options are exported by default. Example: `wp acm blueprint export --wp-options='blogname, permalink_structure`
 - `wp acm blueprint import` now updates WordPress options if blueprints contain a `wp-options` key with a list of options values, keyed by option name.
 

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -409,6 +409,12 @@ function update_registered_content_types( array $args ): bool {
 	$updated = update_option( 'atlas_content_modeler_post_types', $args );
 
 	if ( $updated ) {
+		/**
+		 * Re-register post types so that rewrite rules adapt to any changes to
+		 * models' with_front properties.
+		 */
+		register_content_types();
+
 		flush_rewrite_rules( false );
 	}
 

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -345,6 +345,9 @@ function generate_custom_post_type_args( array $args ): array {
 		'graphql_plural_name'   => $args['graphql_plural_name'] ?? camelcase( $plural ),
 		'menu_icon'             => ! empty( $args['model_icon'] ) ? $args['model_icon'] : 'dashicons-admin-post',
 		'rest_controller_class' => __NAMESPACE__ . '\REST_Posts_Controller',
+		'rewrite'               => [
+			'with_front' => $args['with_front'] ?? true,
+		],
 	];
 
 	if ( ! empty( $args['api_visibility'] ) && 'private' === $args['api_visibility'] ) {

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -258,6 +258,11 @@ function update_model( string $post_type_slug, array $args ) {
 		);
 	}
 
+	// Sets “Use Permalink Base” checkbox if unticked, otherwise the unticked value is undefined.
+	if ( empty( $args['with_front'] ) ) {
+		$args['with_front'] = 0;
+	}
+
 	$new_args = wp_parse_args( $args, $content_types[ $post_type_slug ] );
 
 	// Updating the slug is unsupported.

--- a/includes/settings/js/src/components/EditModelModal.jsx
+++ b/includes/settings/js/src/components/EditModelModal.jsx
@@ -376,7 +376,7 @@ export function EditModelModal({ model, isOpen, setIsOpen }) {
 						<label htmlFor="with_front">Use Permalink Base</label>
 						<p className="help">
 							{__(
-								"Post URLs will include prefixes in Settings → Permalinks if this is ticked. (Sets “with_front”.)",
+								"Post URLs will include prefixes from Settings → Permalinks if this is ticked. (Sets “with_front”.)",
 								"atlas-content-modeler"
 							)}
 						</p>

--- a/includes/settings/js/src/components/EditModelModal.jsx
+++ b/includes/settings/js/src/components/EditModelModal.jsx
@@ -347,23 +347,59 @@ export function EditModelModal({ model, isOpen, setIsOpen }) {
 					</div>
 				</div>
 
-				<div className="field">
-					<label htmlFor="model_icon">
-						{__("Model Icon", "atlas-content-modeler")}
-					</label>
-					<p className="help">
-						{__(
-							"Choose an icon to represent your model.",
-							"atlas-content-modeler"
-						)}
-					</p>
+				<div className="row">
+					<div className="field col-sm">
+						<label htmlFor="model_icon">
+							{__("Model Icon", "atlas-content-modeler")}
+						</label>
+						<p className="help">
+							{__(
+								"Choose an icon to represent your model.",
+								"atlas-content-modeler"
+							)}
+						</p>
 
-					<IconPicker
-						setValue={setValue}
-						buttonClasses="primary first"
-						register={register}
-						modelIcon={model.model_icon}
-					/>
+						<IconPicker
+							setValue={setValue}
+							buttonClasses="primary first"
+							register={register}
+							modelIcon={model.model_icon}
+						/>
+					</div>
+					<div
+						className={
+							errors.with_front
+								? "field has-error form-check form-check-inline col-sm"
+								: "field form-check form-check-inline col-sm"
+						}
+					>
+						<label htmlFor="with_front">Use Permalink Base</label>
+						<p className="help">
+							{__(
+								"Post URLs will include prefixes in Settings → Permalinks if this is ticked. (Sets “with_front”.)",
+								"atlas-content-modeler"
+							)}
+						</p>
+
+						<input
+							name="with_front"
+							id="with_front"
+							type="checkbox"
+							value="1"
+							ref={register}
+							defaultChecked={model?.with_front ?? true}
+						/>
+
+						<label
+							htmlFor="with_front"
+							className="form-check-label"
+						>
+							{__(
+								"Use front permalink base",
+								"atlas-content-modeler"
+							)}
+						</label>
+					</div>
 				</div>
 
 				<div

--- a/includes/settings/scss/_model-list.scss
+++ b/includes/settings/scss/_model-list.scss
@@ -112,7 +112,8 @@
 			max-width: 500px;
 		}
 
-		input[type="radio"] {
+		input[type="radio"],
+		input[type="checkbox"] {
 			width: 1rem;
 		}
 	}

--- a/tests/acceptance/EditContentModelCest.php
+++ b/tests/acceptance/EditContentModelCest.php
@@ -24,6 +24,7 @@ class EditContentModelCest {
 		$i->fillField( [ 'name' => 'plural' ], 'Cats' );
 		$i->fillField( [ 'name' => 'description' ], 'Cats are better than candy.' );
 		$i->see( '27/250', 'span.count' );
+		$i->uncheckOption( [ 'name' => 'with_front' ] );
 
 		// Change the model's icon.
 		$i->click( '.dashicons-picker' );
@@ -44,6 +45,13 @@ class EditContentModelCest {
 		// Check the label in the WP admin sidebar was updated without refreshing the page.
 		$menu_label = $i->grabTextFrom( '#menu-posts-candy .wp-menu-name' );
 		$i->assertEquals( 'Cats', $menu_label );
+
+		// Check updated data persists in the edit modal when reopened.
+		$i->click( '.model-list button.options' );
+		$i->click( '.dropdown-content a.edit' );
+		$i->dontSeeCheckboxIsChecked( [ 'name' => 'with_front' ] );
+		$i->seeInField( [ 'name' => 'singular' ], 'Cat' );
+		$i->seeInField( [ 'name' => 'plural' ], 'Cats' );
 	}
 
 	public function i_see_a_warning_if_the_model_singular_name_is_reserved( AcceptanceTester $i ) {

--- a/tests/integration/api-validation/test-data/models.php
+++ b/tests/integration/api-validation/test-data/models.php
@@ -38,6 +38,7 @@ return array(
 		'api_visibility'  => 'public',
 		'model_icon'      => 'dashicons-admin-post',
 		'description'     => 'A public content model with fields',
+		'with_front'      => false,
 		'fields'          => get_test_fields(),
 	),
 	'private-fields' => array(

--- a/tests/integration/api-validation/test-rest-model-endpoints.php
+++ b/tests/integration/api-validation/test-rest-model-endpoints.php
@@ -45,11 +45,13 @@ class RestModelEndpointTests extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
+		global $wp_post_types;
+		global $wp_rest_server;
 		parent::tear_down();
 		wp_set_current_user( null );
-		global $wp_rest_server;
 		$wp_rest_server = null;
 		$this->server   = null;
+		$wp_post_types  = null;
 		delete_option( 'atlas_content_modeler_post_types' );
 	}
 

--- a/tests/integration/api-validation/test-rest-models-endpoints.php
+++ b/tests/integration/api-validation/test-rest-models-endpoints.php
@@ -44,11 +44,13 @@ class RestModelsEndpointTests extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
+		global $wp_post_types;
+		global $wp_rest_server;
 		parent::tear_down();
 		wp_set_current_user( null );
-		global $wp_rest_server;
 		$wp_rest_server = null;
 		$this->server   = null;
+		$wp_post_types  = null;
 		delete_option( 'atlas_content_modeler_post_types' );
 	}
 

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -17,8 +17,10 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 
 	private $models;
 	private $all_registered_post_types;
+	private $original_wp_rewrite;
 
 	public function set_up() {
+		global $wp_rewrite;
 		parent::set_up();
 
 		/**
@@ -40,14 +42,17 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 
 		$this->all_registered_post_types = get_post_types( [], 'objects' );
 
-		$this->post_ids = $this->get_post_ids();
+		$this->post_ids            = $this->get_post_ids();
+		$this->original_wp_rewrite = $wp_rewrite;
 	}
 
 	public function tear_down() {
+		global $wp_rewrite;
 		parent::tear_down();
 		wp_set_current_user( null );
 		delete_option( 'atlas_content_modeler_post_types' );
 		$this->all_registered_post_types = null;
+		$wp_rewrite                      = $this->original_wp_rewrite;
 	}
 
 	private function get_models() {
@@ -182,4 +187,5 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 
 		update_registered_content_types( [] );
 	}
+
 }

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -127,6 +127,7 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 		$expected_args  = $this->all_registered_post_types['public'];
 		self::assertSame( $generated_args['name'], $expected_args->label );
 		self::assertSame( $generated_args['menu_icon'], $expected_args->menu_icon );
+		self::assertSame( $generated_args['rewrite']['with_front'], $expected_args->rewrite['with_front'] );
 
 		$generated_args = generate_custom_post_type_args(
 			array(

--- a/tests/integration/publisher/test-permalinks.php
+++ b/tests/integration/publisher/test-permalinks.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Tests Content Creation.
+ *
+ * @package AtlasContentModeler
+ */
+
+use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
+
+/**
+ * Class TestPermalinks
+ */
+class TestPermalinks extends WP_UnitTestCase {
+
+	private $post_ids;
+
+	public function set_up() {
+		global $wp_rewrite;
+
+		parent::set_up();
+
+		$wp_rewrite->init();
+		$wp_rewrite->set_permalink_structure( '/posts/%postname%/' );
+
+		/**
+		 * Reset the WPGraphQL schema before each test.
+		 * Lazy loading types only loads part of the schema,
+		 * so we refresh for each test.
+		 */
+		WPGraphQL::clear_schema();
+
+		// Start each test with a fresh relationships registry.
+		\WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->setup();
+
+		update_registered_content_types( $this->get_models() );
+
+		do_action( 'init' );
+
+		$this->post_ids = $this->get_post_ids();
+	}
+
+	private function get_models() {
+		return include dirname( __DIR__ ) . '/api-validation/test-data/models.php';
+	}
+
+	private function get_post_ids() {
+		include_once dirname( __DIR__ ) . '/api-validation/test-data/posts.php';
+
+		return create_test_posts( $this );
+	}
+
+	/**
+	 * Ensures ACM post URLs use the '/posts/' prefix from our custom permalink
+	 * structure in set_up() by default (if they have not specified with_front).
+	 */
+	public function test_with_front_is_used_by_default(): void {
+		$permalink = get_permalink( $this->post_ids['public_post_id'] );
+
+		$this->assertContains( '/posts/', $permalink );
+	}
+
+	/**
+	 * Ensures an ACM post whose model has with_front set to false will not use
+	 * the '/posts/' prefix from our custom permalink structure in set_up() in
+	 * its URL.
+	 */
+	public function test_with_front_is_not_used_if_disabled(): void {
+		$permalink = get_permalink( $this->post_ids['public_fields_post_id'] );
+
+		$this->assertNotContains( '/posts/', $permalink );
+	}
+}

--- a/tests/integration/publisher/test-permalinks.php
+++ b/tests/integration/publisher/test-permalinks.php
@@ -14,10 +14,10 @@ class TestPermalinks extends WP_UnitTestCase {
 
 	private $post_ids;
 
-	public function set_up() {
-		$this->set_permalink_structure( '/posts/%postname%/' );
+	public function setUp() {
+		parent::setUp();
 
-		parent::set_up();
+		$this->set_permalink_structure( '/posts/%postname%/' );
 
 		/**
 		 * Reset the WPGraphQL schema before each test.

--- a/tests/integration/publisher/test-permalinks.php
+++ b/tests/integration/publisher/test-permalinks.php
@@ -14,10 +14,10 @@ class TestPermalinks extends WP_UnitTestCase {
 
 	private $post_ids;
 
-	public function setUp() {
-		parent::setUp();
-
+	public function set_up() {
 		$this->set_permalink_structure( '/posts/%postname%/' );
+
+		parent::set_up();
 
 		/**
 		 * Reset the WPGraphQL schema before each test.

--- a/tests/integration/publisher/test-permalinks.php
+++ b/tests/integration/publisher/test-permalinks.php
@@ -19,9 +19,6 @@ class TestPermalinks extends WP_UnitTestCase {
 
 		parent::set_up();
 
-		$wp_rewrite->init();
-		$wp_rewrite->set_permalink_structure( '/posts/%postname%/' );
-
 		/**
 		 * Reset the WPGraphQL schema before each test.
 		 * Lazy loading types only loads part of the schema,
@@ -33,6 +30,9 @@ class TestPermalinks extends WP_UnitTestCase {
 		\WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->setup();
 
 		update_registered_content_types( $this->get_models() );
+
+		$wp_rewrite->init();
+		$wp_rewrite->set_permalink_structure( '/posts/%postname%/' );
 
 		do_action( 'init' );
 

--- a/tests/integration/publisher/test-permalinks.php
+++ b/tests/integration/publisher/test-permalinks.php
@@ -15,9 +15,9 @@ class TestPermalinks extends WP_UnitTestCase {
 	private $post_ids;
 
 	public function set_up() {
-		$this->set_permalink_structure( '/posts/%postname%/' );
-
 		parent::set_up();
+
+		$this->set_permalink_structure( '/posts/%postname%/' );
 
 		/**
 		 * Reset the WPGraphQL schema before each test.

--- a/tests/integration/publisher/test-permalinks.php
+++ b/tests/integration/publisher/test-permalinks.php
@@ -15,8 +15,6 @@ class TestPermalinks extends WP_UnitTestCase {
 	private $post_ids;
 
 	public function set_up() {
-		global $wp_rewrite;
-
 		parent::set_up();
 
 		/**
@@ -31,8 +29,7 @@ class TestPermalinks extends WP_UnitTestCase {
 
 		update_registered_content_types( $this->get_models() );
 
-		$wp_rewrite->init();
-		$wp_rewrite->set_permalink_structure( '/posts/%postname%/' );
+		$this->set_permalink_structure( '/posts/%postname%/' );
 
 		do_action( 'init' );
 

--- a/tests/integration/publisher/test-permalinks.php
+++ b/tests/integration/publisher/test-permalinks.php
@@ -15,6 +15,8 @@ class TestPermalinks extends WP_UnitTestCase {
 	private $post_ids;
 
 	public function set_up() {
+		$this->set_permalink_structure( '/posts/%postname%/' );
+
 		parent::set_up();
 
 		/**
@@ -28,8 +30,6 @@ class TestPermalinks extends WP_UnitTestCase {
 		\WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->setup();
 
 		update_registered_content_types( $this->get_models() );
-
-		$this->set_permalink_structure( '/posts/%postname%/' );
 
 		do_action( 'init' );
 


### PR DESCRIPTION
## Description

Addresses #457 by adding a “Use Permalink Base” option on the model edit screen to override the with_front setting when registering the model's post type.

https://wpengine.atlassian.net/browse/MTKA-1452

## Details / Context

WordPress registers post types with `'rewrite' => [ 'with_front' => true ]` by default.

This means a site using a custom permalink structure of `/posts/%postname%/` sees their ACM post URLs prefixed by `/posts/`: `/posts/your-acm-model-name/your-post/`.

A user can now untick “Use Permalink Base” if they want `/posts/%postname%/` for regular WP posts, but prefer ACM posts to appear at `/your-acm-model-name/your-post/` (without the `/posts/` prefix).

The PR handles this in a way that does not change behavior for existing models (they will continue to use `with_front` unless a user overrides them by editing the model).

This also does not change the default behavior for new models (new models have empty `with_front`, but custom post type registration logic sets it to true if `with_front` is absent). This is consistent with original behavior and WP defaults.

I chose not to add the field to the "create new model" form, as it's not something a user will need to set or change often, and it reduces the size of the create new model form. (i.e. You can only access the setting when editing a model, not when creating one.) Happy to add it there too if desired, though.

## Testing

Includes e2e tests to check field interactivity and unit tests to check `with_front` applies.

### To test manually

1. Set Permalinks to this custom structure at Settings → Permalinks: `/posts/%postname%/`
2. Create a new model with one field and at least one entry.
3. Run a GraphQL query, being sure to include `uri` as one of the field properties (see screenshots below). The uri in the query response should include the `/posts/` prefix by default.
4. Edit the model and untick the new `“Use Permalink Base”` option.
5. Re-run the query. `/posts/` should no longer appear in the uri.

## Screenshots

<img width="916" alt="Screenshot 2022-03-22 at 18 03 11" src="https://user-images.githubusercontent.com/647669/159535366-e78b6973-9d0d-4e78-82db-14b568994536.png">

<img width="545" alt="Screenshot 2022-03-22 at 18 00 37" src="https://user-images.githubusercontent.com/647669/159534893-802d69a0-ba71-4b24-9914-c9bf465329fc.png">

<img width="765" alt="Screenshot 2022-03-22 at 18 02 24" src="https://user-images.githubusercontent.com/647669/159535292-33f22508-5b0f-431f-9f20-07a2f204b15a.png">

<img width="550" alt="Screenshot 2022-03-22 at 18 03 41" src="https://user-images.githubusercontent.com/647669/159535618-39683f3a-c32f-419d-8286-2f616d2cad85.png">

<img width="921" alt="Screenshot 2022-03-22 at 18 04 12" src="https://user-images.githubusercontent.com/647669/159535629-3ae2f4ce-4e8c-4f9c-96b6-e5a4ef721971.png">

## Documentation Changes

n/a

## Dependant PRs

n/a