### PR TITLE
MTKA-1488: blueprint local file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Function get_model() to retrieve the model schema.
 - Function get_field() to retrieve the model field schema.
 - New "Add New Entry" option in content model dropdowns.
+- Added the ability to upload a ZIP file from your Local File System for BluePrints.
 
 ### Changed
 - Pressing enter in a repeating number, date or single line text field now moves focus to the next field, or adds a new field if focus is in the last field.

--- a/docs/blueprints/index.md
+++ b/docs/blueprints/index.md
@@ -6,6 +6,7 @@ Blueprints can be exported and imported using [ACM’s WP-CLI commands](../wp-cl
 
 - `wp acm blueprint export` will dump the current state of your site to a blueprint zip file.
 - `wp acm blueprint import https://example.com/path/to/blueprint.zip` will import a blueprint from a publicly-accessible URL.
+- `wp acm blueprint import /filesystem/path/to/blueprint.zip` will import a blueprint from a local File Path.
 
 ## Blueprint files
 

--- a/docs/wp-cli/index.md
+++ b/docs/wp-cli/index.md
@@ -14,18 +14,18 @@ Requires: ACM 0.14.0+.
 
 ### Description
 
-Imports an ACM blueprint from a URL.
+Imports an ACM blueprint from a URL or File Path.
 
 ### Synopsis
 
 ```
-wp acm blueprint import <url> [--skip-cleanup]
+wp acm blueprint import <path> [--skip-cleanup]
 ```
 
 ### Options
 
-`<url>`
-The URL of the blueprint zip file to fetch.
+`<path>`
+The URL or File Path of the blueprint zip file.
 
 `[--skip-cleanup]`
 Skips removal of the blueprint zip and manifest files after a
@@ -35,6 +35,7 @@ record of content and files that were installed.
 ### Examples
 
 `wp acm blueprint import https://example.com/path/to/blueprint.zip`
+`wp acm blueprint import /filesystem/path/to/blueprint.zip`
 
 ## wp acm blueprint export
 

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -18,9 +18,9 @@ use WP_Error;
 function get_blueprint( string $path ) {
 	if ( filter_var( $path, FILTER_VALIDATE_URL ) ) {
 		return get_remote_blueprint( $path );
-	} else {
-		return get_local_blueprint( $path );
 	}
+
+	return get_local_blueprint( $path );
 }
 
 /**

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -30,7 +30,6 @@ function get_blueprint( string $path ) {
  * @return string|WP_Error
  */
 function get_local_blueprint( string $path ) {
-
 	if ( ! is_readable( $path ) ) {
 		return new WP_Error(
 			'acm_blueprint_file_not_readable',

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -34,7 +34,7 @@ function get_local_blueprint( string $path ) {
 	if ( ! is_readable( $path ) ) {
 		return new WP_Error(
 			'acm_blueprint_file_not_readable',
-			esc_html__( 'Received empty response body.', 'atlas-content-modeler' )
+			esc_html__( 'File not found or not readable.', 'atlas-content-modeler' )
 		);
 	}
 

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -10,7 +10,46 @@ namespace WPE\AtlasContentModeler\Blueprint\Fetch;
 use WP_Error;
 
 /**
- * Downloads a blueprint zip file from the specified URL.
+ * Gets blueprint from either local or remote path.
+ *
+ * @param string $path The path to the file.
+ * @return string
+ */
+function get_blueprint( string $path ) {
+	if ( filter_var( $path, FILTER_VALIDATE_URL ) ) {
+		return get_remote_blueprint( $path );
+	} else {
+		return get_local_blueprint( $path );
+	}
+}
+
+/**
+ * Downloads a blueprint zip file from the specified local path.
+ *
+ * @param string $path The path to the zip file.
+ * @return string|WP_Error
+ */
+function get_local_blueprint( string $path ) {
+	if ( ! file_exists( $path ) ) {
+		return new WP_Error(
+			'acm_blueprint_invalid_file_path',
+			esc_html__( 'File path was invalid.', 'atlas-content-modeler' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	if ( ! is_readable( $path ) ) {
+		return new WP_Error(
+			'acm_blueprint_file_not_readable',
+			esc_html__( 'Received empty response body.', 'atlas-content-modeler' )
+		);
+	}
+
+	return file_get_contents( $path ); // phpcs:ignore
+}
+
+/**
+ * Downloads a blueprint zip file from the specified remote URL.
  *
  * @param string $url URL to the blueprint zip file.
  *

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -30,13 +30,6 @@ function get_blueprint( string $path ) {
  * @return string|WP_Error
  */
 function get_local_blueprint( string $path ) {
-	if ( ! file_exists( $path ) ) {
-		return new WP_Error(
-			'acm_blueprint_invalid_file_path',
-			esc_html__( 'File path was invalid.', 'atlas-content-modeler' ),
-			[ 'status' => 400 ]
-		);
-	}
 
 	if ( ! is_readable( $path ) ) {
 		return new WP_Error(

--- a/includes/wp-cli/class-blueprint.php
+++ b/includes/wp-cli/class-blueprint.php
@@ -30,7 +30,7 @@ use function WPE\AtlasContentModeler\Blueprint\Import\{
 	unzip_blueprint
 };
 use function WPE\AtlasContentModeler\REST_API\Models\create_models;
-use function WPE\AtlasContentModeler\Blueprint\Fetch\get_remote_blueprint;
+use function WPE\AtlasContentModeler\Blueprint\Fetch\get_blueprint;
 use function WPE\AtlasContentModeler\Blueprint\Fetch\save_blueprint_to_upload_dir;
 use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_types;
 use function WPE\AtlasContentModeler\ContentRegistration\Taxonomies\get_acm_taxonomies;
@@ -53,12 +53,12 @@ use function WPE\AtlasContentModeler\Blueprint\Export\{
  */
 class Blueprint {
 	/**
-	 * Imports an ACM blueprint from a URL.
+	 * Imports an ACM blueprint from a PATH or URL.
 	 *
 	 * ## OPTIONS
 	 *
-	 * <url>
-	 * : The URL of the blueprint zip file to fetch.
+	 * <path>
+	 * : The URL or local path of the blueprint zip file.
 	 *
 	 * [--skip-cleanup]
 	 * : Skips removal of the blueprint zip and manifest files after a
@@ -73,15 +73,15 @@ class Blueprint {
 	 * @param array $assoc_args Optional flags passed to the command.
 	 */
 	public function import( $args, $assoc_args ) {
-		list( $url ) = $args;
+		list( $path ) = $args;
 
 		\WP_CLI::log( 'Fetching zip.' );
-		$zip_file = get_remote_blueprint( $url );
+		$zip_file = get_blueprint( $path );
 		if ( is_wp_error( $zip_file ) ) {
 			\WP_CLI::error( $zip_file->get_error_message() );
 		}
 
-		$valid_file = save_blueprint_to_upload_dir( $zip_file, basename( $url ) );
+		$valid_file = save_blueprint_to_upload_dir( $zip_file, basename( $path ) );
 		if ( is_wp_error( $valid_file ) ) {
 			\WP_CLI::error( $valid_file->get_error_message() );
 		}

--- a/tests/integration/blueprints/test-blueprint-downloads.php
+++ b/tests/integration/blueprints/test-blueprint-downloads.php
@@ -23,7 +23,9 @@ class TestBlueprintDownloadTestCases extends WP_UnitTestCase {
 
 		$blueprint = get_local_blueprint( __DIR__ . '/test-data/acm-rabbits.zip' );
 		$this->assertNotWPError( $blueprint );
-		self::assertSame( 'application/zip', mime_content_type( $blueprint ) );
+
+		$file_info = new finfo( FILEINFO_MIME_TYPE );
+		self::assertSame( 'application/zip', $file_info->buffer( $blueprint ) );
 	}
 
 	/**

--- a/tests/integration/blueprints/test-blueprint-downloads.php
+++ b/tests/integration/blueprints/test-blueprint-downloads.php
@@ -24,8 +24,8 @@ class TestBlueprintDownloadTestCases extends WP_UnitTestCase {
 		$blueprint = get_local_blueprint( __DIR__ . '/test-data/acm-rabbits.zip' );
 		$this->assertNotWPError( $blueprint );
 
-		$file_info = new finfo( FILEINFO_MIME_TYPE );
-		self::assertSame( 'application/zip', $file_info->buffer( $blueprint ) );
+		$file_info = new finfo( FILEINFO_MIME );
+		self::assertSame( 'application/zip; charset=binary', $file_info->buffer( $blueprint ) );
 	}
 
 	/**

--- a/tests/integration/blueprints/test-blueprint-downloads.php
+++ b/tests/integration/blueprints/test-blueprint-downloads.php
@@ -1,8 +1,30 @@
 <?php
 use function WPE\AtlasContentModeler\Blueprint\Fetch\get_remote_blueprint;
+use function WPE\AtlasContentModeler\Blueprint\Fetch\get_local_blueprint;
 use function WPE\AtlasContentModeler\Blueprint\Fetch\save_blueprint_to_upload_dir;
 
 class TestBlueprintDownloadTestCases extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::WPE\AtlasContentModeler\Blueprint\Fetch\get_local_blueprint
+	 */
+	public function test_get_local_blueprint_returns_WP_Error_when_an_empty_path_is_provided(): void {
+		$file = get_local_blueprint( '' );
+		$this->assertWPError( $file );
+	}
+
+	/**
+	 * @covers ::WPE\AtlasContentModeler\Blueprint\Fetch\get_local_blueprint
+	 */
+	public function test_get_local_blueprint_returns_valid_zip_file(): void {
+		if ( ! defined( 'FS_METHOD' ) ) {
+			define( 'FS_METHOD', 'direct' ); // Allows direct filesystem copy operations without FTP/SSH passwords. This only takes effect during testing.
+		}
+
+		$blueprint = get_local_blueprint( __DIR__ . '/test-data/acm-rabbits.zip' );
+		$this->assertNotWPError( $blueprint );
+		self::assertSame( 'application/zip', mime_content_type( $blueprint ) );
+	}
 
 	/**
 	 * @covers ::WPE\AtlasContentModeler\Blueprint\Fetch\get_remote_blueprint


### PR DESCRIPTION
## Description

What changed and why?
Updated get remote blueprint to check for the path and use local or remote function accordingly.

Link to the JIRA ticket if available.
[https://wpengine.atlassian.net/browse/MTKA-1448](https://wpengine.atlassian.net/browse/MTKA-1448)

## Testing
Added tests for local file ZIP type and for empty contents.

## Documentation Changes
Updated verbiage for blueprint cli.
