### PR TITLE
Mtka 1439 dev email domain validation

### DIFF
--- a/includes/settings/js/src/components/fields/AdvancedSettings.jsx
+++ b/includes/settings/js/src/components/fields/AdvancedSettings.jsx
@@ -4,6 +4,7 @@
 import React from "react";
 import Icon from "../../../../../components/icons";
 import { __ } from "@wordpress/i18n";
+import EmailSettings from "./EmailSettings";
 
 const MediaSettings = ({
 	errors,
@@ -527,4 +528,4 @@ const TextSettings = ({
 	);
 };
 
-export { MediaSettings, TextSettings, NumberSettings };
+export { MediaSettings, TextSettings, NumberSettings, EmailSettings };

--- a/includes/settings/js/src/components/fields/EmailSettings.jsx
+++ b/includes/settings/js/src/components/fields/EmailSettings.jsx
@@ -4,20 +4,14 @@ import React from "react";
 import Icon from "../../../../../components/icons";
 import { __ } from "@wordpress/i18n";
 
-// TODO-abotz: figure out why we need important here and remove
-const emailDomainTextArea = css({
-	maxWidth: "none !important",
-	minHeight: "55px !important",
-});
+const emailDomainTextArea = css`
+	.atlas-content-modeler-admin-page & {
+		max-width: none;
+		min-height: 55px;
+	}
+`;
 
-const EmailSettings = ({
-	errors,
-	field,
-	storedData,
-	setValue,
-	getValues,
-	trigger,
-}) => {
+const EmailSettings = ({ errors, storedData, setValue, getValues }) => {
 	return (
 		<>
 			<div className="d-flex flex-column d-sm-flex flex-sm-row">
@@ -35,7 +29,7 @@ const EmailSettings = ({
 						</label>
 						<p>
 							{__(
-								`Comma seperated list of allowed domains, wild cards allowed. Eg "*.edu"`,
+								`Comma-separated list of allowed domains, wildcards allowed. e.g. "*.edu"`,
 								"atlas-content-modeler"
 							)}
 						</p>

--- a/includes/settings/js/src/components/fields/EmailSettings.jsx
+++ b/includes/settings/js/src/components/fields/EmailSettings.jsx
@@ -1,0 +1,90 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/react";
+import React from "react";
+import Icon from "../../../../../components/icons";
+import { __ } from "@wordpress/i18n";
+
+// TODO-abotz: figure out why we need important here and remove
+const emailDomainTextArea = css({
+	maxWidth: "none !important",
+	minHeight: "55px !important",
+});
+
+const EmailSettings = ({
+	errors,
+	field,
+	storedData,
+	setValue,
+	getValues,
+	trigger,
+}) => {
+	return (
+		<>
+			<div className="d-flex flex-column d-sm-flex flex-sm-row">
+				<div className="w-100">
+					<div
+						className={`${
+							errors.allowedDomains ? "field has-error" : "field"
+						} w-100`}
+					>
+						<label htmlFor="allowedDomains">
+							{__(
+								"Specify Allowed Domains",
+								"atlas-content-modeler"
+							)}
+						</label>
+						<p>
+							{__(
+								`Comma seperated list of allowed domains, wild cards allowed. Eg "*.edu"`,
+								"atlas-content-modeler"
+							)}
+						</p>
+						<textarea
+							id="allowedDomains"
+							name="allowedDomains"
+							css={emailDomainTextArea}
+							className="w-100"
+							rows="1"
+							aria-invalid={
+								errors.allowedDomains ? "true" : "false"
+							}
+							placeholder={__(
+								"*.edu, gmail.com, wpengine.com, *.flywheel.com",
+								"atlas-content-modeler"
+							)}
+							onChange={async (e) => {
+								setValue("allowedDomains", e.target.value, {
+									shouldValidate: true,
+								});
+							}}
+							defaultValue={String(
+								getValues("allowedDomains") ??
+									storedData?.allowedDomains
+							)}
+						/>
+						<p className="field-messages">
+							{errors.allowedDomains &&
+								errors.allowedDomains.type ===
+									"formattedCorrectly" && (
+									<span className="error">
+										<Icon type="error" />
+										<span
+											role="alert"
+											className="text-start"
+										>
+											{__(
+												"Must be a comma-separated list of domains and subdomains.",
+												"atlas-content-modeler"
+											)}
+										</span>
+									</span>
+								)}
+						</p>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default EmailSettings;

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -143,7 +143,6 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 		email: {
 			component: EmailSettings,
 			fields: {
-				// TODO-botz: update to validate email domain/subdomain integrity
 				allowedDomains: {
 					setValueAs: (value) =>
 						value ? value.replace(/\s/g, "") : "",
@@ -152,8 +151,16 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 							if (!value) {
 								return true;
 							}
-							const typesRegex = /[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/g;
-							return typesRegex.test(value);
+
+							const domains = value
+								.split(",")
+								.map((domain) => domain.trim());
+							const wildcardDomainRegex = /[A-Za-z0-9-*.]*\.[A-Za-z]+$/;
+							const isValidDomain = (domain) => {
+								return wildcardDomainRegex.test(domain);
+							};
+
+							return domains.every(isValidDomain);
 						},
 					},
 				},

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -154,7 +154,8 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 
 							const domains = value
 								.split(",")
-								.map((domain) => domain.trim());
+								.map((domain) => domain.trim())
+								.filter((domain) => domain.length > 0);
 							const wildcardDomainRegex = /[A-Za-z0-9-*.]*\.[A-Za-z]+$/;
 							const isValidDomain = (domain) => {
 								return wildcardDomainRegex.test(domain);

--- a/includes/settings/js/src/components/fields/Form.jsx
+++ b/includes/settings/js/src/components/fields/Form.jsx
@@ -11,6 +11,7 @@ import {
 	MediaSettings,
 	TextSettings,
 	NumberSettings,
+	EmailSettings,
 } from "./AdvancedSettings";
 import NumberFields from "./NumberFields";
 import DateFields from "./DateFields";
@@ -134,6 +135,25 @@ function Form({ id, position, type, editing, storedData, hasDirtyField }) {
 								return true;
 							}
 							return max >= min;
+						},
+					},
+				},
+			},
+		},
+		email: {
+			component: EmailSettings,
+			fields: {
+				// TODO-botz: update to validate email domain/subdomain integrity
+				allowedDomains: {
+					setValueAs: (value) =>
+						value ? value.replace(/\s/g, "") : "",
+					validate: {
+						formattedCorrectly: (value) => {
+							if (!value) {
+								return true;
+							}
+							const typesRegex = /[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/g;
+							return typesRegex.test(value);
 						},
 					},
 				},

--- a/tests/acceptance/AdvancedSettingsCest.php
+++ b/tests/acceptance/AdvancedSettingsCest.php
@@ -159,4 +159,32 @@ class AdvancedSettingsCest {
 		$i->wait( 1 );
 		$i->see( 'Accepts file types: JPG, JPEG, PDF' );
 	}
+
+	public function i_can_set_allowed_domains_and_subdomains_for_email_fields( \AcceptanceTester $i ) {
+		$i->click( 'Email', '.field-buttons' );
+		$i->wait( 1 );
+
+		$i->fillField( [ 'name' => 'name' ], 'Email' );
+
+		$i->click( 'button[data-testid="edit-model-update-create-settings-button"]' );
+		$i->fillField( [ 'name' => 'allowedDomains' ], 'test' );
+		$i->see( 'Must be a comma-separated list of domains and subdomains.' );
+		$i->wait( 1 );
+
+		$i->fillField( [ 'name' => 'allowedDomains' ], '*.test.com, gmail.com' );
+
+		$i->click( 'button[data-testid="model-advanced-settings-done-button"]' ); // Save Advanced Settings.
+		$i->wait( 1 );
+		$i->click( 'button[data-testid="edit-model-update-create-button"]' ); // Save the field.
+		$i->wait( 1 );
+
+		// Offsets are used here to prevent “other element would receive the click”
+		// due to the “add field” button overlapping the edit button in the center.
+		$i->clickWithLeftButton( '.field-list button.edit', -5, -5 );
+
+		// Open Advanced Settings again.
+		$i->click( 'button[data-testid="edit-model-update-create-settings-button"]' );
+
+		$i->seeInField( '#allowedDomains', '*.test.com,gmail.com' );
+	}
 }


### PR DESCRIPTION
## Description

Add in Advanced Settings for Email that allows for validating Domains and Subdomains. This PR does not include the Publisher side, it only wires up the Developer side.

https://wpengine.atlassian.net/browse/MTKA-1439

## Testing

1. Create new Content Model with an Email Input field.
2. Click on Advanced Settings
3. Set a domain and/or subdomain
4. Attempt to create new model with Email input

## Screenshots

<img width="721" alt="Screen Shot 2022-04-06 at 4 08 13 PM" src="https://user-images.githubusercontent.com/62450648/162071357-0f2a0d05-f0ee-4d90-8999-4a391c4441fe.png">
<img width="780" alt="Screen Shot 2022-04-06 at 4 08 22 PM" src="https://user-images.githubusercontent.com/62450648/162071369-9f68aa78-73a7-40dd-8fe7-13804514755d.png">
<img width="766" alt="Screen Shot 2022-04-06 at 4 08 31 PM" src="https://user-images.githubusercontent.com/62450648/162071377-769b4b3d-584a-4ea2-8733-e2d0e36f3b53.png">
<img width="750" alt="Screen Shot 2022-04-06 at 4 08 50 PM" src="https://user-images.githubusercontent.com/62450648/162071389-4c3f7809-facc-4cbe-9826-6d9429715b13.png">
