### PR TITLE
MTKA-1462: Focus first field on new post screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - Repeatable date field that will allow for publishers to define multiple dates for each date field they create.
 
+### Changed
+- The first field now gains focus when creating a new ACM post.
+
 ## 0.15.0 - 2022-03-24
 ### Added
 - Rich Text, Number and Media fields have a new “make repeatable” option. Enable it on new fields to let publishers add multiple rich text, number or image entries in one field.

--- a/includes/publisher/js/src/components/Field.jsx
+++ b/includes/publisher/js/src/components/Field.jsx
@@ -13,7 +13,7 @@ const integerRegex = /^[-+]?\d+/g;
 const decimalRegex = /^\-?(\d+\.?\d*|\d*\.?\d+)$/g;
 
 export default function Field(props) {
-	const { field, modelSlug } = props;
+	const { field, modelSlug, first } = props;
 	const [errors, setErrors] = useState({});
 
 	/**
@@ -86,6 +86,7 @@ export default function Field(props) {
 			<div
 				id={`field-${field.slug}`}
 				className={`field d-flex flex-column ${field.type}`}
+				{...(first && { "data-first-field": true })}
 			>
 				{fieldMarkup(field, modelSlug, errors, validate)}
 			</div>

--- a/includes/publisher/js/src/components/Fields.jsx
+++ b/includes/publisher/js/src/components/Fields.jsx
@@ -19,8 +19,15 @@ export default function Fields(props) {
 		);
 	}
 
-	return fieldOrder.map((v, i, a) => {
-		const field = fields[v];
-		return <Field field={field} modelSlug={model.slug} key={v} />;
+	return fieldOrder.map((fieldKey, i) => {
+		const field = fields[fieldKey];
+		return (
+			<Field
+				field={field}
+				modelSlug={model.slug}
+				key={fieldKey}
+				first={i === 0} // To help focus the first field.
+			/>
+		);
 	});
 }

--- a/includes/publisher/js/src/components/RichText/useWPEditor.js
+++ b/includes/publisher/js/src/components/RichText/useWPEditor.js
@@ -10,11 +10,33 @@ const { wp, atlasContentModelerFormEditingExperience } = window;
 export default function useWpEditor(textareaIds) {
 	const editorReadyTimer = useRef(null);
 
+	/**
+	 * The init_instance_callback to focus the field if it is the first
+	 * one in the model. Allows users to start typing without having to focus
+	 * the field manually on “new post” forms.
+	 *
+	 * @param {object} editor
+	 */
+	const maybeFocusEditor = (editor) => {
+		let isFirstField =
+			document
+				.getElementById(editor.id)
+				.closest("[data-first-field=true]") !== null &&
+			(textareaIds[0] ?? "") === editor.id;
+
+		let isNewPost = document.body.classList.contains("post-new-php");
+
+		if (isFirstField && isNewPost) {
+			editor.focus();
+		}
+	};
+
 	useEffect(() => {
 		const editorReadyTime = 500;
 		const editorSettingsOverrides = {
 			tinymce: {
 				height: "125",
+				init_instance_callback: maybeFocusEditor,
 				toolbar1:
 					"undo,redo,formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,unlink,wp_add_media",
 			},

--- a/includes/publisher/js/src/index.jsx
+++ b/includes/publisher/js/src/index.jsx
@@ -4,25 +4,10 @@ import ReactDOM from "react-dom";
 import App from "./App";
 import "./../../scss/index.scss";
 import "../../../settings/scss/index.scss";
+import { addClassOnFormSubmit, focusFirstField } from "./publisherFormActions";
 
 const { models, postType } = atlasContentModelerFormEditingExperience;
 const container = document.getElementById("atlas-content-modeler-fields-app");
-
-/**
- * Adds a "submitted" class when the publish form is submitted.
- *
- * Allows styling of :invalid input fields only when the form was
- * submitted. Prevents an issue where error messages appear for
- * required fields when the form is first loaded.
- */
-const addClassOnFormSubmit = () => {
-	const form = document.querySelector("form#post");
-	const publishButton = document.querySelector("input#publish");
-	const addSubmittedClass = () => form.classList.add("submitted");
-
-	publishButton.addEventListener("click", addSubmittedClass);
-	form.addEventListener("submit", addSubmittedClass);
-};
 
 if (container && models.hasOwnProperty(postType)) {
 	const model = models[postType];
@@ -34,4 +19,5 @@ if (container && models.hasOwnProperty(postType)) {
 	);
 
 	addClassOnFormSubmit();
+	focusFirstField();
 }

--- a/includes/publisher/js/src/index.jsx
+++ b/includes/publisher/js/src/index.jsx
@@ -8,6 +8,22 @@ import "../../../settings/scss/index.scss";
 const { models, postType } = atlasContentModelerFormEditingExperience;
 const container = document.getElementById("atlas-content-modeler-fields-app");
 
+/**
+ * Adds a "submitted" class when the publish form is submitted.
+ *
+ * Allows styling of :invalid input fields only when the form was
+ * submitted. Prevents an issue where error messages appear for
+ * required fields when the form is first loaded.
+ */
+const addClassOnFormSubmit = () => {
+	const form = document.querySelector("form#post");
+	const publishButton = document.querySelector("input#publish");
+	const addSubmittedClass = () => form.classList.add("submitted");
+
+	publishButton.addEventListener("click", addSubmittedClass);
+	form.addEventListener("submit", addSubmittedClass);
+};
+
 if (container && models.hasOwnProperty(postType)) {
 	const model = models[postType];
 	const urlParams = new URLSearchParams(window.location.search);
@@ -17,15 +33,5 @@ if (container && models.hasOwnProperty(postType)) {
 		container
 	);
 
-	/**
-	 * Allows styling of :invalid input fields only when the form was
-	 * submitted. Prevents an issue where error messages appear for
-	 * required fields when the form is first loaded.
-	 */
-	const form = document.querySelector("form#post");
-	const publishButton = document.querySelector("input#publish");
-	const addSubmittedClass = () => form.classList.add("submitted");
-
-	publishButton.addEventListener("click", addSubmittedClass);
-	form.addEventListener("submit", addSubmittedClass);
+	addClassOnFormSubmit();
 }

--- a/includes/publisher/js/src/publisherFormActions.js
+++ b/includes/publisher/js/src/publisherFormActions.js
@@ -21,7 +21,7 @@ export const addClassOnFormSubmit = () => {
  * Puts focus on the first field.
  *
  * Allows the user to start interacting with the form immediately,
- * the same as WordPress behavior for core post type.
+ * the same behavior as WordPress core post types.
  *
  * Acts when creating new posts, not when editing existing ones.
  */

--- a/includes/publisher/js/src/publisherFormActions.js
+++ b/includes/publisher/js/src/publisherFormActions.js
@@ -1,0 +1,66 @@
+import { getFieldOrder } from "../../../settings/js/src/queries";
+const { postType, models } = atlasContentModelerFormEditingExperience;
+
+/**
+ * Adds a "submitted" class when the publish form is submitted.
+ *
+ * Allows styling of :invalid input fields only when the form was
+ * submitted. Prevents an issue where error messages appear for
+ * required fields when the form is first loaded.
+ */
+export const addClassOnFormSubmit = () => {
+	const form = document.querySelector("form#post");
+	const publishButton = document.querySelector("input#publish");
+	const addSubmittedClass = () => form.classList.add("submitted");
+
+	publishButton.addEventListener("click", addSubmittedClass);
+	form.addEventListener("submit", addSubmittedClass);
+};
+
+/**
+ * Puts focus on the first field.
+ *
+ * Allows the user to start interacting with the form immediately,
+ * the same as WordPress behavior for core post type.
+ *
+ * Acts when creating new posts, not when editing existing ones.
+ */
+export const focusFirstField = () => {
+	if (!document.body.classList.contains("post-new-php")) {
+		return;
+	}
+
+	const fieldOrder = getFieldOrder(models[postType]?.fields);
+	const firstFieldId = fieldOrder[0] ?? false;
+	const firstField = firstFieldId
+		? models[postType]?.fields[firstFieldId]
+		: false;
+
+	if (!firstField) {
+		return;
+	}
+
+	const { type, inputType } = firstField;
+
+	if (type === "richtext") {
+		return; // Rich Text field focus is handled in the useWPEditor hook.
+	}
+
+	let selector = "input";
+
+	if (type === "text" && inputType === "multi") {
+		selector = "textarea";
+	}
+
+	if (type === "media" || type === "relationship") {
+		selector = "button";
+	}
+
+	const field = document.querySelector(
+		`div[data-first-field=true] ${selector}`
+	);
+
+	if (field) {
+		field.focus();
+	}
+};

--- a/includes/publisher/scss/_classic-form.scss
+++ b/includes/publisher/scss/_classic-form.scss
@@ -193,7 +193,7 @@ $button-primary: #002838;
 			border-color: $form-purple !important;
 		}
 
-		input:focus + .checkmark {
+		.check-container input:focus ~ .checkmark {
 			border-color: $form-purple !important;
 		}
 
@@ -272,7 +272,7 @@ $button-primary: #002838;
 			border-color: $form-purple !important;
 		}
 
-		input:focus + .radio-select {
+		.radio-container input:focus ~ .radio-select {
 			border-color: $form-purple !important;
 		}
 

--- a/tests/acceptance/CreateContentModelMediaFieldCest.php
+++ b/tests/acceptance/CreateContentModelMediaFieldCest.php
@@ -12,10 +12,6 @@ class CreateContentModelMediaFieldCest {
 	 * Ensure a user can add a Media field to the model with a repeatable property.
 	 */
 	public function i_can_create_a_content_model_media_repeatable_field( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
-		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
-
 		$i->click( 'Media', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'positionxyz' );
@@ -33,16 +29,16 @@ class CreateContentModelMediaFieldCest {
 		$i->wait( 1 );
 
 		$i->see( 'Manage Media', 'button[data-testid="media-uploader-manage-media-button"]' );
+
+		// The media button should be in focus as the first field on the page.
+		$active_element = $i->executeJS( "return document.activeElement.getAttribute('data-testid');" );
+		$i->assertEquals( 'media-uploader-manage-media-button', $active_element );
 	}
 
 	/**
 	 * Ensure a user cannot save a Media field with a required repeatable property.
 	 */
 	public function i_cannot_save_empty_required_media_repeatable_field( AcceptanceTester $i ) {
-		$i->loginAsAdmin();
-		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
-		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
-
 		$i->click( 'Media', '.field-buttons' );
 		$i->wait( 1 );
 		$i->fillField( [ 'name' => 'name' ], 'positionxyz' );

--- a/tests/acceptance/CreateContentModelNumberFieldCest.php
+++ b/tests/acceptance/CreateContentModelNumberFieldCest.php
@@ -84,6 +84,10 @@ class CreateContentModelNumberFieldCest {
 			'input',
 			[ 'name' => 'atlas-content-modeler[candy][positionxyz][0]' ]
 		);
+
+		// The first number field should be in focus as the first field on the page.
+		$active_element = $i->executeJS( "return document.activeElement.getAttribute('id');" );
+		$i->assertEquals( 'atlas-content-modeler[candy][positionxyz][0]', $active_element );
 	}
 
 	/**

--- a/tests/acceptance/CreateContentModelTextFieldCest.php
+++ b/tests/acceptance/CreateContentModelTextFieldCest.php
@@ -52,6 +52,10 @@ class CreateContentModelTextFieldCest {
 			'input',
 			[ 'name' => 'atlas-content-modeler[candy][color][0]' ]
 		);
+
+		// The first text field should be in focus as the first field on the page.
+		$active_element = $i->executeJS( "return document.activeElement.getAttribute('name');" );
+		$i->assertEquals( 'atlas-content-modeler[candy][color][0]', $active_element );
 	}
 
 	public function i_can_create_a_content_model_text_field_as_a_textarea( AcceptanceTester $i ) {

--- a/tests/acceptance/CreateRepeatableDateFieldCest.php
+++ b/tests/acceptance/CreateRepeatableDateFieldCest.php
@@ -24,6 +24,10 @@ class CreateRepeatableDateFieldCest {
 			'input',
 			[ 'name' => 'atlas-content-modeler[candy][dates][0]' ]
 		);
+
+		// The date field should be in focus as the first field on the page.
+		$active_element = $i->executeJS( "return document.activeElement.getAttribute('name');" );
+		$i->assertEquals( 'atlas-content-modeler[candy][dates][0]', $active_element );
 	}
 
 	/**

--- a/tests/acceptance/CreateRepeatableRichTextFieldCest.php
+++ b/tests/acceptance/CreateRepeatableRichTextFieldCest.php
@@ -1,6 +1,6 @@
 <?php
 
-class CreateContentModelRepeatableRichTextFieldCest {
+class CreateRepeatableRichTextFieldCest {
 
 	public function _before( \AcceptanceTester $i ) {
 		$i->resizeWindow( 1280, 1024 );
@@ -16,6 +16,14 @@ class CreateContentModelRepeatableRichTextFieldCest {
 		$i->amOnPage( '/wp-admin/edit.php?post_type=candy' );
 		$i->click( 'Add New', '.wrap' );
 		$i->wait( 1 );
+	}
+
+	public function i_see_the_first_field_in_focus_when_adding_a_new_entry( AcceptanceTester $i ) {
+		$i->waitForElementVisible( '.mce-tinymce' );
+
+		$editor_has_focus = $i->executeJS( 'return tinymce.editors[0].hasFocus();' );
+
+		$i->assertTrue( $editor_has_focus );
 	}
 
 	public function i_can_see_a_rich_text_repeatable_field_on_the_publisher_page( AcceptanceTester $i ) {

--- a/tests/jest/components/__snapshots__/Fields.test.js.snap
+++ b/tests/jest/components/__snapshots__/Fields.test.js.snap
@@ -4,6 +4,7 @@ exports[`Fields when given a model, it renders a list of its fields 1`] = `
 Array [
   <div
     className="field d-flex flex-column text"
+    data-first-field={true}
     id="field-firstName"
   >
     <label


### PR DESCRIPTION
## Description

Puts focus on the first field when adding a new ACM entry.

Does not adjust focus when editing ACM entries, consistent with WP core behavior.

https://wpengine.atlassian.net/browse/MTKA-1462
https://wpengine.atlassian.net/browse/MTKA-1458

## Testing

Includes e2e tests to confirm fields of different types are in focus.

### To test manually

Create a model with multiple different field types.

Confirm the first field is in focus when creating a new entry.

## Screenshots

<img width="712" alt="Screenshot 2022-04-05 at 15 26 04" src="https://user-images.githubusercontent.com/647669/161764333-c9d3459d-b552-4beb-9a51-270bc113b0f9.png">
<img width="612" alt="Screenshot 2022-04-05 at 15 26 21" src="https://user-images.githubusercontent.com/647669/161764346-c0a4cf09-92fb-4440-94c3-48a82384dfa3.png">
<img width="629" alt="Screenshot 2022-04-05 at 15 26 39" src="https://user-images.githubusercontent.com/647669/161764349-b74b8da0-ec13-41f0-89c4-d2fb6bed1057.png">
<img width="533" alt="Screenshot 2022-04-05 at 15 26 54" src="https://user-images.githubusercontent.com/647669/161764352-cbed6807-4c72-4d26-90b9-7be9ddcd6af8.png">
<img width="280" alt="Screenshot 2022-04-05 at 15 29 02" src="https://user-images.githubusercontent.com/647669/161764738-1d5dcd37-6456-4818-8176-7def5612820b.png">
