### PR TITLE
Adds description to registered opt in tracking setting

### DIFF
--- a/includes/settings/settings-callbacks.php
+++ b/includes/settings/settings-callbacks.php
@@ -188,7 +188,7 @@ function register_plugin_settings(): void {
 		'atlas_content_modeler_usage_tracking',
 		[
 			'type'              => 'string',
-			'description'       => 'Opt into anonymous usage tracking to help us make Atlas Content Modeler better.',
+			'description'       => __( 'Opt into anonymous usage tracking to help us make Atlas Content Modeler better.', 'atlas-content-modeler' ),
 			'sanitize_callback' => 'sanitize_text_field',
 			'show_in_rest'      => true,
 			'default'           => '0',

--- a/includes/settings/settings-callbacks.php
+++ b/includes/settings/settings-callbacks.php
@@ -188,6 +188,7 @@ function register_plugin_settings(): void {
 		'atlas_content_modeler_usage_tracking',
 		[
 			'type'              => 'string',
+			'description'       => 'Opt into anonymous usage tracking to help us make Atlas Content Modeler better.',
 			'sanitize_callback' => 'sanitize_text_field',
 			'show_in_rest'      => true,
 			'default'           => '0',


### PR DESCRIPTION
This PR adds a description to the registered settings for opt in tracking. To test, visit your local environment `/wp-json/wp/v2` and search for the `atlas_content_modeler_usage_tracking` setting. :)