### PR TITLE
MTKA-1530: Add 'edit' link to related entry row options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - The `wp acm blueprint import` WP-CLI command can now take a path to a local directory containing an `acm.json` blueprint manifest.
 - Developers working on the ACM plugin can now use the `wp acm blueprint import demo` WP-CLI command to import demo models with different field configurations.
-- Related entries in relationship fields now have a “View” link to open or edit them in a new tab.
+- Related entries in relationship fields now have an “Edit” link to view or edit them in a new tab.
 
 ## 0.18.0 - 2022-06-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - The `wp acm blueprint import` WP-CLI command can now take a path to a local directory containing an `acm.json` blueprint manifest.
 - Developers working on the ACM plugin can now use the `wp acm blueprint import demo` WP-CLI command to import demo models with different field configurations.
+- Related entries in relationship fields now have a “View” link to open or edit them in a new tab.
 
 ## 0.18.0 - 2022-06-16
 ### Changed

--- a/includes/components/icons/ExternalLink.jsx
+++ b/includes/components/icons/ExternalLink.jsx
@@ -1,17 +1,18 @@
 import React from "react";
 
-const ExternalLinkIcon = () => {
+const ExternalLinkIcon = ({ width = 16, height = 16, color = "#002838" }) => {
 	return (
 		<svg
-			width="16"
-			height="16"
+			width={width}
+			height={height}
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 			className="icon-external-link"
+			viewBox="0 0 16 16"
 		>
 			<path
 				d="M3 0a3 3 0 00-3 3v5a1 1 0 102 0V3a1 1 0 011-1h10a1 1 0 011 1v10a1 1 0 01-1 1H5.828c-.89 0-1.337-1.077-.707-1.707L9 8.414V10a1 1 0 102 0V6v-.005a.995.995 0 00-.29-.699l-.006-.006A.996.996 0 0010 5H6a1 1 0 000 2h1.586l-3.879 3.879C1.817 12.769 3.156 16 5.828 16H13a3 3 0 003-3V3a3 3 0 00-3-3H3z"
-				fill="#002838"
+				fill={color}
 			/>
 		</svg>
 	);

--- a/includes/components/icons/index.js
+++ b/includes/components/icons/index.js
@@ -25,7 +25,7 @@ import FileIcon from "./FileIcon";
 import ImgIcon from "./ImgIcon";
 import AudioIcon from "./AudioIcon";
 
-export default function Icon({ type, size, noCircle }) {
+export default function Icon({ type, size, noCircle, width, height, color }) {
 	switch (type) {
 		case "add":
 			return <AddIcon noCircle={noCircle} size={size} />;
@@ -42,7 +42,9 @@ export default function Icon({ type, size, noCircle }) {
 		case "error":
 			return <ErrorIcon size={size} />;
 		case "external-link":
-			return <ExternalLinkIcon />;
+			return (
+				<ExternalLinkIcon width={width} height={height} color={color} />
+			);
 		case "info":
 			return <InfoIcon />;
 		case "link":

--- a/includes/publisher/js/src/components/relationship/Options.jsx
+++ b/includes/publisher/js/src/components/relationship/Options.jsx
@@ -1,3 +1,4 @@
+/* global atlasContentModelerFormEditingExperience */
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import Icon from "acm-icons";
 import { maybeCloseDropdown } from "../../../../../settings/js/src/utils";

--- a/includes/publisher/js/src/components/relationship/Options.jsx
+++ b/includes/publisher/js/src/components/relationship/Options.jsx
@@ -81,6 +81,12 @@ const Options = ({ entry, setSelectedEntries }) => {
 					)}
 				>
 					{__("View", "atlas-content-modeler")}
+					<Icon
+						type="external-link"
+						width="13"
+						height="13"
+						color="#7e5cef"
+					/>
 				</a>
 				<a
 					className="delete"

--- a/includes/publisher/js/src/components/relationship/Options.jsx
+++ b/includes/publisher/js/src/components/relationship/Options.jsx
@@ -4,6 +4,8 @@ import { maybeCloseDropdown } from "../../../../../settings/js/src/utils";
 import { sprintf, __ } from "@wordpress/i18n";
 import { Dropdown } from "../../../../../shared-assets/js/components/Dropdown";
 
+const { adminUrl } = atlasContentModelerFormEditingExperience;
+
 const Options = ({ entry, setSelectedEntries }) => {
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const timer = useRef(null);
@@ -60,6 +62,26 @@ const Options = ({ entry, setSelectedEntries }) => {
 				<Icon type="options" />
 			</button>
 			<div className={`dropdown-content ${dropdownOpen ? "" : "hidden"}`}>
+				<a
+					className="view"
+					href={`${adminUrl}post.php?post=${entry.id}&action=edit`}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={() => {
+						setDropdownOpen(false);
+					}}
+					onBlur={() => maybeCloseDropdown(setDropdownOpen, timer)}
+					aria-label={sprintf(
+						/* translators: title of the entry to view. */
+						__(
+							"View the %s entry in a new tab.",
+							"atlas-content-modeler"
+						),
+						entry?.title?.rendered
+					)}
+				>
+					{__("View", "atlas-content-modeler")}
+				</a>
 				<a
 					className="delete"
 					href="#"

--- a/includes/publisher/js/src/components/relationship/Options.jsx
+++ b/includes/publisher/js/src/components/relationship/Options.jsx
@@ -42,6 +42,10 @@ const Options = ({ entry, setSelectedEntries }) => {
 		return () => clearTimeout(timer.current);
 	}, [timer]);
 
+	const relatedModelSingularTitle =
+		atlasContentModelerFormEditingExperience?.models[entry.type]
+			?.singular ?? __("Entry", "atlas-content-modeler");
+
 	return (
 		<Dropdown>
 			<button
@@ -78,7 +82,11 @@ const Options = ({ entry, setSelectedEntries }) => {
 						entry?.title?.rendered
 					)}
 				>
-					{__("View", "atlas-content-modeler")}
+					{sprintf(
+						/* translators: Custom post type singular name, such as Cat. */
+						__("View %s", "atlas-content-modeler"),
+						relatedModelSingularTitle
+					)}
 					<Icon
 						type="external-link"
 						width="13"

--- a/includes/publisher/js/src/components/relationship/Options.jsx
+++ b/includes/publisher/js/src/components/relationship/Options.jsx
@@ -1,11 +1,8 @@
-/* global atlasContentModelerFormEditingExperience */
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import Icon from "acm-icons";
 import { maybeCloseDropdown } from "../../../../../settings/js/src/utils";
 import { sprintf, __ } from "@wordpress/i18n";
 import { Dropdown } from "../../../../../shared-assets/js/components/Dropdown";
-
-const { adminUrl } = atlasContentModelerFormEditingExperience;
 
 const Options = ({ entry, setSelectedEntries }) => {
 	const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -65,7 +62,7 @@ const Options = ({ entry, setSelectedEntries }) => {
 			<div className={`dropdown-content ${dropdownOpen ? "" : "hidden"}`}>
 				<a
 					className="view"
-					href={`${adminUrl}post.php?post=${entry.id}&action=edit`}
+					href={`${atlasContentModelerFormEditingExperience?.adminUrl}post.php?post=${entry.id}&action=edit`}
 					target="_blank"
 					rel="noopener noreferrer"
 					onClick={() => {

--- a/includes/publisher/js/src/components/relationship/Options.jsx
+++ b/includes/publisher/js/src/components/relationship/Options.jsx
@@ -65,7 +65,7 @@ const Options = ({ entry, setSelectedEntries }) => {
 			</button>
 			<div className={`dropdown-content ${dropdownOpen ? "" : "hidden"}`}>
 				<a
-					className="view"
+					className="edit"
 					href={`${atlasContentModelerFormEditingExperience?.adminUrl}post.php?post=${entry.id}&action=edit`}
 					target="_blank"
 					rel="noopener noreferrer"
@@ -74,9 +74,9 @@ const Options = ({ entry, setSelectedEntries }) => {
 					}}
 					onBlur={() => maybeCloseDropdown(setDropdownOpen, timer)}
 					aria-label={sprintf(
-						/* translators: title of the entry to view. */
+						/* translators: title of the entry to edit. */
 						__(
-							"View the %s entry in a new tab.",
+							"Edit the %s entry in a new tab.",
 							"atlas-content-modeler"
 						),
 						entry?.title?.rendered
@@ -84,7 +84,7 @@ const Options = ({ entry, setSelectedEntries }) => {
 				>
 					{sprintf(
 						/* translators: Custom post type singular name, such as Cat. */
-						__("View %s", "atlas-content-modeler"),
+						__("Edit %s", "atlas-content-modeler"),
 						relatedModelSingularTitle
 					)}
 					<Icon

--- a/tests/acceptance/CreateRelationshipFieldEntryCest.php
+++ b/tests/acceptance/CreateRelationshipFieldEntryCest.php
@@ -343,10 +343,12 @@ class CreateRelationshipFieldEntryCest {
 		$i->waitForElementVisible( 'div.relation-model-card' );
 		$i->see( 'No Title', 'div.relation-model-card' );
 
-		// Remove the linked entry from the “rights” side and update it.
+		// Confirm that a link to edit the linked “left” appears in the related entry options list with the correct label.
 		$i->waitForElementVisible( '.options' );
 		$i->click( '.options' );
-		$i->waitForElementVisible( '.dropdown-content .delete' );
+		$i->see( 'Edit Left', '.dropdown-content .edit' );
+
+		// Remove the linked entry from the “rights” side and update it.
 		$i->click( '.dropdown-content .delete' );
 		$i->waitForElementNotVisible( '.options' );
 		$i->dontSee( 'No Title', 'div.relation-model-card' ); // Linked entry was removed.


### PR DESCRIPTION
## Description

Adds an 'edit' link to related entry options so that publishers can open related entries in a new window.

Refreshes the related entry list when opening another tab (such as via the “Edit” link) and returning to the page.

https://wpengine.atlassian.net/browse/MTKA-1530

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.
- [x] Reviewed the UI change with Mason.

## Testing

Extends an existing test to check the “Edit” link appears in the dropdown.

To test manually:

1. Create a model with a related field.
2. Add a post with a related entry.
3. You should see an edit link in the related entry dropdown. It should open the related entry in a new window.

## Screenshots

<img width="1045" alt="Screenshot 2022-06-28 at 15 23 52" src="https://user-images.githubusercontent.com/647669/176189775-938682ef-0dde-4a7e-a45e-16a19b0e2c4f.png">

https://user-images.githubusercontent.com/647669/176644130-bb4aea17-83d3-42ab-8bc3-abbc664095fc.mov