### PR TITLE
NOJIRA: remove blueprint cleanup step

### DIFF
--- a/docs/wp-cli/index.md
+++ b/docs/wp-cli/index.md
@@ -19,18 +19,13 @@ Imports an ACM blueprint from a URL or File Path.
 ### Synopsis
 
 ```
-wp acm blueprint import <path> [--skip-cleanup]
+wp acm blueprint import <path>
 ```
 
 ### Options
 
 `<path>`
 The URL or local path of the blueprint zip file, or local path to the blueprint folder containing the acm.json manifest file. Local paths must be absolute.
-
-`[--skip-cleanup]`
-Skips removal of the blueprint zip and manifest files after a
-successful import. Useful when testing blueprints or to leave a
-record of content and files that were installed.
 
 ### Examples
 

--- a/includes/blueprints/import.php
+++ b/includes/blueprints/import.php
@@ -550,22 +550,3 @@ function import_options( array $options ): void {
 		update_option( $name, $value );
 	}
 }
-
-/**
- * Deletes the blueprint zip file and manifest file.
- *
- * Leaves media files in place because they are linked to imported media.
- *
- * @param string $blueprint_zip_path Path to the blueprint zip file.
- * @param string $blueprint_folder_path Path to the blueprint folder.
- * @return void
- */
-function cleanup( $blueprint_zip_path, $blueprint_folder_path ) {
-	if ( file_exists( $blueprint_zip_path ) ) {
-		wp_delete_file( $blueprint_zip_path );
-	}
-
-	if ( file_exists( $blueprint_folder_path . '/acm.json' ) ) {
-		wp_delete_file( $blueprint_folder_path . '/acm.json' );
-	}
-}

--- a/includes/wp-cli/class-blueprint.php
+++ b/includes/wp-cli/class-blueprint.php
@@ -17,7 +17,6 @@ namespace WPE\AtlasContentModeler\WP_CLI;
 
 use function WPE\AtlasContentModeler\Blueprint\Import\{
 	check_versions,
-	cleanup,
 	get_manifest,
 	import_acm_relationships,
 	import_media,
@@ -61,13 +60,6 @@ class Blueprint {
 	 * : The URL or local path of the blueprint zip file, or local path to the
 	 * blueprint folder containing the acm.json manifest file. Local paths must
 	 * be absolute.
-	 *
-	 * [--skip-cleanup]
-	 * : Skips removal of the blueprint zip and manifest files after a
-	 * successful import. Useful when testing blueprints or to leave a
-	 * record of content and files that were installed. Has no effect
-	 * if the `path` passed to `blueprint import` is a local directory
-	 * and not a zip file.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -225,14 +217,6 @@ class Blueprint {
 		if ( ! empty( $manifest['wp-options'] ?? [] ) ) {
 			\WP_CLI::log( 'Restoring WordPress options.' );
 			import_options( $manifest['wp-options'] );
-		}
-
-		if (
-			! ( $assoc_args['skip-cleanup'] ?? false )
-			&& ! $path_is_directory
-		) {
-			\WP_CLI::log( 'Deleting zip and manifest.' );
-			cleanup( $zip_file, $blueprint_folder );
 		}
 
 		\WP_CLI::success( 'Import complete.' );

--- a/tests/integration/blueprints/test-blueprint-import.php
+++ b/tests/integration/blueprints/test-blueprint-import.php
@@ -7,7 +7,6 @@
 
 use function WPE\AtlasContentModeler\Blueprint\Import\{
 	check_versions,
-	cleanup,
 	get_manifest,
 	import_acm_relationships,
 	import_media,
@@ -303,17 +302,6 @@ class BlueprintImportTest extends WP_UnitTestCase {
 
 		self::assertStringEndsWith( 'acm-rabbits/', $unzipped_folder );
 		self::assertTrue( is_readable( $upload_dir . '/acm-rabbits/acm.json' ) );
-	}
-
-	public function test_cleanup() {
-		$this->copy_media_to_wp_uploads();
-
-		$upload_dir = wp_upload_dir()['path'];
-
-		cleanup( $upload_dir . '/acm-rabbits.zip', $upload_dir . '/blueprint-good/' );
-
-		self::assertFalse( is_readable( $upload_dir . '/acm-rabbits.zip' ) );
-		self::assertFalse( is_readable( $upload_dir . '/blueprint-good/acm.json' ) );
 	}
 
 	private function copy_media_to_wp_uploads() {


### PR DESCRIPTION
Because the step is throwing a fatal error in production, I think it's better to remove it than conditionally run it. That way the plugin behaves the same way everywhere. (The cleanup step just removed the .zip file and manifest; it's ok to leave these in place.)

As @andrewbotz pointed out in https://github.com/wpengine/atlas-content-modeler/pull/601#pullrequestreview-1049563443, we don't have a great way to report back to the user that cleanup failed, and we can't really expect them to remove any blueprint files manually in production.

Previous changelog entry from #601 about preventing fatal errors still stands.

This may also cut down with future maintenance/fatal error issues arising from that step.