### PR TITLE
Updates deprecated php 8.1 FILTER_SANITIZE_STRING

### DIFF
--- a/includes/settings/settings-callbacks.php
+++ b/includes/settings/settings-callbacks.php
@@ -78,8 +78,8 @@ add_filter( 'parent_file', __NAMESPACE__ . '\maybe_override_submenu_file' );
 function maybe_override_submenu_file( $parent_file ) {
 	global $submenu_file;
 
-	$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
-	$view = filter_input( INPUT_GET, 'view', FILTER_SANITIZE_STRING );
+	$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+	$view = filter_input( INPUT_GET, 'view', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 	if ( $page === 'atlas-content-modeler' && $view === 'taxonomies' ) {
 		$submenu_file = 'atlas-content-modeler&amp;view=taxonomies'; // phpcs:ignore -- global override needed to set current submenu page without JavaScript.


### PR DESCRIPTION
For MTKA-1465 we need to update FILTER_SANITIZE_STRING.

`FILTER_SANITIZE_FULL_SPECIAL_CHARS` will do what we need here and is compatible 8.1.

Leaving this PR draft until I've gone through each deprecated function and change in 8.1