### PR TITLE
NOJIRA: Fix validate_number_type to accept decimals and 0 values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Fixed
 - Fields will now save empty values when existing content is removed.
+- 0 can now be entered into number fields via the `insert_model_entry()` PHP function.
+- Decimals can now be entered into number fields via the `insert_model_entry()` PHP function.
 
 ## 0.19.0 - 2022-06-29
 ### Added

--- a/includes/api/validation-functions.php
+++ b/includes/api/validation-functions.php
@@ -462,11 +462,19 @@ function validate_email_field( $value, array $field ): void {
 function validate_number_type( $value, $number_type, string $message = '' ): void {
 	$message = $message ?: \__( 'Value must be a valid number', 'atlas-content-modeler' );
 
-	if ( $number_type === 'integer' && ! filter_var( $value, FILTER_VALIDATE_INT ) ) {
+	if (
+		$number_type === 'integer'
+		&& $value !== 0 // Accept 0 as a valid integer.
+		&& is_float( $value )
+	) {
 		throw new Validation_Exception( $message );
 	}
 
-	if ( $number_type === 'decimal' && floor( $value ) !== $value ) {
+	if (
+		$number_type === 'decimal'
+		&& $value !== 0 // Accept 0 as a valid decimal. Helps with JSON responses that don't strictly type 0 as 0.00.
+		&& ! is_float( $value )
+	) {
 		throw new Validation_Exception( $message );
 	}
 }

--- a/includes/api/validation-functions.php
+++ b/includes/api/validation-functions.php
@@ -451,12 +451,15 @@ function validate_email_field( $value, array $field ): void {
 /**
  * Validate the number type.
  *
- * Will not throw for invalid numeric integer strings such as "test".
+ * Type-checks numbers and numeric strings.
+ *
+ * Will not throw for strings such as "test" passed as integer types.
  * Use `validate_number()` to validate a string as numeric.
  *
- * The zero values 0, 0.0, -0 and -0.0 are considered valid for all types.
+ * The zero values 0, 0.0, -0 and -0.0 and their string equivalents are
+ * considered valid for all types.
  *
- * @param mixed  $value The value.
+ * @param mixed  $value The value as a number or string.
  * @param mixed  $number_type The number type.
  * @param string $message Optional. The error message.
  *

--- a/includes/api/validation-functions.php
+++ b/includes/api/validation-functions.php
@@ -449,13 +449,18 @@ function validate_email_field( $value, array $field ): void {
 }
 
 /**
- * Validate for valid number type.
+ * Validate the number type.
+ *
+ * Will not throw for invalid numeric integer strings such as "test".
+ * Use `validate_number()` to validate a string as numeric.
+ *
+ * The zero values 0, 0.0, -0 and -0.0 are considered valid for all types.
  *
  * @param mixed  $value The value.
  * @param mixed  $number_type The number type.
  * @param string $message Optional. The error message.
  *
- * @throws Validation_Exception Exception when value is invalid.
+ * @throws Validation_Exception Exception when value is the invalid type.
  *
  * @return void
  */

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -768,15 +768,6 @@ class TestValidationFunctions extends Integration_TestCase {
 		validate_number_min_max_step( $value, $field, $message );
 	}
 
-	/**
-	 * @testWith
-	 * [ 4.2, "integer", "Number Field must be of type integer" ]
-	 */
-	public function test_validate_number_field_type_is_integer( $value, $number_type, $message ) {
-		$this->expectExceptionMessage( $message );
-		validate_number_type( $value, $number_type, $message );
-	}
-
 	public function test_validate_post_exists_will_throw_an_exception_if_post_does_not_exist() {
 		$this->expectException( Validation_Exception::class );
 		$this->expectExceptionMessage( 'The post object was not found' );

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -668,12 +668,68 @@ class TestValidationFunctions extends Integration_TestCase {
 	}
 
 	/**
+	 * Checks that invalid numbers do not pass type validation.
+	 *
 	 * @testWith
-	 * [ 4, "decimal", "Number Field must be of type decimal" ]
+	 * [ -1, "decimal", "Must be a decimal" ]
+	 * [ 4, "decimal", "Must be a decimal" ]
+	 * [ 1000, "decimal", "Must be a decimal" ]
+	 * [ 0.00001, "integer", "Must be an integer" ]
+	 * [ "0.00001", "integer", "Must be an integer" ]
+	 * [ -1.1, "integer", "Must be an integer" ]
+	 * [ 4.0, "integer", "Must be an integer" ]
+	 * [ "4.0", "integer", "Must be an integer" ]
+	 * [ 1000.0, "integer", "Must be an integer" ]
+	 * [ "1000.0", "integer", "Must be an integer" ]
+	 * [ 10.1, "integer", "Must be an integer" ]
+	 * [ "10.1", "integer", "Must be an integer" ]
 	 */
-	public function test_validate_number_field_type_is_decimal( $value, $type, $message ) {
+	public function test_validate_number_type_rejects_invalid_numbers( $value, $type, $message ) {
 		$this->expectExceptionMessage( $message );
 		validate_number_type( $value, $type, $message );
+	}
+
+	/**
+	 * Checks that valid numbers pass type validation.
+	 *
+	 * @testWith
+	 * [ -0, "integer", "Must be an integer" ]
+	 * [ "-0", "integer", "Must be an integer" ]
+	 * [ -0.0, "integer", "Must be an integer" ]
+	 * [ "-0.0", "integer", "Must be an integer" ]
+	 * [ 0, "integer", "Must be an integer" ]
+	 * [ "0", "integer", "Must be an integer" ]
+	 * [ 0.0, "integer", "Must be an integer" ]
+	 * [ "0.0", "integer", "Must be an integer" ]
+	 * [ -1, "integer", "Must be an integer" ]
+	 * [ "-1", "integer", "Must be an integer" ]
+	 * [ 1, "integer", "Must be an integer" ]
+	 * [ "1", "integer", "Must be an integer" ]
+	 * [ 33, "integer", "Must be an integer" ]
+	 * [ "33", "integer", "Must be an integer" ]
+	 * [ -0, "decimal", "Must be a decimal" ]
+	 * [ "-0", "decimal", "Must be a decimal" ]
+	 * [ -0.0, "decimal", "Must be a decimal" ]
+	 * [ "-0.0", "decimal", "Must be a decimal" ]
+	 * [ 0, "decimal", "Must be a decimal" ]
+	 * [ "0", "decimal", "Must be a decimal" ]
+	 * [ 0.0, "decimal", "Must be a decimal" ]
+	 * [ "0.0", "decimal", "Must be a decimal" ]
+	 * [ -1.0, "decimal", "Must be a decimal" ]
+	 * [ "-1.0", "decimal", "Must be a decimal" ]
+	 * [ -1.11, "decimal", "Must be a decimal" ]
+	 * [ "-1.11", "decimal", "Must be a decimal" ]
+	 * [ 3.1415926535, "decimal", "Must be a decimal" ]
+	 * [ "3.1415926535", "decimal", "Must be a decimal" ]
+	 * [ 4.0, "decimal", "Must be a decimal" ]
+	 * [ "4.0", "decimal", "Must be a decimal" ]
+	 * [ 4.1, "decimal", "Must be a decimal" ]
+	 * [ "4.1", "decimal", "Must be a decimal" ]
+	 * [ 44.1, "decimal", "Must be a decimal" ]
+	 * [ "44.1", "decimal", "Must be a decimal" ]
+	 */
+	public function test_validate_number_type_accepts_valid_numbers( $value, $type, $message ) {
+		$this->assertNull( validate_number_type( $value, $type, $message ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fixes `validate_number_type()` so that:

- 0 can be inserted into an integer number field via `insert_model_entry()` without throwing an error.
- Decimal values can be inserting into a decimal number field via `insert_model_entry()` without throwing an error.

Currently on `main`, running `wp eval "acm_test_import_post_content()";` after activating the test plugin below produces errors:

```php
<?php
/* Plugin Name: WPE Test Plugin */

use function WPE\AtlasContentModeler\API\insert_model_entry;

function acm_test_import_post_content() {	
	$model_slug = 'rabbit';
	$field_data = [
		'name' => 'Peter',		
		'speedDec' => 2.2,
		'speedInt' => 0,
	];

	$post_id = insert_model_entry( $model_slug, $field_data );

	var_dump( $post_id );
}
```

Error sample:

```
class WPE\AtlasContentModeler\WP_Error#2322 (3) {
  public $errors =>
  array(2) {
    'speedInt' =>
    array(1) {
      [0] =>
      string(32) "speedInt must be of type integer"
    }
    'speedDec' =>
    array(1) {
      [0] =>
      string(32) "speedDec must be of type decimal"
    }
  }
  public $error_data =>
  array(0) {
  }
  protected $additional_data =>
  array(0) {
  }
}
```

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

Extended unit tests extensively to test validate_number_type more thoroughly.

To test manually:

1. Create a rabbits model with 'name' (text field), 'speedDec' (numeric field, decimal) and 'speedInt` (numeric field, integer) fields.
1. Create a file named `test-plugin.php` in `wp-content/plugins/` with the PHP content above.
1. Activate the "WPE Test Plugin" plugin.
1. Run `wp eval "acm_test_import_post_content();"` in the command line.

You should see output including the generated post ID such as:

```sh
> wp eval "acm_test_import_post_content();"
/Users/[user.name]/Sites/local/app/public/wp-content/plugins/test.php:16:
int(2939)
```