### PR TITLE
chore: Bump "Tested up to" to 6.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Atlas Content Modeler ===
 Requires at least: 5.7
-Tested up to: 5.9.3
+Tested up to: 6.0
 Requires PHP: 7.2
 Stable tag: 0.17.0
 License: GPLv2 or later


### PR DESCRIPTION
## Description

Updates the "Tested up to" value to 6.0, so that WP doesn't show a warning about it not being tested with WP 6.0.

We typically do this as part of the release PR, but I wanted to do it now since someone brought it to our attention and it was fresh on my mind.