### PR TITLE
Added validate_min() and validate_max() validation functions

### DIFF
--- a/includes/api/validation-functions.php
+++ b/includes/api/validation-functions.php
@@ -299,3 +299,53 @@ function validate_not_empty( $value, string $message = 'The field cannot be empt
 		throw new Validation_Exception( $message );
 	}
 }
+
+/**
+ * Validate a string, array, or number is at least the given minimum.
+ *
+ * @param mixed  $value The value.
+ * @param int    $min The minimum criteria.
+ * @param string $message The optional error message.
+ *
+ * @throws Validation_Exception Exception when value is invalid.
+ *
+ * @return void
+ */
+function validate_min( $value, int $min, string $message = 'The field must be at least the minimum' ): void {
+	if ( \is_string( $value ) && \strlen( $value ) < $min ) {
+		throw new Validation_Exception( $message );
+	}
+
+	if ( \is_array( $value ) && \count( $value ) < $min ) {
+		throw new Validation_Exception( $message );
+	}
+
+	if ( \is_numeric( $value ) && (float) $value < $min ) {
+		throw new Validation_Exception( $message );
+	}
+}
+
+/**
+ * Validate a string, array, or number is at most the given maximum.
+ *
+ * @param mixed  $value The value.
+ * @param int    $max The maximum criteria.
+ * @param string $message The optional error message.
+ *
+ * @throws Validation_Exception Exception when value is invalid.
+ *
+ * @return void
+ */
+function validate_max( $value, int $max, string $message = 'The field cannot exceed the maximum' ): void {
+	if ( \is_string( $value ) && \strlen( $value ) > $max ) {
+		throw new Validation_Exception( $message );
+	}
+
+	if ( \is_array( $value ) && \count( $value ) > $max ) {
+		throw new Validation_Exception( $message );
+	}
+
+	if ( \is_numeric( $value ) && (float) $value > $max ) {
+		throw new Validation_Exception( $message );
+	}
+}

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -6,13 +6,13 @@ use WPE\AtlasContentModeler\Validation_Exception;
 use function WPE\AtlasContentModeler\API\validation\validate_model_field_data;
 use function WPE\AtlasContentModeler\API\validation\validate_multiple_choice_field;
 use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
-use function WPE\AtlasContentModeler\API\validation\validate_max;
-use function WPE\AtlasContentModeler\API\validation\validate_min;
 use function WPE\AtlasContentModeler\API\validation\validate_in_array;
 use function WPE\AtlasContentModeler\API\validation\validate_array;
 use function WPE\AtlasContentModeler\API\validation\validate_string;
 use function WPE\AtlasContentModeler\API\validation\validate_number;
 use function WPE\AtlasContentModeler\API\validation\validate_date;
+use function WPE\AtlasContentModeler\API\validation\validate_min;
+use function WPE\AtlasContentModeler\API\validation\validate_max;
 
 class TestValidationFunctions extends Integration_TestCase {
 	/**
@@ -372,5 +372,84 @@ class TestValidationFunctions extends Integration_TestCase {
 		$this->expectExceptionMessage( $message );
 
 		validate_in_array( 'test', [], $message );
+	}
+
+	/**
+	 * @testWith
+	 * [ "", 1 ]
+	 * [ "a", 2 ]
+	 * [ [], 1 ]
+	 * [ [ "item" ], 2 ]
+	 * [ 0, 1 ]
+	 * [ 1, 2 ]
+	 */
+	public function test_validate_min_will_throw_an_exception_if_invalid( $value, $min ) {
+		$this->expectException( Validation_Exception::class );
+		$this->expectExceptionMessage( 'The field must be at least the minimum' );
+
+		validate_min( $value, $min );
+	}
+
+	/**
+	 * @testWith
+	 * [ "", 0 ]
+	 * [ "a", 1 ]
+	 * [ [], 0 ]
+	 * [ [ "item" ], 1 ]
+	 * [ 0, 0 ]
+	 * [ 1, 1 ]
+	 */
+	public function test_validate_min_will_not_throw_an_exception_if_valid( $value, $min ) {
+		$this->assertNull( validate_min( $value, $min ) );
+	}
+
+	/**
+	 * @testWith
+	 * [ "", 1, "The field must be at least 1 character" ]
+	 * [ [], 1, "The field must contain at least 1 item" ]
+	 * [ 0, 1, "The value must equal 1 or greater" ]
+	 */
+	public function test_validate_min_will_use_a_custom_exception_message( $value, $min, $message ) {
+		$this->expectExceptionMessage( $message );
+
+		validate_min( $value, $min, $message );
+	}
+
+	/**
+	 * @testWith
+	 * [ "22", 1 ]
+	 * [ [ "item", "item2" ], 1 ]
+	 * [ 2, 1 ]
+	 */
+	public function test_validate_max_will_throw_an_exception_if_invalid( $value, $max ) {
+		$this->expectException( Validation_Exception::class );
+		$this->expectExceptionMessage( 'The field cannot exceed the maximum' );
+
+		validate_max( $value, $max );
+	}
+
+	/**
+	 * @testWith
+	 * [ "", 1 ]
+	 * [ "a", 1 ]
+	 * [ [], 1 ]
+	 * [ [ "item" ], 1 ]
+	 * [ 0, 1 ]
+	 * [ 1, 1 ]
+	 */
+	public function test_validate_max_will_not_throw_an_exception_if_valid( $value, $max ) {
+		$this->assertNull( validate_max( $value, $max ) );
+	}
+
+	/**
+	 * @testWith
+	 * [ "aa", 1, "The field cannot be greater than 1 character" ]
+	 * [ [ "item", "item2" ], 1, "The field cannot contain more than 1 items" ]
+	 * [ 2, 1, "The value cannot exceed 1" ]
+	 */
+	public function test_validate_max_will_use_a_custom_exception_message( $value, $max, $message ) {
+		$this->expectExceptionMessage( $message );
+
+		validate_max( $value, $max, $message );
 	}
 }


### PR DESCRIPTION
## Description

This pull request adds `validate_min()` and `validate_max()` validation functions for upcoming validation functionality.

Given a value that is a string, array, or numeric, that value will be assessed against the given minimum value or maximum value. Each function has an optional validation message.

```
function validate_min( $value, int $min, string $message = 'The field must be at least the minimum' ): void
```

```
function validate_max( $value, int $max, string $message = 'The field cannot exceed the maximum' ): void
```