### PR TITLE
[NOJIRA] chore: update browserslist caniuse-lite dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5419,13 +5419,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001258",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001319",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
+      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -19392,9 +19398,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001258",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA=="
+      "version": "1.0.30001319",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
+      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
## Description
This PR updates the browserslist caniuse-lite database. Why?
> This update will bring data about new browsers to polyfills tools like Autoprefixer or Babel and reduce already unnecessary polyfills.

> You need to do it regularly for three reasons:

> 1. To use the latest browser’s versions and statistics in queries like last 2 versions or >1%. For example, if you created your project 2 years ago and did not update your dependencies, last 1 version will return 2 year old browsers.
> 2. Actual browsers data will lead to using less polyfills. It will reduce size of JS and CSS files and improve website performance.
> 3. caniuse-lite deduplication: to synchronize version in different tools.

Source: https://github.com/browserslist/browserslist#browsers-data-updating



When running `npm start` or `npm run build`, the following message is shown in the console:
```
console: Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
```

Running the command above gives us this output:
```
Latest version:     1.0.30001319
Installed version:  1.0.30001258
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ npm install caniuse-lite
Cleaning package.json dependencies from caniuse-lite
$ npm uninstall caniuse-lite
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 93
+ and_chr 99
- and_ff 92
+ and_ff 96
- chrome 92
- chrome 91
- chrome 90
- chrome 87
- chrome 85
+ chrome 98
+ chrome 97
+ chrome 96
+ chrome 93
+ chrome 79
- edge 92
+ edge 98
+ edge 97
- firefox 91
- firefox 90
+ firefox 97
+ firefox 96
- ios_saf 14.5-14.7
+ ios_saf 15.2-15.3
+ ios_saf 15.0-15.1
+ ios_saf 14.5-14.8
+ ios_saf 12.2-12.5
- opera 78
- opera 77
+ opera 83
+ opera 82
+ safari 15.2-15.3
+ safari 15.1
- samsung 14.0
+ samsung 16.0
```

## Testing
Automated tests should continue to pass.
