### PR TITLE
NOJIRA: Confirm paths exist before deleting during blueprint cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Fixed
+- Prevent a fatal error during the blueprint import cleanup process.
+
 ## 0.19.1 - 2022-07-13
 ### Added
 - Related entries in relationship fields now have an “Edit” link to view or edit them in a new tab.

--- a/includes/blueprints/import.php
+++ b/includes/blueprints/import.php
@@ -561,6 +561,11 @@ function import_options( array $options ): void {
  * @return void
  */
 function cleanup( $blueprint_zip_path, $blueprint_folder_path ) {
-	wp_delete_file( $blueprint_zip_path );
-	wp_delete_file( $blueprint_folder_path . '/acm.json' );
+	if ( file_exists( $blueprint_zip_path ) ) {
+		wp_delete_file( $blueprint_zip_path );
+	}
+
+	if ( file_exists( $blueprint_folder_path . '/acm.json' ) ) {
+		wp_delete_file( $blueprint_folder_path . '/acm.json' );
+	}
 }


### PR DESCRIPTION
## Description

This fix is designed to address a fatal error affecting all new Atlas blueprint installs.

I haven't been able to reproduce it locally, but attempting to install any blueprint in Portal currently produces the error below during the WP instance setup.

If all looks good we will need to release 0.19.2 today to fix this.

```
#0 /nas/content/live/bpatlasblue840/wp-includes/functions.php(7287): unlink('PK\x03\x04\n\x00\x00\x00\x00\x008V\x92T\x00...')
#1 /nas/content/live/bpatlasblue840/wp-content/plugins/atlas-content-modeler/includes/blueprints/import.php(564): wp_delete_file('PK\x03\x04\n\x00\x00\x00\x00\x008V\x92T\x00...')
#2 /nas/content/live/bpatlasblue840/wp-content/plugins/atlas-content-modeler/includes/wp-cli/class-blueprint.php(235): WPE\AtlasContentModeler\Blueprint\Import\cleanup('PK\x03\x04\n\x00\x00\x00\x00\x008V\x92T\x00...', '/nas/content/li...')
#3 [internal function]: WPE\AtlasContentModeler\WP_CLI\Blueprint->import(Array, Array)
#4 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(100): call_user_func(Array, Array, Array)
#5 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#6 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(491): call_user_func(Object(Closure), Array, Array)
#7 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(417): WP_CLI\Dispatcher\Subcommand->invoke(Array, Array, Array)
#8 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(440): WP_CLI\Runner->run_command(Array, Array)
#9 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1237): WP_CLI\Runner->run_command_and_exit()
#10 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#11 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(78): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#12 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#13 phar:///usr/local/bin/wp/php/boot-phar.php(11): include('phar:///usr/loc...')
#14 /usr/local/bin/wp(4): include('phar:///usr/loc...')
#15 {main}
  thrown in /nas/content/live/bpatlasblue840/wp-includes/functions.php on line 7287
Error: There has been a critical error on this website.Learn more about troubleshooting WordPress. There has been a critical error on this website.
```

When running the same command locally there is no such error:

```
> wp acm blueprint import https://github.com/wpengine/atlas-blueprint-basic/raw/main/acm-blueprint.zip
Fetching blueprint.
Unzipping.
Verifying ACM manifest.
Checking minimum versions.
Importing posts.
Importing terms.
Tagging posts.
Importing media.
Importing post meta.
Restoring WordPress options.
Deleting zip and manifest.
Success: Import complete.
```

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

The existing test for blueprint cleanup (`test_cleanup` in `tests/integration/blueprints/test-blueprint-import.php` should continue to pass.)