### PR TITLE
[MTKA-1479] refactor post slug generation

### DIFF
--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -315,6 +315,15 @@ final class FormEditingExperience {
 			return;
 		}
 
+		if ( $post->post_status === 'auto-draft' ) {
+			$post->post_name  = $post->ID;
+			$post->post_title = 'entry' . $post->ID;
+			remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
+			wp_update_post( $post, false, false );
+			add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
+			return;
+		}
+
 		if ( ! $update ) {
 			return;
 		}

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -220,7 +220,9 @@ final class FormEditingExperience {
 						$value = get_post_meta( $post->ID, $field['slug'], true );
 						if ( ! empty( $field['isTitle'] ) && $value !== $post->post_title ) {
 							$post->post_title = $value;
+							remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
 							wp_update_post( $post, false, false );
+							add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
 						}
 						$models[ $this->screen->post_type ]['fields'][ $key ]['value'] = $value;
 					}
@@ -296,10 +298,6 @@ final class FormEditingExperience {
 	 */
 	public function set_post_attributes( int $post_ID, WP_Post $post, bool $update ): void {
 		if ( ! array_key_exists( $post->post_type, $this->models ) ) {
-			return;
-		}
-
-		if ( $post->post_status === 'auto-draft' ) {
 			return;
 		}
 
@@ -665,7 +663,9 @@ final class FormEditingExperience {
 			if ( ! empty( $title_value ) ) {
 				if ( $post->post_title !== $title_value ) {
 					$post->post_title = $title_value;
+					remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
 					wp_update_post( $post, false, false );
+					add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
 				}
 				return $title_value;
 			}
@@ -808,7 +808,8 @@ final class FormEditingExperience {
 		}
 
 		$post->post_title = $meta_value;
+		remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
 		wp_update_post( $post, true, false );
+		add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
 	}
-
 }

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -220,9 +220,7 @@ final class FormEditingExperience {
 						$value = get_post_meta( $post->ID, $field['slug'], true );
 						if ( ! empty( $field['isTitle'] ) && $value !== $post->post_title ) {
 							$post->post_title = $value;
-							remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
-							wp_update_post( $post, false, false );
-							add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
+							$this->update_post( $post );
 						}
 						$models[ $this->screen->post_type ]['fields'][ $key ]['value'] = $value;
 					}
@@ -307,9 +305,7 @@ final class FormEditingExperience {
 
 		$post->post_title = 'entry' . $post_ID;
 		$post->post_name  = $post_ID;
-		remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
-		wp_update_post( $post, false, false );
-		add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
+		$this->update_post( $post );
 	}
 
 	/**
@@ -637,9 +633,7 @@ final class FormEditingExperience {
 			if ( ! empty( $title_value ) ) {
 				if ( $post->post_title !== $title_value ) {
 					$post->post_title = $title_value;
-					remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
-					wp_update_post( $post, false, false );
-					add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
+					$this->update_post( $post );
 				}
 				return $title_value;
 			}
@@ -782,8 +776,22 @@ final class FormEditingExperience {
 		}
 
 		$post->post_title = $meta_value;
+		$this->update_post( $post );
+	}
+
+	/**
+	 * Updates the post with the provided data.
+	 *
+	 * Removes ACM callbacks attached to `wp_insert_post`
+	 * to prevent them from running again when we update the post.
+	 *
+	 * @param \WP_Post $post The post data to be saved.
+	 *
+	 * @return void
+	 */
+	private function update_post( $post ): void {
 		remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
-		wp_update_post( $post, true, false );
+		wp_update_post( $post, false, false );
 		add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
 	}
 }

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -301,26 +301,12 @@ final class FormEditingExperience {
 			return;
 		}
 
-		if ( $post->post_status === 'auto-draft' ) {
-			$post->post_name  = $post->ID;
-			$post->post_title = 'entry' . $post->ID;
-			remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
-			wp_update_post( $post, false, false );
-			add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
+		if ( $post->post_status !== 'auto-draft' ) {
 			return;
 		}
 
-		if ( ! $update ) {
-			return;
-		}
-
-		$slug = wp_unique_post_slug( sanitize_title_with_dashes( $post->post_title, 'save' ), $post->ID, $post->post_status, $post->post_type, $post->post_parent );
-
-		if ( $slug === $post->post_name ) {
-			return;
-		}
-
-		$post->post_name = $slug;
+		$post->post_title = 'entry' . $post_ID;
+		$post->post_name  = $post_ID;
 		remove_action( 'wp_insert_post', [ $this, 'set_post_attributes' ] );
 		wp_update_post( $post, false, false );
 		add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -301,18 +301,6 @@ final class FormEditingExperience {
 			return;
 		}
 
-		if (
-			! isset( $_POST['atlas-content-modeler-pubex-nonce'] ) ||
-			! wp_verify_nonce(
-				sanitize_text_field(
-					wp_unslash( $_POST['atlas-content-modeler-pubex-nonce'] )
-				),
-				'atlas-content-modeler-pubex-nonce'
-			) ) {
-			$this->error_save_post = __( 'Nonce verification failed when saving your content. Please try again.', 'atlas-content-modeler' );
-			return;
-		}
-
 		if ( $post->post_status === 'auto-draft' ) {
 			$post->post_name  = $post->ID;
 			$post->post_title = 'entry' . $post->ID;

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -776,6 +776,9 @@ final class FormEditingExperience {
 		}
 
 		$post->post_title = $meta_value;
+		if ( empty( $post->post_name ) || (int) $post->post_name === $post->ID ) {
+			$post->post_name = wp_unique_post_slug( sanitize_title( $meta_value, 'save' ), $post->ID, $post->post_status, $post->post_type, $post->post_parent );
+		}
 		$this->update_post( $post );
 	}
 

--- a/tests/integration/api-validation/test-data/posts.php
+++ b/tests/integration/api-validation/test-data/posts.php
@@ -54,6 +54,13 @@ function create_test_posts( $test_class ) {
 
 	populate_post( $ids['private_fields_post_id'], 'private-fields', $test_class );
 
+	$ids['auto_draft_post_id'] = $test_class->factory->post->create(
+		array(
+			'post_status' => 'auto-draft',
+			'post_type'   => 'public',
+		)
+	);
+
 	return $ids;
 }
 

--- a/tests/integration/api-validation/test-data/posts.php
+++ b/tests/integration/api-validation/test-data/posts.php
@@ -57,7 +57,7 @@ function create_test_posts( $test_class ) {
 	$ids['auto_draft_post_id'] = $test_class->factory->post->create(
 		array(
 			'post_status' => 'auto-draft',
-			'post_type'   => 'public',
+			'post_type'   => 'public-fields',
 		)
 	);
 

--- a/tests/integration/api-validation/test-rest-model-data.php
+++ b/tests/integration/api-validation/test-rest-model-data.php
@@ -165,7 +165,7 @@ class RestModelDataTests extends WP_UnitTestCase {
 		$request       = new \WP_REST_Request( 'GET', $this->namespace . $this->public_route . '/' . $this->post_ids['public_post_id'] );
 		$response      = $this->server->dispatch( $request );
 		$response_data = $response->get_data();
-		self::assertEquals( $this->post_ids['public_post_id'], $response_data['slug'] );
+		self::assertEquals( $this->post_ids['public_post_id'], $response_data['id'] );
 	}
 
 	/**
@@ -187,7 +187,7 @@ class RestModelDataTests extends WP_UnitTestCase {
 		$response      = $this->server->dispatch( $request );
 		$response_data = $response->get_data();
 		self::assertSame( 200, $response->get_status() );
-		self::assertEquals( $this->post_ids['draft_public_post_id'], $response_data['slug'] );
+		self::assertEquals( $this->post_ids['draft_public_post_id'], $response_data['id'] );
 	}
 
 	/**
@@ -208,7 +208,7 @@ class RestModelDataTests extends WP_UnitTestCase {
 		$response      = $this->server->dispatch( $request );
 		$response_data = $response->get_data();
 		self::assertSame( 200, $response->get_status() );
-		self::assertEquals( $this->post_ids['private_post_id'], $response_data['slug'] );
+		self::assertEquals( $this->post_ids['private_post_id'], $response_data['id'] );
 	}
 
 	/**

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -86,6 +86,15 @@ class TestContentCreation extends WP_UnitTestCase {
 		$form->set_post_attributes( $this->post_ids['public_post_id'], $post, false );
 		$post = get_post( $this->post_ids['public_post_id'] );
 		self::assertSame( 'Test dog', $post->post_title );
+
+		// Get initial auto-draft post.
+		$auto_draft_post = get_post( $this->post_ids['auto_draft_post_id'] );
+
+		// Set the post attributes, update the post, and get the updated post.
+		$form->set_post_attributes( $this->post_ids['auto_draft_post_id'], $auto_draft_post, false );
+		$auto_draft_post = get_post( $this->post_ids['auto_draft_post_id'] );
+		// Confirm auto-draft post title is 'entry{xx}', where xx is the post ID.
+		self::assertSame( 'entry' . $this->post_ids['auto_draft_post_id'], $auto_draft_post->post_title );
 	}
 
 	public function test_post_title_synced_from_postmeta_table_to_posts_table(): void {

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -90,11 +90,30 @@ class TestContentCreation extends WP_UnitTestCase {
 		// Get initial auto-draft post.
 		$auto_draft_post = get_post( $this->post_ids['auto_draft_post_id'] );
 
-		// Set the post attributes, update the post, and get the updated post.
+		// Set the post attributes and update the post.
 		$form->set_post_attributes( $this->post_ids['auto_draft_post_id'], $auto_draft_post, false );
-		$auto_draft_post = get_post( $this->post_ids['auto_draft_post_id'] );
+
 		// Confirm auto-draft post title is 'entry{xx}', where xx is the post ID.
-		self::assertSame( 'entry' . $this->post_ids['auto_draft_post_id'], $auto_draft_post->post_title );
+		self::assertSame(
+			'entry' . $this->post_ids['auto_draft_post_id'],
+			$auto_draft_post->post_title
+		);
+
+		// Publish the post and confirm the post_title is unchanged.
+		$auto_draft_post              = get_post( $this->post_ids['auto_draft_post_id'] );
+		$auto_draft_post->post_status = 'publish';
+		wp_update_post( $auto_draft_post, false, false );
+		self::assertSame(
+			'entry' . $this->post_ids['auto_draft_post_id'],
+			get_post_field( 'post_title', $this->post_ids['auto_draft_post_id'] )
+		);
+
+		// Save the title field value and confirm the post_title is updated.
+		update_post_meta( $this->post_ids['auto_draft_post_id'], 'singleLineRequired', 'This meta value should become the post title' );
+		self::assertSame(
+			'This meta value should become the post title',
+			get_post_field( 'post_title', $this->post_ids['auto_draft_post_id'] )
+		);
 	}
 
 	public function test_post_title_synced_from_postmeta_table_to_posts_table(): void {
@@ -128,28 +147,33 @@ class TestContentCreation extends WP_UnitTestCase {
 		// Get initial auto-draft post.
 		$auto_draft_post = get_post( $this->post_ids['auto_draft_post_id'] );
 
-		// Set the post attributes, update the post, and get the updated post.
+		// Set the post attributes and update the post.
 		$form->set_post_attributes( $this->post_ids['auto_draft_post_id'], $auto_draft_post, false );
-		$auto_draft_post = get_post( $this->post_ids['auto_draft_post_id'] );
+
 		/**
 		 * Confirm auto-draft post slug/name is '{xx}', where xx is the post ID.
 		 * This casts the post_name value to an int, because WP stores it as a string.
 		 * Casting to an int should result in it matching the post ID, which is an integer.
 		 */
-		self::assertSame( $this->post_ids['auto_draft_post_id'], (int) $auto_draft_post->post_name );
+		self::assertSame(
+			$this->post_ids['auto_draft_post_id'],
+			(int) get_post_field( 'post_name', $this->post_ids['auto_draft_post_id'] )
+		);
 
-		// Confirm auto-draft post title is 'entry{xx}', where xx is the post ID.
-		self::assertSame( 'entry' . $this->post_ids['auto_draft_post_id'], $auto_draft_post->post_title );
-
-		// Publish the post and confirm the post_title and post_name values are untouched.
+		// Publish the post and confirm the post_name is unchanged.
+		$auto_draft_post              = get_post( $this->post_ids['auto_draft_post_id'] );
 		$auto_draft_post->post_status = 'publish';
 		wp_update_post( $auto_draft_post, false, false );
-		self::assertSame( $this->post_ids['auto_draft_post_id'], (int) $auto_draft_post->post_name );
-		self::assertSame( 'entry' . $this->post_ids['auto_draft_post_id'], $auto_draft_post->post_title );
+		self::assertSame(
+			$this->post_ids['auto_draft_post_id'],
+			(int) get_post_field( 'post_name', $this->post_ids['auto_draft_post_id'] )
+		);
 
-		// Save the title value and confirm the post_title and post_name are updated.
-		update_post_meta( $this->post_ids['auto_draft_post_id'], 'singleLineRequired', 'This meta value should become the post title' );
-		self::assertSame( 'This meta value should become the post title', get_post_field( 'post_title', $this->post_ids['auto_draft_post_id'] ) );
-		self::assertSame( 'this-meta-value-should-become-the-post-title', get_post_field( 'post_name', $this->post_ids['auto_draft_post_id'] ) );
+		// Save the title value and confirm the post_name is generated and saved. `singleLineRequired` is a title field.
+		update_post_meta( $this->post_ids['auto_draft_post_id'], 'singleLineRequired', 'Cows go moo' );
+		self::assertSame(
+			'cows-go-moo',
+			get_post_field( 'post_name', $this->post_ids['auto_draft_post_id'] )
+		);
 	}
 }

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -96,7 +96,7 @@ class TestContentCreation extends WP_UnitTestCase {
 		// Confirm auto-draft post title is 'entry{xx}', where xx is the post ID.
 		self::assertSame(
 			'entry' . $this->post_ids['auto_draft_post_id'],
-			$auto_draft_post->post_title
+			get_post_field( 'post_title', $this->post_ids['auto_draft_post_id'] )
 		);
 
 		// Publish the post and confirm the post_title is unchanged.

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -175,5 +175,17 @@ class TestContentCreation extends WP_UnitTestCase {
 			'cows-go-moo',
 			get_post_field( 'post_name', $this->post_ids['auto_draft_post_id'] )
 		);
+
+		/**
+		 * Update the title value and confirm the post_name is untouched.
+		 * We do not want to generate a post_name value every time the title
+		 * is updated. We only generate a post_name value when it is empty
+		 * or when it is the same as the post ID number.
+		 */
+		update_post_meta( $this->post_ids['auto_draft_post_id'], 'singleLineRequired', 'Cows go moo and ducks go quack' );
+		self::assertSame(
+			'cows-go-moo',
+			get_post_field( 'post_name', $this->post_ids['auto_draft_post_id'] )
+		);
 	}
 }

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -112,4 +112,30 @@ class TestContentCreation extends WP_UnitTestCase {
 		update_post_meta( $post_id, 'singleLineRequired', $meta_title ); // singleLineRequired is configured as a title field.
 		self::assertSame( get_post_field( 'post_title', $post_id ), $meta_title );
 	}
+
+	public function test_correct_post_name(): void {
+		$form = new FormEditingExperience();
+
+		// Get the initial post.
+		$post = get_post( $this->post_ids['public_post_id'] );
+
+		// Set the post attributes and update the post.
+		$form->set_post_attributes( $this->post_ids['public_post_id'], $post, false );
+		$post = get_post( $this->post_ids['public_post_id'] );
+		// Post slug should match the sanitized version of the post title. e.g. "Test dog" becomes "test-dog".
+		self::assertSame( 'test-dog', $post->post_name );
+
+		// Get initial auto-draft post.
+		$auto_draft_post = get_post( $this->post_ids['auto_draft_post_id'] );
+
+		// Set the post attributes, update the post, and get the updated post.
+		$form->set_post_attributes( $this->post_ids['auto_draft_post_id'], $auto_draft_post, false );
+		$auto_draft_post = get_post( $this->post_ids['auto_draft_post_id'] );
+		/**
+		 * Confirm auto-draft post slug/name is '{xx}', where xx is the post ID.
+		 * This casts the post_name value to an int, because WP stores it as a string.
+		 * Casting to an int should result in it matching the post ID, which is an integer.
+		 */
+		self::assertSame( $this->post_ids['auto_draft_post_id'], (int) $auto_draft_post->post_name );
+	}
 }

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -140,5 +140,16 @@ class TestContentCreation extends WP_UnitTestCase {
 
 		// Confirm auto-draft post title is 'entry{xx}', where xx is the post ID.
 		self::assertSame( 'entry' . $this->post_ids['auto_draft_post_id'], $auto_draft_post->post_title );
+
+		// Publish the post and confirm the post_title and post_name values are untouched.
+		$auto_draft_post->post_status = 'publish';
+		wp_update_post( $auto_draft_post, false, false );
+		self::assertSame( $this->post_ids['auto_draft_post_id'], (int) $auto_draft_post->post_name );
+		self::assertSame( 'entry' . $this->post_ids['auto_draft_post_id'], $auto_draft_post->post_title );
+
+		// Save the title value and confirm the post_title and post_name are updated.
+		update_post_meta( $this->post_ids['auto_draft_post_id'], 'singleLineRequired', 'This meta value should become the post title' );
+		self::assertSame( 'This meta value should become the post title', get_post_field( 'post_title', $this->post_ids['auto_draft_post_id'] ) );
+		self::assertSame( 'this-meta-value-should-become-the-post-title', get_post_field( 'post_name', $this->post_ids['auto_draft_post_id'] ) );
 	}
 }

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -85,8 +85,7 @@ class TestContentCreation extends WP_UnitTestCase {
 		// Set the post attributes and update the post.
 		$form->set_post_attributes( $this->post_ids['public_post_id'], $post, false );
 		$post = get_post( $this->post_ids['public_post_id'] );
-
-		$this->assertStringStartsWith( 'entry', $post->post_title );
+		self::assertSame( 'Test dog', $post->post_title );
 	}
 
 	public function test_post_title_synced_from_postmeta_table_to_posts_table(): void {

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -137,5 +137,8 @@ class TestContentCreation extends WP_UnitTestCase {
 		 * Casting to an int should result in it matching the post ID, which is an integer.
 		 */
 		self::assertSame( $this->post_ids['auto_draft_post_id'], (int) $auto_draft_post->post_name );
+
+		// Confirm auto-draft post title is 'entry{xx}', where xx is the post ID.
+		self::assertSame( 'entry' . $this->post_ids['auto_draft_post_id'], $auto_draft_post->post_title );
 	}
 }


### PR DESCRIPTION
## Description

- [x] Continue generating fallback slug on posts with no title field
- [x] Generate post slug from title field
- [x] Tests

<!--
Include a summary of the change and some contextual information.
-->

<!--
Provide a link to the JIRA ticket (if any) for issue tracking purposes
-->

https://wpengine.atlassian.net/browse/MTKA-1479

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation and updated wiki pages.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. And in order to have these dependencies listed as part of the checks section, use the following syntax:

Depends on #1234
-->
