### PR TITLE
MTKA-1477: Add Email repeatable option to modeler

### DIFF
--- a/includes/settings/js/src/components/fields/EmailFields.jsx
+++ b/includes/settings/js/src/components/fields/EmailFields.jsx
@@ -7,7 +7,7 @@ import { ModelsContext } from "../../ModelsContext";
 import { useLocationSearch } from "../../utils";
 import { __ } from "@wordpress/i18n";
 
-const EmailFields = ({ register, data, fieldId }) => {
+const EmailFields = ({ register, data, editing, fieldId }) => {
 	const { models } = useContext(ModelsContext);
 	const query = useLocationSearch();
 	const currentModel = query.get("id");
@@ -15,9 +15,39 @@ const EmailFields = ({ register, data, fieldId }) => {
 	const titleFieldId = getTitleFieldId(fields);
 	const showTitleField = !titleFieldId || titleFieldId === fieldId;
 	const [showTitle, setShowTitle] = useState(data?.isTitle);
+	const [showRepeatableEmail, setShowRepeatableEmail] = useState(
+		data?.isRepeatableEmail
+	);
 
 	return (
 		<>
+			{data && (
+				<div className={"field"}>
+					<legend>
+						{__("Repeatable Field", "atlas-content-modeler")}
+					</legend>
+					<input
+						name="isRepeatableEmail"
+						type="checkbox"
+						id={`is-repeatable-email-${fieldId}`}
+						ref={register}
+						defaultChecked={showRepeatableEmail}
+						onChange={() =>
+							setShowRepeatableEmail(!showRepeatableEmail)
+						}
+						disabled={editing || showTitle}
+					/>
+					<label
+						htmlFor={`is-repeatable-email-${fieldId}`}
+						className="checkbox is-repeatable"
+					>
+						{__(
+							"Make this field repeatable",
+							"atlas-content-modeler"
+						)}
+					</label>
+				</div>
+			)}
 			{showTitleField && (
 				<div className="field">
 					<legend>Title Field</legend>
@@ -28,7 +58,7 @@ const EmailFields = ({ register, data, fieldId }) => {
 						ref={register}
 						onChange={() => setShowTitle(!showTitle)}
 						defaultChecked={data?.isTitle}
-						disabled={!!titleFieldId}
+						disabled={!!titleFieldId || showRepeatableEmail}
 					/>
 					<label
 						htmlFor={`is-title-${fieldId}`}


### PR DESCRIPTION
## Description

Allow adding repeatable to the Email input field when creating via the Modeler.

https://wpengine.atlassian.net/browse/MTKA-1477

## Testing

1. Create a new model
2. Add Email input type
3. Attempt to create Email input type with repeater option checked (Only Repeater OR Title can be selected)

## Screenshots

<img width="779" alt="Screen Shot 2022-04-20 at 8 26 29 AM" src="https://user-images.githubusercontent.com/62450648/164241365-ab74d7cd-0367-4efe-b682-3f8e8ad5924d.png">
<img width="776" alt="Screen Shot 2022-04-20 at 8 26 38 AM" src="https://user-images.githubusercontent.com/62450648/164241386-9f144323-3e46-4d5b-8000-4922d39a2794.png">

