### PR TITLE
[NOJIRA] Allow publisher field values to be cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Fixed
+- Fields will now save empty values when existing content is removed.
+
 ## 0.19.0 - 2022-06-29
 ### Added
 - The `wp acm blueprint import` WP-CLI command can now take a path to a local directory containing an `acm.json` blueprint manifest.

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -437,8 +437,11 @@ final class FormEditingExperience {
 		foreach ( $posted_values as $key => $value ) {
 			$key = sanitize_text_field( $key );
 
-			// Do not save empty values for new posts, but allow 0 values.
-			if ( ! $update && empty( $value ) && $value !== '0' && $value !== 0 ) {
+			// Delete or ignore empty values, but allow 0 values.
+			if ( empty( $value ) && $value !== '0' && $value !== 0 ) {
+				if ( $update ) {
+					delete_post_meta( $post_id, $key );
+				}
 				continue;
 			}
 

--- a/includes/publisher/class-publisher-form-editing-experience.php
+++ b/includes/publisher/class-publisher-form-editing-experience.php
@@ -72,7 +72,7 @@ final class FormEditingExperience {
 		add_action( 'current_screen', [ $this, 'current_screen' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'edit_form_after_title', [ $this, 'render_app_container' ] );
-		add_action( 'save_post', [ $this, 'save_post' ], 10, 2 );
+		add_action( 'save_post', [ $this, 'save_post' ], 10, 3 );
 		add_action( 'wp_insert_post', [ $this, 'set_post_attributes' ], 10, 3 );
 		add_filter( 'redirect_post_location', [ $this, 'append_error_to_location' ], 10, 2 );
 		add_action( 'admin_notices', [ $this, 'display_save_post_errors' ] );
@@ -313,8 +313,9 @@ final class FormEditingExperience {
 	 *
 	 * @param int     $post_id The post ID.
 	 * @param WP_Post $post    The post object being saved.
+	 * @param bool    $update     True if the post is being updated (rather than created).
 	 */
-	public function save_post( int $post_id, WP_Post $post ): void {
+	public function save_post( int $post_id, WP_Post $post, bool $update ): void {
 		if ( empty( $_POST['atlas-content-modeler'] ) || empty( $_POST['atlas-content-modeler'][ $post->post_type ] ) ) {
 			return;
 		}
@@ -436,8 +437,8 @@ final class FormEditingExperience {
 		foreach ( $posted_values as $key => $value ) {
 			$key = sanitize_text_field( $key );
 
-			// Do not save empty values, but allow 0 values.
-			if ( empty( $value ) && $value !== '0' && $value !== 0 ) {
+			// Do not save empty values for new posts, but allow 0 values.
+			if ( ! $update && empty( $value ) && $value !== '0' && $value !== 0 ) {
 				continue;
 			}
 

--- a/tests/acceptance/UpdateExistingModelEntryCest.php
+++ b/tests/acceptance/UpdateExistingModelEntryCest.php
@@ -2,7 +2,7 @@
 
 class UpdateExistingModelEntryCest {
 
-	public function i_can_update_an_existing_model_entry( AcceptanceTester $i ) {
+	public function _before( \AcceptanceTester $i ) {
 		$i->maximizeWindow();
 		$i->loginAsAdmin();
 		$content_model = $i->haveContentModel( 'goose', 'geese', [ 'description' => 'Geese go honk' ] );
@@ -65,7 +65,9 @@ class UpdateExistingModelEntryCest {
 
 		$i->click( 'Publish', '#publishing-action' );
 		$i->wait( 2 );
+	}
 
+	public function i_can_update_an_existing_model_entry( AcceptanceTester $i ) {
 		// Update the entry.
 		$i->fillField( [ 'name' => 'atlas-content-modeler[goose][color]' ], 'Green' );
 		$i->switchToIFrame( '#field-description iframe' );
@@ -92,5 +94,20 @@ class UpdateExistingModelEntryCest {
 		$i->click( 'Update', '#publishing-action' );
 		$i->wait( 2 );
 		$i->see( 'Nonce verification failed when saving your content. Please try again.' );
+	}
+
+	public function i_can_clear_fields_in_an_existing_model_entry( AcceptanceTester $i ) {
+			// Clear some fields.
+			$i->fillField( [ 'name' => 'atlas-content-modeler[goose][color]' ], '' );
+			$i->fillField( [ 'name' => 'atlas-content-modeler[goose][age]' ], '' );
+			$i->fillField( [ 'name' => 'atlas-content-modeler[goose][dateOfBirth]' ], '' );
+
+			$i->click( 'Update', '#publishing-action' );
+			$i->wait( 2 );
+
+			// Confirm fields are still cleared after updating.
+			$i->seeInField( [ 'name' => 'atlas-content-modeler[goose][color]' ], '' );
+			$i->seeInField( [ 'name' => 'atlas-content-modeler[goose][age]' ], '' );
+			$i->seeInField( [ 'name' => 'atlas-content-modeler[goose][dateOfBirth]' ], '' );
 	}
 }


### PR DESCRIPTION
## Description

- Allows values in fields to be cleared.
- Deletes post meta if an update to the post makes it empty.

Previously, emptying a field and clicking Update would not overwrite the old value with the new empty value (except for relationship fields, which cleared fine).

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

Extended an existing e2e test to confirm publisher fields can be cleared and saved.

To test manually:

- Create a model with a text field and number field.
- Create a post with values in both fields.
- Try to clear the values of both fields. It should work on this branch (but won't on main).
- Try to enter '0' in the number field. The 0 should still persist after save (it should not count as empty and so you'll see 0 instead of an empty field).