### PR TITLE
MTKA-1408: Stop admin notices overlaying the Screen Options button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Options buttons now use the mouse pointer cursor.
 - The `wp acm blueprint import` command no longer reports “Could not read an acm.json file” if the blueprint zip file was renamed after creation.
 - Fixed issue where it was possible to improperly lead a model ID with a number.
+- WordPress admin notices no longer overlay the Screen Options button on ACM entry pages.
 
 ## 0.14.0 - 2022-02-10
 ### Added

--- a/includes/settings/scss/_base.scss
+++ b/includes/settings/scss/_base.scss
@@ -7,6 +7,13 @@ body.toplevel_page_atlas-content-modeler {
 	font-weight: 400;
 }
 
+@media screen and (min-width: 782px) {
+	.post-php .notice:first-of-type,
+	.post-new-php .notice:first-of-type {
+		margin-top: 30px;
+	}
+}
+
 .toplevel_page_atlas-content-modeler #wpcontent {
 	padding-left: 0;
 }


### PR DESCRIPTION
## Description

Moves admin notices down so they don't overlay the Screen Options button.

https://wpengine.atlassian.net/browse/MTKA-1408

## Testing

I wasn't able to write an e2e test for this due to admin notices that sometimes appear in our testing environment (“a WordPress update is available”) that aren't dismissible. These give false-positive test results for checks that the “post updated” notice appears below the Screen Options button, making tests unreliable.

We discussed this in standup and decided that it's ok to omit the e2e test here because regressions would have low impact.

### To test manually

Publish any ACM post. Check that the notice appears below the screen options button.

If you closed the ACM feedback banner and want to restore it, use this WP-CLI command:

`wp user meta delete [your-username] acm_hide_feedback_banner`

## Screenshots

| Before | After |
|-|-|
| <img width="1386" alt="Screenshot 2022-03-24 at 11 54 39" src="https://user-images.githubusercontent.com/647669/159901794-b8bf0b55-af87-4ce1-86fc-6591477f935f.png"> | <img width="1375" alt="Screenshot 2022-03-24 at 11 54 22" src="https://user-images.githubusercontent.com/647669/159901840-abb67c49-be9b-450d-bdce-d19dea3ea108.png"> |

Other examples (after):

<img width="1387" alt="Screenshot 2022-03-24 at 11 55 09" src="https://user-images.githubusercontent.com/647669/159901891-fb19ebe8-0c92-45cd-9609-78d5dc2d2323.png">

<img width="1378" alt="Screenshot 2022-03-24 at 11 55 48" src="https://user-images.githubusercontent.com/647669/159901899-7d561d47-490e-49c2-bd4d-38ee791ab6a2.png">

## Documentation Changes

n/a

## Dependant PRs

n/a