### PR TITLE
Save post title data to wp_posts table

### DIFF
--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -88,4 +88,20 @@ class TestContentCreation extends WP_UnitTestCase {
 
 		$this->assertStringStartsWith( 'entry', $post->post_title );
 	}
+
+	public function test_post_title_synced_from_postmeta_table_to_posts_table(): void {
+		$meta_title = 'This is a title from meta that should be synced to the posts table';
+
+		$post_id = wp_insert_post(
+			[
+				'post_title'  => 'moo',
+				'post_name'   => 'moo',
+				'post_status' => 'publish',
+				'post_type'   => 'public-fields',
+			]
+		);
+
+		update_post_meta( $post_id, 'singleLineRequired', $meta_title ); // singleLineRequired is configured as a title field.
+		self::assertSame( get_post_field( 'post_title', $post_id ), $meta_title );
+	}
 }

--- a/tests/integration/publisher/test-publisher-callbacks.php
+++ b/tests/integration/publisher/test-publisher-callbacks.php
@@ -31,6 +31,8 @@ class PublisherCallbacksTestCases extends WP_UnitTestCase {
 		self::assertSame( 10, has_action( 'do_meta_boxes', [ $this->class, 'move_meta_boxes' ] ) );
 		self::assertSame( 10, has_action( 'do_meta_boxes', [ $this->class, 'remove_thumbnail_meta_box' ] ) );
 		self::assertSame( 10, has_action( 'transition_post_status', [ $this->class, 'maybe_add_location_callback' ] ) );
+		self::assertSame( 10, has_action( 'added_post_meta', [ $this->class, 'sync_title_field_to_posts_table' ] ) );
+		self::assertSame( 10, has_action( 'updated_postmeta', [ $this->class, 'sync_title_field_to_posts_table' ] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Saves post title data to `wp_posts` table when a title field is saved to `wp_postmeta`.

More title work coming in other PRs.

https://wpengine.atlassian.net/browse/MTKA-1370

## Testing
- Add a model with a Text field configured to be the Title Field
- Add a new post entry
- Confirm that the values you enter into the Text field are saved to the post_title field of the new post. (postmeta is left as is for now)
- Update post, confirm update is saved to post_title field.

