### PR TITLE
[MTKA-1386] Add checklist for changelog entries to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,37 +1,47 @@
 ## Description
 
 <!--
-Include a summary of the change and some contextual information.
+What changed and why?
 -->
 
 <!--
-Provide a link to the JIRA ticket (if any) for issue tracking purposes
+Link to the JIRA ticket if available.
 -->
 
 https://wpengine.atlassian.net/browse/
 
+## Checklist
+
+I have:
+
+- [ ] Added an entry to CHANGELOG.md.
+
 ## Testing
 
 <!--
-Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
+What automated tests did you add to prove the changes work?
+-->
+
+<!--
+What steps should reviewers take to test manually?
 -->
 
 ## Screenshots
 
 <!--
-If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
+Add screenshots from before and after if your change is visual.
 -->
 
 ## Documentation Changes
 
 <!--
-List corresponding changes to the documentation and updated wiki pages.
+Add links to documentation or wiki changes.
 -->
 
-## Dependant PRs
+## Dependent PRs
 
 <!--
-List any dependent PR's that are awaiting review. And in order to have these dependencies listed as part of the checks section, use the following syntax:
+List dependent PRs awaiting review with this syntax:
 
-Depends on #1234
+Depends on #1234.
 -->


### PR DESCRIPTION
## Description

- Adds a changelog reminder to the GitHub PR template.
- Shortens other prompts.

https://wpengine.atlassian.net/browse/MTKA-1386