### PR TITLE
MTKA-1493: Ensure repeating fields return non-null value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 ### Changed
 - Text fields can now use “title” as their API identifier if “use this field as the entry title” is ticked.
+### Fixed
+- Issue where adding a new repeating field to an existing model schema could break GraphQL queries under certain conditions.
+- Empty field values are no longer saved to the database.
 
 ## 0.17.0 - 2022-05-05
 ### Added

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -425,6 +425,12 @@ final class FormEditingExperience {
 
 		foreach ( $posted_values as $key => $value ) {
 			$key = sanitize_text_field( $key );
+
+			// Do not save empty values.
+			if ( empty( $value ) ) {
+				continue;
+			}
+
 			/**
 			 * Check if an existing value matches the submitted value
 			 * and short-circuit the loop. Otherwise `update_post_meta`

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -380,6 +380,16 @@ final class FormEditingExperience {
 					}
 				} else {
 					$existing = get_post_meta( $post_id, sanitize_text_field( $slug ), true );
+					// Clean up empty values already saved in db.
+					if ( $existing === '' || $existing === [] ) {
+						$deleted = delete_post_meta( $post_id, sanitize_text_field( $slug ) );
+						if ( ! $deleted ) {
+							/* translators: %s: atlas content modeler field slug */
+							$this->error_save_post = sprintf( __( 'There was an error deleting the %s field data.', 'atlas-content-modeler' ), $slug );
+						}
+						continue;
+					}
+
 					if ( empty( $existing ) ) {
 						continue;
 					}

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -424,4 +424,42 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
 		}
 	}
+
+	public function test_adding_new_repeating_field_to_existing_model_does_not_break_graphql_queries(): void {
+		$new_field = array(
+			'show_in_rest'      => true,
+			'show_in_graphql'   => true,
+			'type'              => 'email',
+			'id'                => '1651005489',
+			'position'          => '500000',
+			'name'              => 'New-Email-Repeater',
+			'slug'              => 'newEmailRepeater',
+			'isRepeatableEmail' => 'true',
+			'required'          => true,
+		);
+
+		$this->test_models['public-fields']['fields']['1651005489'] = $new_field;
+		update_registered_content_types( $this->test_models );
+
+		try {
+			$results = graphql(
+				[
+					'query' => '
+				{
+					publicsFields {
+						nodes {
+							databaseId
+							newEmailRepeater
+						}
+					}
+				}
+				',
+				]
+			);
+
+			self::assertSame( [], $results['data']['publicsFields']['nodes'][0]['newEmailRepeater'] );
+		} catch ( Exception $exception ) {
+			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
+		}
+	}
 }


### PR DESCRIPTION
## Description
Fixes issue where it's possible for a repeating field to break WPGraphQL queries due to returning null when an iterable is expected.

If you edit a model schema and add a new repeating field after entries have been created, and then you run a GraphQL query that contains that field, it's likely the query will be broken until existing posts have been edited.
Error message:
> "User Error: expected iterable, but did not find one for field BusinessDetail.phoneNumbers."

**Steps to reproduce:**
1. Create a new model
2. Add a single entry for that model
3. Edit the model and add a repeating field (configure as not required)
4. Click the Open in GraphiQL link
5. Run the pre-filled query that includes the new repeating field name
6. See error
7. Edit previously-created entry, do not add any values to the repeating field you just added, update the post.
8. Run GraphQL query again
9. See that error is gone

This PR address this issue by ensuring we return an array if the field is repeatable.

Related, our save post logic is saving empty arrays to the database, which fixes the query problem but is not ideal because:
- We can't expect users to edit all of their existing entries to fix queries when they decide to add fields to their schemas.
- We really shouldn't be littering the database with empty values.

This PR address this save post issue by:
- Not saving empty values
- Cleaning up empty values if they exist

<!--
Link to the JIRA ticket if available.
-->

https://wpengine.atlassian.net/browse/MTKA-1493

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing
Existing tests continue to pass.

New test passes

### Manual steps to test:
Using a new model, repeat steps 1-5 from above. You should see no errors.

