### PR TITLE
MTKA-1435: Add email validation with test

### DIFF
--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -79,6 +79,16 @@ export default function Field(props) {
 			}
 		}
 
+		if (field.type === "email") {
+			if (!event.target.validity.valid) {
+				error = __("Value must be an email.", "atlas-content-modeler");
+			}
+
+			if (field?.required && event.target.value.trim() === "") {
+				error = defaultError;
+			}
+		}
+
 		setErrors({ ...errors, [field.slug]: error });
 	}
 

--- a/includes/publisher/lib/field-functions.php
+++ b/includes/publisher/lib/field-functions.php
@@ -246,6 +246,8 @@ function sanitize_field( string $type, $value ) {
 			}
 			$options_object[] = $value;
 			return $options_object;
+		case 'email':
+			return filter_var( $value, FILTER_SANITIZE_EMAIL );
 		default:
 			return $value;
 	}

--- a/tests/acceptance/PublishModelCest.php
+++ b/tests/acceptance/PublishModelCest.php
@@ -189,7 +189,16 @@ class PublishModelCest {
 		$i->see( 'This field is required' );
 		$i->wait( 1 );
 
-		$i->seeInField( 'atlas-content-modeler[goose][email]', '' );
+		$i->fillField( [ 'name' => 'atlas-content-modeler[goose][email]' ], 'email' );
+		$i->scrollTo( '#submitdiv' );
+
+		$i->click( 'Publish', '#publishing-action' );
+		$i->wait( 2 );
+
+		$i->see( 'Value must be an email.' );
+		$i->wait( 1 );
+
+		$i->seeInField( 'atlas-content-modeler[goose][email]', 'email' );
 	}
 
 	public function i_can_publish_a_model_entry( AcceptanceTester $i ) {


### PR DESCRIPTION
## Description

Add email input validation.

https://wpengine.atlassian.net/browse/MTKA-1435

## Testing

1. Create new model with email input type
2. Attempt to publish email type with bad input data, such as : `test@`
3. View validation error messages and fix issues
4. Attempt to publish after fixing email input to a valid email address. (`test@example`)

## Screenshots
<img width="929" alt="Screen Shot 2022-03-28 at 11 14 48 AM" src="https://user-images.githubusercontent.com/62450648/160442596-347ce2cd-0db0-491a-8e9a-19aae3a6c384.png">
<img width="927" alt="Screen Shot 2022-03-28 at 11 15 01 AM" src="https://user-images.githubusercontent.com/62450648/160442618-b7749c4a-e147-4b80-972f-d3acf4934abf.png">
<img width="927" alt="Screen Shot 2022-03-28 at 11 16 05 AM" src="https://user-images.githubusercontent.com/62450648/160442627-682b0be1-7b1c-42d6-a4f0-08fb3924a252.png">

