### PR TITLE
Allow "title" as field ID for entry title text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Changed
+- Text fields can now use “title” as their API identifier if “use this field as the entry title” is ticked.
+
 ## 0.17.0 - 2022-05-05
 ### Added
 - Mutations support to create, update and delete entries via GraphQL. All fields are supported except media and relationships for now. Find examples at https://github.com/wpengine/atlas-content-modeler/blob/main/docs/mutations/index.md.

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -491,6 +491,14 @@ function register_content_fields_with_graphql( TypeRegistry $type_registry ) {
 				continue;
 			}
 
+			/**
+			 * We allow a 'title' slug for title fields, but WPGraphQL already
+			 * registers a 'title' field so no need to re-register.
+			 */
+			if ( $field['slug'] === 'title' ) {
+				continue;
+			}
+
 			$rich_text = $field['type'] === 'richtext';
 
 			if ( 'relationship' === $field['type'] && isset( $models[ $field['reference'] ] ) ) {

--- a/includes/rest-api/graphql.php
+++ b/includes/rest-api/graphql.php
@@ -185,7 +185,7 @@ function is_allowed_field_id( array $field, string $model = '' ): bool {
  * For example, 'title' is normally not permitted as a field ID because it
  * conflicts with the default 'title' registered by WPGraphQL. But when isTitle
  * is set for that field, we allow it and take steps in WPGraphQL field
- * registration and field saving logic to handle it as a special case.
+ * registration to handle it as a special case.
  *
  * @param array $field Field properties.
  * @return bool True if the `$field` has a slug that is allowed to be used.

--- a/includes/rest-api/routes/content-model-field.php
+++ b/includes/rest-api/routes/content-model-field.php
@@ -19,7 +19,7 @@ use function WPE\AtlasContentModeler\REST_API\Fields\content_model_field_exists;
 use function WPE\AtlasContentModeler\REST_API\Fields\content_model_multi_option_exists;
 use function WPE\AtlasContentModeler\REST_API\Fields\content_model_multi_option_slug_exists;
 use function WPE\AtlasContentModeler\REST_API\Fields\content_model_reverse_slug_exists;
-use function WPE\AtlasContentModeler\REST_API\GraphQL\is_registered_field_id;
+use function WPE\AtlasContentModeler\REST_API\GraphQL\is_allowed_field_id;
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes' );
 /**
@@ -78,7 +78,7 @@ function dispatch_update_content_model_field( WP_REST_Request $request ) {
 	if (
 		$request->get_method() === 'POST' &&
 		isset( $params['slug'] ) &&
-		is_registered_field_id( $params['slug'], $graphql_type, true )
+		! is_allowed_field_id( $params, $graphql_type, true )
 	) {
 		return new WP_Error(
 			'acm_reserved_field_slug',

--- a/tests/acceptance/CreateFieldWithReservedSlugCest.php
+++ b/tests/acceptance/CreateFieldWithReservedSlugCest.php
@@ -7,6 +7,10 @@ class CreateFieldWithReservedSlugCest {
 	/**
 	 * Checks that a field does not use a reserved slug that was registered by
 	 * WPGraphQL itself.
+	 *
+	 * The 'title' slug is not allowed by default unless 'isTitle' is also true.
+	 *
+	 * @covers WPE\AtlasContentModeler\REST_API\GraphQL\is_allowed_field_id
 	 */
 	public function i_can_not_create_a_field_with_a_reserved_default_slug( AcceptanceTester $i ) {
 		$i->loginAsAdmin();
@@ -15,12 +19,36 @@ class CreateFieldWithReservedSlugCest {
 
 		$i->click( 'Text', '.field-buttons' );
 		$i->wait( 1 );
-		$i->fillField( [ 'name' => 'name' ], 'id' );
-		$i->seeInField( '#slug', 'id' );
+		$i->fillField( [ 'name' => 'name' ], 'title' );
+		$i->seeInField( '#slug', 'title' );
 		$i->click( 'button[data-testid="edit-model-update-create-button"]' );
 
 		$i->waitForElementVisible( '.field-messages .error' );
 		$i->see( 'Identifier in use or reserved', '.field-messages .error' );
+	}
+
+	/**
+	 * Checks that a text field with a 'title' slug is allowed when 'use this
+	 * field as the entry title' is ticked.
+	 *
+	 * @covers WPE\AtlasContentModeler\REST_API\GraphQL\is_field_id_exception
+	 */
+	public function i_can_create_a_title_field_with_a_slug_of_title( AcceptanceTester $i ) {
+		$i->loginAsAdmin();
+		$content_model = $i->haveContentModel( 'Candy', 'Candies' );
+		$i->amOnWPEngineEditContentModelPage( $content_model['slug'] );
+
+		$i->click( 'Text', '.field-buttons' );
+		$i->wait( 1 );
+		$i->fillField( [ 'name' => 'name' ], 'title' );
+		$i->seeInField( '#slug', 'title' );
+		$i->checkOption( 'input[name="isTitle"]' );
+		$i->click( 'button[data-testid="edit-model-update-create-button"]' );
+		$i->wait( 1 );
+
+		$i->see( 'Text', '.field-list div.type' );
+		$i->see( 'Title', '.field-list div.widest' );
+		$i->see( 'entry title', '.field-list div.tags' );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Allows “title” as a field API identifier when “use this field as the entry title” is ticked.

Does not adjust existing data save / retrieval logic. Titles will be stored under 'title' in post meta as well as in wp_posts.post_title, but the benefits of this are:

- Does not require adjustments to our already complicated title field logic.
- Allows devs to retrieve titles from post meta or post_title without considering whether the field is marked as `isTitle`.
- Simplifies future paths to allowing editable field slugs. (If we add special logic to omit writing title data to post meta here, we may have to create the title post meta for all existing posts when a user changes a post title slug from 'title' to something else.)

https://wpengine.atlassian.net/browse/MTKA-1447

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing
Adjusts e2e tests to prove that:
- A field can have an ID of 'title' if "use this field as the entry title" is ticked.
- A field cannot have an ID of 'title' if "use this field as the entry title" is not ticked.

To test manually.
- Try to create a text field with an API identifier of 'title' without ticking 'use this field as the entry title'. You should see an error on submit.
- Try to create a text field with an API identifier of 'title' and tick 'use this field as the entry title'. This should work.
- Fetch your entries from WPGraphQL. You should see values under the 'title' field.

## Screenshots

<!--
Add screenshots from before and after if your change is visual.
-->

## Documentation Changes

<!--
Add links to documentation or wiki changes.
-->

## Dependent PRs

<!--
List dependent PRs awaiting review with this syntax:

Depends on #1234.
-->
