### PR TITLE
MTKA-1463: Focus newly added text repeater field rows

### DIFF
--- a/includes/publisher/js/src/components/Text/Text.jsx
+++ b/includes/publisher/js/src/components/Text/Text.jsx
@@ -149,13 +149,9 @@ export default function Text({
 																	maxLength={
 																		field?.maxChars
 																	}
-																	onKeyPress={(
-																		event
-																	) => {
-																		handleKeyPress(
-																			event
-																		);
-																	}}
+																	onKeyPress={
+																		handleKeyPress
+																	}
 																	value={
 																		fieldValues[
 																			index

--- a/includes/publisher/js/src/components/Text/Text.jsx
+++ b/includes/publisher/js/src/components/Text/Text.jsx
@@ -49,13 +49,47 @@ export default function Text({
 		useFocusNewFields(modelSlug, field?.slug, fieldValues);
 
 		/**
-		 * Handle keypress to add new entry and continue entering data
-		 * @param {*} event
+		 * When enter is pressed move focus to the next field, or add a new
+		 * field if the field in focus is the final one in the repeating list.
+		 *
+		 * @param {object} event
 		 */
 		function handleKeyPress(event) {
 			if (event.key === "Enter") {
 				event.preventDefault();
-				addButtonRef.current.click();
+
+				const lastFieldIsInFocus =
+					document.activeElement.getAttribute("name") ===
+					`atlas-content-modeler[${modelSlug}][${field.slug}][${
+						fieldValues?.length - 1
+					}]`;
+
+				if (lastFieldIsInFocus) {
+					addButtonRef.current.click();
+					return;
+				}
+
+				const activeFieldName = document.activeElement.getAttribute(
+					"name"
+				);
+
+				const activeFieldIndex = [
+					...document.querySelectorAll(
+						`[name*="atlas-content-modeler[${modelSlug}][${field.slug}]`
+					),
+				]
+					.map((field) => field.getAttribute("name"))
+					.indexOf(activeFieldName);
+
+				const nextField = document.querySelector(
+					`[name="atlas-content-modeler[${modelSlug}][${
+						field.slug
+					}][${activeFieldIndex + 1}]`
+				);
+
+				if (nextField) {
+					nextField.focus();
+				}
 			}
 		}
 

--- a/includes/publisher/js/src/components/Text/Text.jsx
+++ b/includes/publisher/js/src/components/Text/Text.jsx
@@ -4,6 +4,7 @@ import { __ } from "@wordpress/i18n";
 import Icon from "../../../../../components/icons";
 import TrashIcon from "../../../../../components/icons/TrashIcon";
 import AddRepeatableItemButton from "./AddRepeatableItemButton";
+import useFocusNewFields from "../shared/repeaters/useFocusNewFields";
 
 export default function Text({
 	field,
@@ -44,6 +45,8 @@ export default function Text({
 			validFieldValues.length > 0 &&
 			validFieldValues.length < field.minRepeatable;
 		const isRequired = field?.required || isMinRequired;
+
+		useFocusNewFields(modelSlug, field?.slug, fieldValues);
 
 		/**
 		 * Handle keypress to add new entry and continue entering data

--- a/includes/publisher/js/src/components/shared/repeaters/useFocusNewFields.js
+++ b/includes/publisher/js/src/components/shared/repeaters/useFocusNewFields.js
@@ -1,0 +1,39 @@
+import { useRef, useEffect } from "react";
+
+/**
+ * Moves focus to the final field in a repeating field group when a new field
+ * is added.
+ *
+ * @param {string} modelSlug
+ * @param {string} fieldSlug
+ * @param {array} fieldValues
+ */
+const useFocusNewFields = (modelSlug, fieldSlug, fieldValues) => {
+	const fieldCount = useRef(fieldValues?.length);
+
+	/**
+	 * Move focus to the last field if the list of fieldValues grows.
+	 */
+	useEffect(() => {
+		const focusLastField = () => {
+			const lastField = document.querySelector(
+				`[name="atlas-content-modeler[${modelSlug}][${fieldSlug}][${
+					fieldValues?.length - 1
+				}]"`
+			);
+			if (lastField) {
+				lastField.focus();
+			}
+		};
+
+		const fieldWasAdded = fieldValues?.length === fieldCount.current + 1;
+
+		if (fieldWasAdded) {
+			focusLastField();
+		}
+
+		fieldCount.current = fieldValues?.length;
+	}, [fieldValues, fieldCount]);
+};
+
+export default useFocusNewFields;

--- a/tests/acceptance/CreateContentModelTextFieldCest.php
+++ b/tests/acceptance/CreateContentModelTextFieldCest.php
@@ -52,6 +52,11 @@ class CreateContentModelTextFieldCest {
 			'input',
 			[ 'name' => 'atlas-content-modeler[candy][color][0]' ]
 		);
+
+		// Confirm new repeating text inputs gain focus when they are added.
+		$i->click( 'Add Item', '.add-option' );
+		$active_element = $i->executeJS( "return document.activeElement.getAttribute('name');" );
+		$i->assertEquals( 'atlas-content-modeler[candy][color][1]', $active_element );
 	}
 
 	public function i_can_create_a_content_model_text_field_as_a_textarea( AcceptanceTester $i ) {


### PR DESCRIPTION
## Description

- Focuses new text repeater fields when they are created, instead of keeping focus on the “add item” button.
- Adjusts @matthewguywright's branch to make the enter key add a new row only if the last repeating field is in focus, instead of when any of the repeating fields are in focus. (Pressing enter in the first field no longer creates a new field if there are fields below the first one.) If one of the fields other than the final one is in focus pressing enter now moves focus down one row.

Only applies these changes to the Text field. We plan to apply to other fields (and add changelog notes) in @matthewguywright's PR.

https://wpengine.atlassian.net/browse/MTKA-1463

## Testing

Includes an e2e test to check that newly added fields gain focus.

### To test manually
1. Create a repeating text field (single line, not multiline).
2. Create a new post and add a new text field row to the repeater — the new field should gain focus when you click the “add item” button (or when you press the enter key when your cursor is in the last field in the repeater).

## Screenshots

https://user-images.githubusercontent.com/647669/161978855-6a183c12-cdd4-4874-b7ca-d9f166388ddc.mov

## Documentation Changes

n/a

## Dependant PRs

n/a