### PR TITLE
MTKA-1535: Allow model singular and plural name case changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fields will now save empty values when existing content is removed.
 - 0 can now be entered into number fields via the `insert_model_entry()` PHP function.
 - Decimals can now be entered into number fields via the `insert_model_entry()` PHP function.
+- You can now edit the case of model singular and plural names.
 
 ## 0.19.0 - 2022-06-29
 ### Added

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -229,7 +229,7 @@ function update_model( string $post_type_slug, array $args ) {
 	}
 
 	if (
-		model_property_changed( $post_type_slug, 'singular', $args['singular'] )
+		model_property_changed( $post_type_slug, 'singular', $args['singular'], true )
 		&& root_type_exists( $args['singular'] )
 	) {
 		return new WP_Error(
@@ -240,7 +240,7 @@ function update_model( string $post_type_slug, array $args ) {
 	}
 
 	if (
-		model_property_changed( $post_type_slug, 'plural', $args['plural'] )
+		model_property_changed( $post_type_slug, 'plural', $args['plural'], true )
 		&& root_type_exists( $args['plural'] )
 	) {
 		return new WP_Error(
@@ -360,10 +360,21 @@ function delete_model( string $post_type_slug ) {
  * @param string $slug The model ID.
  * @param string $property The property to check.
  * @param mixed  $new_value The property's new value.
+ * @param bool   $ignore_case Optionally ignore case for string comparisons. Default false.
  * @return bool
  */
-function model_property_changed( string $slug, string $property, $new_value ): bool {
+function model_property_changed( string $slug, string $property, $new_value, bool $ignore_case = false ): bool {
 	$acm_models = get_registered_content_types();
+	$old_value  = $acm_models[ $slug ][ $property ] ?? null;
 
-	return ( $acm_models[ $slug ][ $property ] ?? null ) !== $new_value;
+	if (
+		$ignore_case
+		&& is_string( $new_value )
+		&& is_string( $old_value )
+		&& strtolower( $old_value ) === strtolower( $new_value )
+	) {
+		return false;
+	}
+
+	return $old_value !== $new_value;
 }

--- a/tests/integration/api-validation/test-rest-model-endpoints.php
+++ b/tests/integration/api-validation/test-rest-model-endpoints.php
@@ -1,5 +1,6 @@
 <?php
 
+use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_types;
 use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
 use \WPE\AtlasContentModeler\ContentConnect\Plugin as ContentConnect;
 
@@ -189,6 +190,29 @@ class RestModelEndpointTests extends WP_UnitTestCase {
 
 		self::assertSame( 200, $response->get_status() );
 		self::assertSame( $new_model['description'], $models['public']['description'] );
+	}
+
+	public function test_can_change_model_singular_and_plural_name_case(): void {
+		wp_set_current_user( 1 );
+		$model = 'public';
+
+		$request  = new WP_REST_Request( 'GET', $this->namespace . $this->route . '/' . $model );
+		$response = $this->server->dispatch( $request );
+
+		// Update the model's singular and plural names, but only change the case of both strings.
+		$new_model             = $this->test_models[ $model ];
+		$new_model['singular'] = 'public'; // Original is 'Public'.
+		$new_model['plural']   = 'publics'; // Original is 'Publics'.
+		$request               = new WP_REST_Request( 'PATCH', $this->namespace . $this->route . '/' . $model );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( json_encode( $new_model ) );
+
+		$response = $this->server->dispatch( $request );
+		$models   = get_registered_content_types();
+
+		self::assertSame( 200, $response->get_status() );
+		self::assertSame( $new_model['singular'], $models['public']['singular'] );
+		self::assertSame( $new_model['plural'], $models['public']['plural'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Prevents “[singular|plural] name is in use” errors when editing a model's singular or plural names to change the case.

https://wpengine.atlassian.net/browse/MTKA-1535

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

Includes unit tests to confirm the singular/plural case can be changed.

To test manually:

1. Create a model.
2. Edit the model and change its singular/plural name case (e.g. Rabbits → rabbits, Rabbit → rabbit).