### PR TITLE
Bump stable tag for 0.19.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.2
-Stable tag: 0.19.1
+Stable tag: 0.19.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Author: WP Engine


### PR DESCRIPTION
I missed this from the release PR at https://github.com/wpengine/atlas-content-modeler/pull/602.