### PR TITLE
[NO-JIRA] Accept local directory as blueprint import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Added
+- The `wp acm blueprint import` WP-CLI command can now take a path to a local directory containing an `acm.json` blueprint manifest.
+
+
 ## 0.18.0 - 2022-06-16
 ### Changed
 - Text fields can now use “title” as their API identifier if “use this field as the entry title” is ticked.

--- a/docs/wp-cli/index.md
+++ b/docs/wp-cli/index.md
@@ -25,7 +25,7 @@ wp acm blueprint import <path> [--skip-cleanup]
 ### Options
 
 `<path>`
-The URL or local path of the blueprint zip file, or local path to the blueprint folder containing the acm json manifest file. Local paths must be absolute.
+The URL or local path of the blueprint zip file, or local path to the blueprint folder containing the acm.json manifest file. Local paths must be absolute.
 
 `[--skip-cleanup]`
 Skips removal of the blueprint zip and manifest files after a

--- a/docs/wp-cli/index.md
+++ b/docs/wp-cli/index.md
@@ -25,7 +25,7 @@ wp acm blueprint import <path> [--skip-cleanup]
 ### Options
 
 `<path>`
-The URL or File Path of the blueprint zip file.
+The URL or local path of the blueprint zip file, or local path to the blueprint folder containing the acm json manifest file. Local paths must be absolute.
 
 `[--skip-cleanup]`
 Skips removal of the blueprint zip and manifest files after a
@@ -34,8 +34,11 @@ record of content and files that were installed.
 
 ### Examples
 
-`wp acm blueprint import https://example.com/path/to/blueprint.zip`
-`wp acm blueprint import /filesystem/path/to/blueprint.zip`
+```
+wp acm blueprint import https://example.com/path/to/blueprint.zip
+wp acm blueprint import /local/path/to/blueprint.zip
+wp acm blueprint import /local/path/to/blueprint-folder/
+```
 
 ## wp acm blueprint export
 

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -33,7 +33,7 @@ function get_local_blueprint( string $path ) {
 	if ( ! is_readable( $path ) ) {
 		return new WP_Error(
 			'acm_blueprint_file_not_readable',
-			esc_html__( 'File not found or not readable.', 'atlas-content-modeler' )
+			esc_html__( 'File or directory not found or readable.', 'atlas-content-modeler' )
 		);
 	}
 

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -108,18 +108,25 @@ function save_blueprint_to_upload_dir( string $blueprint, string $filename ) {
 	}
 
 	$destination      = trailingslashit( wp_upload_dir()['path'] ) . $filename;
-	$is_absolute_path = '/' === $blueprint[0];
+	$is_absolute_path = $blueprint[0] === '/' ?? false;
 
 	/**
 	 * Copy blueprints given as a path to a local directory to the WordPress
 	 * upload directory. Ensures media is accessible to WordPress, and will
 	 * stay accessible if the original blueprint path is moved or removed.
 	 */
-
 	if (
-		$is_absolute_path
-		&& pathinfo( $blueprint, PATHINFO_EXTENSION ) !== 'zip'
+		$is_absolute_path &&
+		pathinfo( $blueprint, PATHINFO_EXTENSION ) === ''
 	) {
+		if ( ! $wp_filesystem->is_dir( $blueprint ) ) {
+			return new WP_Error(
+				'acm_blueprint_save_error',
+				/* translators: path to blueprint */
+				sprintf( esc_html__( 'Could not read directory at %s', 'atlas-content-modeler' ), $blueprint )
+			);
+		}
+
 		$wp_filesystem->mkdir( $destination );
 
 		$copied = copy_dir( $blueprint, $destination );

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -9,8 +9,6 @@ namespace WPE\AtlasContentModeler\Blueprint\Fetch;
 
 use WP_Error;
 
-use function WP_CLI\Utils\is_path_absolute;
-
 /**
  * Gets blueprint from either local or remote path.
  *

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -9,6 +9,8 @@ namespace WPE\AtlasContentModeler\Blueprint\Fetch;
 
 use WP_Error;
 
+use function WP_CLI\Utils\is_path_absolute;
+
 /**
  * Gets blueprint from either local or remote path.
  *
@@ -107,14 +109,18 @@ function save_blueprint_to_upload_dir( string $blueprint, string $filename ) {
 		\WP_Filesystem();
 	}
 
-	$destination = trailingslashit( wp_upload_dir()['path'] ) . $filename;
+	$destination      = trailingslashit( wp_upload_dir()['path'] ) . $filename;
+	$is_absolute_path = '/' === $blueprint[0];
 
 	/**
 	 * Copy blueprints given as a path to a local directory to the WordPress
 	 * upload directory. Ensures media is accessible to WordPress, and will
 	 * stay accessible if the original blueprint path is moved or removed.
 	 */
-	if ( is_dir( $blueprint ) ) {
+	if (
+		$is_absolute_path
+		&& is_dir( $blueprint )
+	) {
 		$wp_filesystem->mkdir( $destination );
 
 		$copied = copy_dir( $blueprint, $destination );

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -115,9 +115,10 @@ function save_blueprint_to_upload_dir( string $blueprint, string $filename ) {
 	 * upload directory. Ensures media is accessible to WordPress, and will
 	 * stay accessible if the original blueprint path is moved or removed.
 	 */
+
 	if (
 		$is_absolute_path
-		&& is_dir( $blueprint )
+		&& pathinfo( $blueprint, PATHINFO_EXTENSION ) !== 'zip'
 	) {
 		$wp_filesystem->mkdir( $destination );
 

--- a/includes/blueprints/fetch.php
+++ b/includes/blueprints/fetch.php
@@ -96,9 +96,9 @@ function get_remote_blueprint( string $url ) {
  * Saves the provided blueprint zip file to the uploads directory.
  *
  * @param string $blueprint The blueprint zip file or path to a local blueprint directory.
- * @param string $filename  The name of the file to be saved.
+ * @param string $filename  The name of the file or directory to be saved.
  *
- * @return string|WP_Error Local blueprint zip file destination path on success.
+ * @return string|WP_Error Local blueprint zip file or directory destination path on success.
  */
 function save_blueprint_to_upload_dir( string $blueprint, string $filename ) {
 	global $wp_filesystem;

--- a/includes/wp-cli/class-blueprint.php
+++ b/includes/wp-cli/class-blueprint.php
@@ -80,7 +80,7 @@ class Blueprint {
 	 */
 	public function import( $args, $assoc_args ) {
 		list( $path )      = $args;
-		$path_is_directory = is_dir( $path );
+		$path_is_directory = pathinfo( $path, PATHINFO_EXTENSION ) === '';
 
 		if ( $path_is_directory ) {
 			$blueprint_folder = save_blueprint_to_upload_dir( $path, basename( $path ) );

--- a/includes/wp-cli/class-blueprint.php
+++ b/includes/wp-cli/class-blueprint.php
@@ -58,39 +58,55 @@ class Blueprint {
 	 * ## OPTIONS
 	 *
 	 * <path>
-	 * : The URL or local path of the blueprint zip file.
+	 * : The URL or local path of the blueprint zip file, or local path to the
+	 * blueprint folder containing the acm.json manifest file. Local paths must
+	 * be absolute.
 	 *
 	 * [--skip-cleanup]
 	 * : Skips removal of the blueprint zip and manifest files after a
 	 * successful import. Useful when testing blueprints or to leave a
-	 * record of content and files that were installed.
+	 * record of content and files that were installed. Has no effect
+	 * if the `path` passed to `blueprint import` is a local directory
+	 * and not a zip file.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp acm blueprint import https://example.com/path/to/blueprint.zip
+	 *     wp acm blueprint import /local/path/to/blueprint.zip
+	 *     wp acm blueprint import /local/path/to/blueprint-folder/
 	 *
 	 * @param array $args Options passed to the command.
 	 * @param array $assoc_args Optional flags passed to the command.
 	 */
 	public function import( $args, $assoc_args ) {
-		list( $path ) = $args;
+		list( $path )      = $args;
+		$path_is_directory = is_dir( $path );
 
-		\WP_CLI::log( 'Fetching zip.' );
-		$zip_file = get_blueprint( $path );
-		if ( is_wp_error( $zip_file ) ) {
-			\WP_CLI::error( $zip_file->get_error_message() );
+		if ( $path_is_directory ) {
+			$blueprint_folder = save_blueprint_to_upload_dir( $path, basename( $path ) );
+			if ( is_wp_error( $blueprint_folder ) ) {
+				\WP_CLI::error( $blueprint_folder->get_error_message() );
+			}
 		}
 
-		$valid_file = save_blueprint_to_upload_dir( $zip_file, basename( $path ) );
-		if ( is_wp_error( $valid_file ) ) {
-			\WP_CLI::error( $valid_file->get_error_message() );
-		}
+		if ( ! $path_is_directory ) {
+			\WP_CLI::log( 'Fetching blueprint.' );
+			$zip_file = get_blueprint( $path );
+			if ( is_wp_error( $zip_file ) ) {
+				\WP_CLI::error( $zip_file->get_error_message() );
+			}
 
-		\WP_CLI::log( 'Unzipping.' );
-		$blueprint_folder = unzip_blueprint( $valid_file );
+			$valid_file = save_blueprint_to_upload_dir( $zip_file, basename( $path ) );
+			if ( is_wp_error( $valid_file ) ) {
+				\WP_CLI::error( $valid_file->get_error_message() );
+			}
 
-		if ( is_wp_error( $blueprint_folder ) ) {
-			\WP_CLI::error( $blueprint_folder->get_error_message() );
+			\WP_CLI::log( 'Unzipping.' );
+			$blueprint_folder = unzip_blueprint( $valid_file );
+
+			if ( is_wp_error( $blueprint_folder ) ) {
+				\WP_CLI::error( $blueprint_folder->get_error_message() );
+			}
 		}
 
 		\WP_CLI::log( 'Verifying ACM manifest.' );
@@ -199,7 +215,10 @@ class Blueprint {
 			import_options( $manifest['wp-options'] );
 		}
 
-		if ( ! ( $assoc_args['skip-cleanup'] ?? false ) ) {
+		if (
+			! ( $assoc_args['skip-cleanup'] ?? false )
+			&& ! $path_is_directory
+		) {
 			\WP_CLI::log( 'Deleting zip and manifest.' );
 			cleanup( $zip_file, $blueprint_folder );
 		}

--- a/tests/integration/blueprints/test-blueprint-downloads.php
+++ b/tests/integration/blueprints/test-blueprint-downloads.php
@@ -115,7 +115,7 @@ class TestBlueprintDownloadTestCases extends WP_UnitTestCase {
 			define( 'FS_METHOD', 'direct' ); // Allows direct filesystem copy operations without FTP/SSH passwords. This only takes effect during testing.
 		}
 
-		$blueprint_folder = '/app/tests/integration/blueprints/test-data/blueprint-good';
+		$blueprint_folder = __DIR__ . '/test-data/blueprint-good';
 		$destination      = save_blueprint_to_upload_dir( $blueprint_folder, 'blueprint-good' );
 		self::assertTrue( is_readable( $destination ) );
 		self::assertTrue( is_dir( $destination ) );
@@ -129,7 +129,7 @@ class TestBlueprintDownloadTestCases extends WP_UnitTestCase {
 			define( 'FS_METHOD', 'direct' ); // Allows direct filesystem copy operations without FTP/SSH passwords. This only takes effect during testing.
 		}
 
-		$non_existent_blueprint_folder = '/app/tests/integration/blueprints/test-data/this-blueprint-does-not-exist';
+		$non_existent_blueprint_folder = __DIR__ . '/test-data/this-blueprint-does-not-exist';
 		$destination                   = save_blueprint_to_upload_dir( $non_existent_blueprint_folder, 'this-blueprint-does-not-exist' );
 		$this->assertWPError( $destination );
 		self::assertSame( 'acm_blueprint_save_error', $destination->get_error_code() );

--- a/tests/integration/blueprints/test-blueprint-downloads.php
+++ b/tests/integration/blueprints/test-blueprint-downloads.php
@@ -108,6 +108,35 @@ class TestBlueprintDownloadTestCases extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::WPE\AtlasContentModeler\Blueprint\Fetch\save_blueprint_to_upload_dir
+	 */
+	public function test_save_blueprint_to_upload_dir_copies_directory_when_given_a_good_local_directory(): void {
+		if ( ! defined( 'FS_METHOD' ) ) {
+			define( 'FS_METHOD', 'direct' ); // Allows direct filesystem copy operations without FTP/SSH passwords. This only takes effect during testing.
+		}
+
+		$blueprint_folder = '/app/tests/integration/blueprints/test-data/blueprint-good';
+		$destination      = save_blueprint_to_upload_dir( $blueprint_folder, 'blueprint-good' );
+		self::assertTrue( is_readable( $destination ) );
+		self::assertTrue( is_dir( $destination ) );
+	}
+
+	/**
+	 * @covers ::WPE\AtlasContentModeler\Blueprint\Fetch\save_blueprint_to_upload_dir
+	 */
+	public function test_save_blueprint_to_upload_dir_gives_error_when_given_a_bad_local_directory(): void {
+		if ( ! defined( 'FS_METHOD' ) ) {
+			define( 'FS_METHOD', 'direct' ); // Allows direct filesystem copy operations without FTP/SSH passwords. This only takes effect during testing.
+		}
+
+		$non_existent_blueprint_folder = '/app/tests/integration/blueprints/test-data/this-blueprint-does-not-exist';
+		$destination                   = save_blueprint_to_upload_dir( $non_existent_blueprint_folder, 'this-blueprint-does-not-exist' );
+		$this->assertWPError( $destination );
+		self::assertSame( 'acm_blueprint_save_error', $destination->get_error_code() );
+		self::assertStringStartsWith( 'Could not read directory at', $destination->get_error_message() );
+	}
+
+	/**
 	 * Returns test blueprint data.
 	 *
 	 * @return string


### PR DESCRIPTION
## Description

Allows import of blueprints by passing the path to a local folder containing an acm.json file:

```
wp acm blueprint import /Users/[your.name]/Sites/local/app/public/wp-content/plugins/atlas-content-modeler/tests/integration/blueprints/test-data/blueprint-good
```

In preparation for https://wpengine.atlassian.net/browse/MTKA-1376 (“Create ACM developer blueprint file and documentation”), so that we can store and import developer blueprint samples locally in directories instead of zip files.

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

Extended existing blueprint tests to check that copying a folder works the same way as copying a zip file.

To test manually:

Run this WP-CLI command to reset your ACM models/taxomonies:

```
wp option delete atlas_content_modeler_taxonomies && wp option delete atlas_content_modeler_post_types
```

Then run this command, replacing `/Users/[your.name]/Sites/local/app/public/` with the path to your local WP root.

```
> wp acm blueprint import /Users/[your.name]/Sites/local/app/public/wp-content/plugins/atlas-content-modeler/tests/integration/blueprints/test-data/blueprint-good
Verifying ACM manifest.
Checking minimum versions.
Importing ACM models and fields.
Importing ACM taxonomies.
Importing posts.
Importing terms.
Tagging posts.
Importing media.
Importing post meta.
Restoring ACM relationships.
Restoring WordPress options.
Success: Import complete.
```

A bad path should return an error:

```sh
> wp acm blueprint import /Users/nick.cernis/Sites/local/app/public/wp-content/plugins/atlas-content-modeler/tests/integration/blueprints/test-data/blueprint-go
Error: Could not read directory at /Users/nick.cernis/Sites/local/app/public/wp-content/plugins/atlas-content-modeler/tests/integration/blueprints/test-data/blueprint-go
```

Import commands for local and remote zip files should behave as before:

LOCAL ZIP:

```
> wp acm blueprint import /Users/nick.cernis/Sites/local/app/public/wp-content/plugins/atlas-content-modeler/tests/integration/blueprints/test-data/acm-rabbits.zip
Cannot load Zend OPcache - it was already loaded
Fetching blueprint.
Unzipping.
Verifying ACM manifest.
Checking minimum versions.
Importing ACM models and fields.
Importing ACM taxonomies.
Importing posts.
Importing terms.
Tagging posts.
Importing media.
Importing post meta.
Restoring ACM relationships.
Deleting zip and manifest.
Success: Import complete.
```

REMOTE ZIP:

```sh
> wp acm blueprint import https://raw.githubusercontent.com/wpengine/atlas-blueprint-portfolio/main/acm-blueprint.zip
Fetching blueprint.
Unzipping.
Verifying ACM manifest.
Checking minimum versions.
Importing ACM models and fields.
Importing posts.
Importing terms.
Tagging posts.
Importing media.
Importing post meta.
Restoring WordPress options.
Deleting zip and manifest.
Success: Import complete.
```

## Screenshots

```sh
local/app/public
> wp acm blueprint import /Users/nick.cernis/Sites/local/app/public/wp-content/plugins/atlas-content-modeler/tests/integration/blueprints/test-data/blueprint-good
Verifying ACM manifest.
Checking minimum versions.
Importing ACM models and fields.
Importing ACM taxonomies.
Importing posts.
Importing terms.
Tagging posts.
Importing media.
Importing post meta.
Restoring ACM relationships.
Restoring WordPress options.
Success: Import complete.
```

<img width="548" alt="Screenshot 2022-06-22 at 15 18 26" src="https://user-images.githubusercontent.com/647669/175038812-89b67d43-5bc5-43cd-9be7-ac4ea8d4caf3.png">

<img width="322" alt="Screenshot 2022-06-22 at 15 18 37" src="https://user-images.githubusercontent.com/647669/175038822-4e6015ef-a220-46b9-a896-dddb402fd0c7.png">

## Documentation Changes

Includes adjustments to WP-CLI docs.
