### PR TITLE
MTKA-1473: bypass term insertion if it already exists for blueprint import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Fixed
 - Title values are now saved to the wp_posts table as expected, instead of being exposed with WP filters. This fixes a few things, such as queries that search the post title field.
 - Post slugs are now generated from the post title value, like they are for post types built into WordPress.
+- Taxonomy terms that already exist are skipped when importing a blueprint.
 
 ## 0.16.0 - 2022-04-06
 ### Added

--- a/includes/blueprints/import.php
+++ b/includes/blueprints/import.php
@@ -297,7 +297,7 @@ function import_terms( array $post_terms ) {
 			];
 
 			// Continue if the term already exists.
-			$term_already_exists = term_exists( $term['name'], $term['taxonomy'], $term['parent'] );
+			$term_already_exists = term_exists( $term['name'], $term['taxonomy'], $term['parent'] ?? null );
 
 			if ( $term_already_exists ) {
 				continue;

--- a/includes/blueprints/import.php
+++ b/includes/blueprints/import.php
@@ -297,7 +297,7 @@ function import_terms( array $post_terms ) {
 			];
 
 			// Continue if the term already exists.
-			$term_already_exists = term_exists( $term['name'], $term['taxonomy'] );
+			$term_already_exists = term_exists( $term['name'], $term['taxonomy'], $term['parent'] );
 
 			if ( $term_already_exists ) {
 				continue;

--- a/includes/blueprints/import.php
+++ b/includes/blueprints/import.php
@@ -296,6 +296,13 @@ function import_terms( array $post_terms ) {
 				'description' => $term['description'] ?? '',
 			];
 
+			// Continue if the term already exists.
+			$term_already_exists = term_exists( $term['name'], $term['taxonomy'] );
+
+			if ( $term_already_exists ) {
+				continue;
+			}
+
 			$inserted_term = wp_insert_term( $term['name'], $term['taxonomy'], $term_info );
 
 			if ( is_wp_error( $inserted_term ) ) {


### PR DESCRIPTION
## Description

Skip term insertion if it already exists during blueprint zip import.