### PR TITLE
MTKA-1438: Add email type as string to graphql

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -760,6 +760,7 @@ function map_html_field_type_to_graphql_field_type( string $field_type ): ?strin
 		case 'string':
 		case 'date':
 		case 'richtext':
+		case 'email':
 			return 'String';
 		case 'multipleChoice':
 			return 'list';

--- a/tests/integration/api-validation/test-data/fields.php
+++ b/tests/integration/api-validation/test-data/fields.php
@@ -411,5 +411,18 @@ function get_test_fields() {
 			'minChars'         => '',
 			'maxChars'         => '',
 		),
+		'1648828035'    => array(
+			'show_in_rest'     => true,
+			'show_in_graphql'  => true,
+			'type'             => 'email',
+			'id'               => '1648828035',
+			'position'         => '400000',
+			'name'             => 'Email',
+			'slug'             => 'email',
+			'isRepeatableDate' => 'true',
+			'required'         => false,
+			'minChars'         => '',
+			'maxChars'         => '',
+		),
 	);
 }

--- a/tests/integration/api-validation/test-data/posts.php
+++ b/tests/integration/api-validation/test-data/posts.php
@@ -81,6 +81,7 @@ function populate_post( $post_id, $model, $test_class ) {
 	update_post_meta( $post_id, 'multiLine', 'This is multi-line text' );
 	update_post_meta( $post_id, 'richText', 'This is a rich text field' );
 	update_post_meta( $post_id, 'richTextRepeatable', [ '<p>First</p>', '<p>Second</p>' ] );
+	update_post_meta( $post_id, 'email', 'email@test.com' );
 	update_post_meta( $post_id, 'numberInteger', '42' );
 	update_post_meta( $post_id, 'numberIntegerRepeat', [ 0, 1, 2 ] );
 	update_post_meta( $post_id, 'numberDecimal', '3.14' );

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -63,6 +63,7 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 							richTextRepeatable
 							numberIntergerRequired
 							numberIntegerRepeat
+							email
 							mediaRepeat
 							dateRequired
 							dateRepeatable
@@ -104,6 +105,9 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 			self::assertArrayHasKey( 'richTextRepeatable', $results['data']['publicsFields']['nodes'][0] );
 			self::assertSame( $results['data']['publicsFields']['nodes'][0]['richTextRepeatable'][0], '<p>First</p>' );
 			self::assertSame( $results['data']['publicsFields']['nodes'][0]['richTextRepeatable'][1], '<p>Second</p>' );
+
+			self::assertArrayHasKey( 'email', $results['data']['publicsFields']['nodes'][0] );
+			self::assertSame( $results['data']['publicsFields']['nodes'][0]['email'], 'email@test.com' );
 
 			self::assertArrayHasKey( 'dateRepeatable', $results['data']['publicsFields']['nodes'][0] );
 			self::assertIsArray( $results['data']['publicsFields']['nodes'][0]['dateRepeatable'] );


### PR DESCRIPTION
## Description

Allow email type to be queryable via GraphQL.

https://wpengine.atlassian.net/browse/MTKA-1438

## Testing

1. Create new content model that includes an email
2. Publish model with an input type of email
3. Attempt to query published data model via GraphQL

## Screenshots

<img width="1068" alt="Screen Shot 2022-03-31 at 11 18 42 AM" src="https://user-images.githubusercontent.com/62450648/161102725-133ca7f8-69d0-4e21-b06a-4104b5caddc1.png">
<img width="1073" alt="Screen Shot 2022-03-31 at 11 18 33 AM" src="https://user-images.githubusercontent.com/62450648/161102759-54d656ce-f16b-449d-a32d-55fe3e310002.png">
<img width="967" alt="Screen Shot 2022-03-31 at 11 15 39 AM" src="https://user-images.githubusercontent.com/62450648/161102777-a637887d-d7b6-441f-b9d6-0a509441e9d5.png">

