### PR TITLE
ci: specify Node 16.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
   plugin-build-npm:
     executor:
       name: node/default
-      tag: lts
+      tag: '16.13.0'
     parameters:
       slug:
         type: string
@@ -134,7 +134,7 @@ jobs:
   plugin-build-readme:
     executor:
       name: node/default
-      tag: lts
+      tag: '16.13.0'
     parameters:
       slug:
         type: string
@@ -336,7 +336,7 @@ jobs:
   plugin-test-jest:
     executor:
       name: node/default
-      tag: lts
+      tag: '16.13.0'
     parameters:
       slug:
         type: string
@@ -355,7 +355,7 @@ jobs:
   plugin-test-lint-js:
     executor:
       name: node/default
-      tag: lts
+      tag: '16.13.0'
     parameters:
       slug:
         type: string


### PR DESCRIPTION
## Description

Addresses recent build errors, which appear to be related to Node versioning. https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler?status=none&status=failed

I used the SSH option to debug what's going on in the container. Node 16.15.x was installed, and it fails on that version. I installed 16.13.0 and that fixes it. Not sure why it wasn't reading our `.nvmrc` config. This is a temp fix until we can upgrade things to work with newer versions, and should unblock all the other PRs.

