### PR TITLE
test: confirm title field value is searchable in GraphQL

### DIFF
--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -144,4 +144,27 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
 		}
 	}
+
+	public function test_title_fields_can_be_searched_in_graphql(): void {
+		try {
+			$results = graphql(
+				[
+					'query' => '
+				{
+					publicsFields(where: {search: "required"}) {
+						nodes {
+							title
+						}
+					}
+				}
+				',
+				]
+			);
+
+			// Matches value of singleLineRequired field, which is configured as the title field.
+			self::assertSame( 'This is required single line text', $results['data']['publicsFields']['nodes'][0]['title'] );
+		} catch ( Exception $exception ) {
+			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
+		}
+	}
 }


### PR DESCRIPTION
## Description
Adds a WPGraphQL search query to confirm that title values are searchable.

## Testing
New test passes, existing tests continue to pass.
