### PR TITLE
[NOJIRA] Extend blueprint import timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Crud function insert_model_entry() will now append relationship ids.
 - Text field entries via CRUD are now validated for min and max characters.
 - Text field entries created via the PHP API are now validated for minRepeatable and maxRepeatable.
+- Extended timeout for `wp acm blueprint import` command from 5 seconds to 15 seconds.
 
 ### Fixed
 - Issue where adding a new repeating field to an existing model schema could break GraphQL queries under certain conditions.

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -13,7 +13,7 @@ use WP_Error;
  * Gets blueprint from either local or remote path.
  *
  * @param string $path The path to the file.
- * @return string
+ * @return string|WP_Error
  */
 function get_blueprint( string $path ) {
 	if ( filter_var( $path, FILTER_VALIDATE_URL ) ) {
@@ -56,7 +56,7 @@ function get_remote_blueprint( string $url ) {
 		);
 	}
 
-	$response = wp_remote_get( $url );
+	$response = wp_remote_get( $url, [ 'timeout' => 15 ] );
 
 	if ( is_wp_error( $response ) ) {
 		return new WP_Error(


### PR DESCRIPTION
## Description

Extends the timeout for getting remote zip files during `wp acm blueprint import` to 15 seconds from the default of 5.

To reduce observed timeouts while fetching blueprints:

```sh
x wp acm blueprint import https://raw.githubusercontent.com/wpengine/atlas-blueprint-portfolio/main/acm-blueprint.zip
Fetching zip.
Error: cURL error 28: Operation timed out after 5000 milliseconds with 4308047 out of 4718267 bytes received
```

15 is arbitrary but seems safer than 5.

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

No automated tests required.

You could try running this command over a slow connection to check it completes more consistently:

```
wp acm blueprint import https://raw.githubusercontent.com/wpengine/atlas-blueprint-portfolio/main/acm-blueprint.zip
```
