### PR TITLE
MTKA-1488 Response functions

### DIFF
--- a/includes/rest-api/init-rest-api.php
+++ b/includes/rest-api/init-rest-api.php
@@ -22,6 +22,7 @@ function atlas_content_modeler_rest_init(): void {
 		'models.php',
 		'fields.php',
 		'taxonomies.php',
+		'rest-functions.php',
 		// REST routes resolving to `/wp-json/wp/v2/wpe/atlas/[filename]`.
 		'routes/content-model.php',
 		'routes/content-models.php',

--- a/includes/rest-api/rest-functions.php
+++ b/includes/rest-api/rest-functions.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * REST related functions.
+ *
+ * @package AtlasContentModeler
+ */
+
+declare(strict_types=1);
+
+namespace WPE\AtlasContentModeler\REST_API;
+
+/**
+ * Format a response for ACM response format.
+ *
+ * @param  bool  $success Response status.
+ * @param  array $data    The response data.
+ *
+ * @return array The response data as an array.
+ */
+function format_response_data( bool $success, array $data ): array {
+	return \compact( 'success', 'data' );
+}
+
+/**
+ * Create a WP_REST_Response that uses ACM response data formatting.
+ *
+ * @param bool  $success Whether the response was successful or not.
+ * @param array $data    The data for the response.
+ * @param int   $status  Optional http status code. Default 200.
+ * @param array $headers Optional http headers. Default empty array.
+ *
+ * @return \WP_REST_Response A WP_REST_Response object.
+ */
+function create_rest_response( bool $success, array $data, int $status = 200, array $headers = [] ): \WP_REST_Response {
+	$data = format_response_data( $success, $data );
+
+	return new \WP_REST_Response( $data, $status, $headers );
+}

--- a/tests/integration/rest/test-rest-functions.php
+++ b/tests/integration/rest/test-rest-functions.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Tests for rest-functions.php
+ */
+
+use function WPE\AtlasContentModeler\REST_API\format_response_data;
+use function WPE\AtlasContentModeler\REST_API\create_rest_response;
+
+/**
+ * Class Rest_Functions_Test
+ */
+class Rest_Functions_Test extends WP_UnitTestCase {
+	public function test_format_response_data_will_format_the_response_data() {
+		$expected = [
+			'success' => true,
+			'data'    => [ 0, 1, 2, 3, 4, 5 ],
+		];
+
+		$this->assertEquals( $expected, format_response_data( true, range( 0, 5 ) ) );
+	}
+
+	public function test_create_rest_response_will_create_a_WP_REST_Response_object() {
+		$expected = [
+			'success' => true,
+			'data'    => [ 0, 1, 2, 3, 4, 5 ],
+		];
+
+		$response = create_rest_response( true, range( 0, 5 ) );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [], $response->get_headers() );
+	}
+
+	public function test_create_rest_response_will_set_the_status_code() {
+		$response = create_rest_response( true, [], 201 );
+
+		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	public function test_create_rest_response_will_set_the_headers() {
+		$response = create_rest_response( true, [], 200, [ 'X_ACM_HEADER' => 'some_value' ] );
+
+		$this->assertEquals( [ 'X_ACM_HEADER' => 'some_value' ], $response->get_headers() );
+	}
+}


### PR DESCRIPTION
## Description

This pull request adds two functions for the upcoming REST response format/structure updates.

### format_response_data()
Format data to the REST response structure.

```
format_response_data( bool $success, array $data ): array
```

**Example**
```
[
    "success" => <boolean>,
    "data" => <array|object>
]
```

### create_rest_response()
Generate a `WP_REST_Response` object with data that fulfills the response format.

```
create_rest_response( bool $success, array $data, int $status = 200, array $headers = [] ): \WP_REST_Response
```

**Example data**
```
{
    "status": true,
    "data": [
        { /* ... */ },
        { /* ... */ }
    ]
}
```

