### PR TITLE
Adds recommendations for reverse relationships in documentation

### DIFF
--- a/docs/crud/index.md
+++ b/docs/crud/index.md
@@ -62,7 +62,7 @@ The following examples with use a Rabbit model with a slug of `rabbit`. The Rabb
 
 #### Example #2 Successful content model creation with relationship in forward direction.
 
-Inserting enries in a reverse relationship is currently unsupported in the reverse direction. If a reverse relationship entry is needed, it is advised to insert or update in the forward direction from the model that has the relationship field.
+Inserting entries in a reverse relationship is currently unsupported in the reverse direction. If a reverse relationship entry is needed, it is advised to insert or update in the forward direction from the model that has the relationship field.
 
 ```php
 use function WPE\AtlasContentModeler\API\insert_model_entry;

--- a/docs/crud/index.md
+++ b/docs/crud/index.md
@@ -62,7 +62,7 @@ The following examples with use a Rabbit model with a slug of `rabbit`. The Rabb
 
 #### Example #2 Successful content model creation with relationship in forward direction.
 
-Inserting enries in a reverse relationship is currently unsupported in the reverse direction. If a reverse relationship entry is needed, it is advisded to insert or update in the forward direction from the model that has the relationship field.
+Inserting enries in a reverse relationship is currently unsupported in the reverse direction. If a reverse relationship entry is needed, it is advised to insert or update in the forward direction from the model that has the relationship field.
 
 ```php
 use function WPE\AtlasContentModeler\API\insert_model_entry;

--- a/docs/crud/index.md
+++ b/docs/crud/index.md
@@ -53,7 +53,37 @@ Will result in the following
 int(139)
 ```
 
-#### Example #2 Unsuccessful content model creation.
+### Examples
+
+The following examples with use a Rabbit model with a slug of `rabbit`. The Rabbit model has the following three fields:
+- Name `name` (text, required)
+- Color `color` (text, required)
+- Breed `breed` (relationship, reverse enabled)
+
+#### Example #2 Successful content model creation with relationship in forward direction.
+
+Inserting enries in a reverse relationship is currently unsupported in the reverse direction. If a reverse relationship entry is needed, it is advisded to insert or update in the forward direction from the model that has the relationship field.
+
+```php
+use function WPE\AtlasContentModeler\API\insert_model_entry;
+
+$model_slug = 'rabbit';
+$field_data = [
+	'name' => 'Peter',
+	'color' => 'Brown',
+	'breed' => 138,
+];
+
+$post_id = insert_model_entry( $model_slug, $field_data );
+
+var_dump( $post_id );
+```
+Will result in the following
+```
+int(139)
+```
+
+#### Example #3 Unsuccessful content model creation.
 ```php
 use function WPE\AtlasContentModeler\API\insert_model_entry;
 


### PR DESCRIPTION
This PR adds recommendations on using reverse relationships to encourage inserting/updating using the forward direction instead of the reverse due to how an insert is only ever relative to itself and reverse relationships are changing the properties of another post.