### PR TITLE
MTKA-1562: Add model field API Identifier to model fields list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 - Related entries in relationship fields now have an “Edit” link to view or edit them in a new tab.
+- Added model field API Identifier to model field list.
 
 ### Fixed
 - Fields will now save empty values when existing content is removed.

--- a/includes/settings/js/src/components/fields/Field.jsx
+++ b/includes/settings/js/src/components/fields/Field.jsx
@@ -103,6 +103,15 @@ function Field({
 									<div className="col-sm-3 col-12 text-center text-sm-start">
 										<div className="widest mb-2 mb-sm-0">
 											<strong>{data.name}</strong>
+											{"  "}
+											<span
+												title={__(
+													"API Identifier",
+													"atlas-content-modeler"
+												)}
+											>
+												({data.slug})
+											</span>
 										</div>
 									</div>
 									<div className="col-sm-6 col-12 text-center text-sm-end">

--- a/tests/acceptance/CreateContentModelTextFieldCest.php
+++ b/tests/acceptance/CreateContentModelTextFieldCest.php
@@ -21,6 +21,7 @@ class CreateContentModelTextFieldCest {
 
 		$i->see( 'Text', '.field-list div.type' );
 		$i->see( 'Color', '.field-list div.widest' );
+		$i->see( 'color', '.field-list div.widest' );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This pull request adds the content model field API Identifier to the content model field list. This will allow a quick reference to the field API Identifier.

![Screen Shot 2022-07-13 at 9 04 05 AM](https://user-images.githubusercontent.com/1128283/178753010-259352a7-2fa2-465e-8231-5ef2c9144157.png)

## Checklist

I have:

- [ ] Added an entry to CHANGELOG.md.
