### PR TITLE
MTKA-1585 validate_number_type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Fixed
+- Decimal values ending in 0, such as 1.0, will now pass validation for validate_number_type() for integers.
+
 ## 0.20.0 - 2022-08-09
 ### Added
 - The email field gains a “make this field unique” setting so that emails can not be used more than once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Atlas Content Modeler Changelog
 
 ## Unreleased
+### Added
+- Added `validate_integer()` and `validate_decimal()` functions.
+
 ### Fixed
 - Decimal values ending in 0, such as 1.0, will now pass validation for validate_number_type() for integers.
 

--- a/includes/api/validation-functions.php
+++ b/includes/api/validation-functions.php
@@ -468,39 +468,10 @@ function validate_email_field( $value, array $field ): void {
  * @return void
  */
 function validate_number_type( $value, $number_type, string $message = '' ): void {
-	$message           = $message ?: \__( 'Value must be a valid number', 'atlas-content-modeler' );
-	$is_numeric_string = is_string( $value ) && is_numeric( $value );
-
-	/**
-	 * Accept zero values for integers and decimals. Helps with JSON responses
-	 * that do not encode 0 correctly as 0.00 or vice versa.
-	 */
-	if (
-		$value === 0
-		|| $value === 0.0
-		|| $is_numeric_string && (float) $value === 0.0
-	) {
-		return;
-	}
-
-	if (
-		$number_type === 'integer'
-		&& (
-			is_float( $value )
-			|| $is_numeric_string && str_contains( $value, '.' )
-		)
-	) {
-		throw new Validation_Exception( $message );
-	}
-
-	if (
-		$number_type === 'decimal'
-		&& (
-			! $is_numeric_string && ! is_float( $value )
-			|| $is_numeric_string && ! str_contains( $value, '.' )
-		)
-	) {
-		throw new Validation_Exception( $message );
+	if ( 'decimal' === $number_type ) {
+		validate_decimal( $value, $message );
+	} else {
+		validate_integer( $value, $message );
 	}
 }
 

--- a/includes/api/validation-functions.php
+++ b/includes/api/validation-functions.php
@@ -505,6 +505,26 @@ function validate_number_type( $value, $number_type, string $message = '' ): voi
 }
 
 /**
+ * Validate a value for an integer.
+ *
+ * @param mixed  $value   The value to validate.
+ * @param string $message Optional error message.
+ *
+ * @throws Validation_Exception Exception when value is the invalid type.
+ *
+ * @return void
+ */
+function validate_integer( $value, string $message = '' ): void {
+	$message = $message ?: \__( 'Value must be a valid number', 'atlas-content-modeler' );
+
+	validate_number( $value, $message );
+
+	if ( false === \filter_var( (float) $value, FILTER_VALIDATE_INT ) ) {
+		throw new Validation_Exception( $message );
+	}
+}
+
+/**
  * Validate a value for a decimal.
  *
  * @param mixed  $value   The value to validate.

--- a/includes/api/validation-functions.php
+++ b/includes/api/validation-functions.php
@@ -515,7 +515,7 @@ function validate_number_type( $value, $number_type, string $message = '' ): voi
  * @return void
  */
 function validate_integer( $value, string $message = '' ): void {
-	$message = $message ?: \__( 'Value must be a valid number', 'atlas-content-modeler' );
+	$message = $message ?: \__( 'Value must be a valid integer', 'atlas-content-modeler' );
 
 	validate_number( $value, $message );
 
@@ -535,7 +535,7 @@ function validate_integer( $value, string $message = '' ): void {
  * @return void
  */
 function validate_decimal( $value, string $message = '' ): void {
-	$message = $message ?: \__( 'Value must be a valid number', 'atlas-content-modeler' );
+	$message = $message ?: \__( 'Value must be a valid decimal', 'atlas-content-modeler' );
 
 	validate_number( $value, $message );
 

--- a/includes/api/validation-functions.php
+++ b/includes/api/validation-functions.php
@@ -505,6 +505,26 @@ function validate_number_type( $value, $number_type, string $message = '' ): voi
 }
 
 /**
+ * Validate a value for a decimal.
+ *
+ * @param mixed  $value   The value to validate.
+ * @param string $message Optional error message.
+ *
+ * @throws Validation_Exception Exception when value is the invalid type.
+ *
+ * @return void
+ */
+function validate_decimal( $value, string $message = '' ): void {
+	$message = $message ?: \__( 'Value must be a valid number', 'atlas-content-modeler' );
+
+	validate_number( $value, $message );
+
+	if ( false === \filter_var( $value, FILTER_VALIDATE_FLOAT ) ) {
+		throw new Validation_Exception( $message );
+	}
+}
+
+/**
  * Validate for valid number.
  *
  * @param mixed  $value The value.

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -441,9 +441,15 @@ class TestValidationFunctions extends Integration_TestCase {
 	/**
 	 * @testWith
 	 * [ 0 ]
+	 * [ "0" ]
 	 * [ 0.1 ]
+	 * [ "0.1" ]
 	 * [ 1.0 ]
+	 * [ "1.0" ]
 	 * [ 1 ]
+	 * [ "1" ]
+	 * [ 1.1 ]
+	 * [ "1.1" ]
 	 */
 	public function test_validate_number_will_return_null_if_valid_number( $value ) {
 		$this->assertNull( validate_number( $value ) );

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -690,7 +690,7 @@ class TestValidationFunctions extends Integration_TestCase {
 	}
 
 	/**
-	 * Checks that valid numbers pass type validation.
+	 * Checks that valid integer numbers pass validation.
 	 *
 	 * @testWith
 	 * [ -0, "integer", "Must be an integer" ]
@@ -707,6 +707,15 @@ class TestValidationFunctions extends Integration_TestCase {
 	 * [ "1", "integer", "Must be an integer" ]
 	 * [ 33, "integer", "Must be an integer" ]
 	 * [ "33", "integer", "Must be an integer" ]
+	 */
+	public function test_validate_number_type_accepts_valid_integer_numbers( $value, $type, $message ) {
+		$this->assertNull( validate_number_type( $value, $type, $message ) );
+	}
+
+	/**
+	 * Checks that valid decimal numbers pass validation.
+	 *
+	 * @testWith
 	 * [ -0, "decimal", "Must be a decimal" ]
 	 * [ "-0", "decimal", "Must be a decimal" ]
 	 * [ -0.0, "decimal", "Must be a decimal" ]
@@ -728,7 +737,7 @@ class TestValidationFunctions extends Integration_TestCase {
 	 * [ 44.1, "decimal", "Must be a decimal" ]
 	 * [ "44.1", "decimal", "Must be a decimal" ]
 	 */
-	public function test_validate_number_type_accepts_valid_numbers( $value, $type, $message ) {
+	public function test_validate_number_type_accepts_valid_decimal_numbers( $value, $type, $message ) {
 		$this->assertNull( validate_number_type( $value, $type, $message ) );
 	}
 

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -510,14 +510,14 @@ class TestValidationFunctions extends Integration_TestCase {
 		$this->expectException( Validation_Exception::class );
 		$this->expectExceptionMessage( 'Value must be a valid number' );
 
-		validate_number( $value );
+		validate_decimal( $value );
 	}
 
 	public function test_validate_decimal_will_use_the_custom_message() {
 		$message = 'That value is not a number';
 		$this->expectExceptionMessage( $message );
 
-		validate_number( null, $message );
+		validate_decimal( null, $message );
 	}
 
 	public function test_validate_string_will_return_null_if_valid_string() {

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -10,6 +10,7 @@ use function WPE\AtlasContentModeler\API\validation\validate_array;
 use function WPE\AtlasContentModeler\API\validation\validate_string;
 use function WPE\AtlasContentModeler\API\validation\validate_number;
 use function WPE\AtlasContentModeler\API\validation\validate_decimal;
+use function WPE\AtlasContentModeler\API\validation\validate_integer;
 use function WPE\AtlasContentModeler\API\validation\validate_date;
 use function WPE\AtlasContentModeler\API\validation\validate_min;
 use function WPE\AtlasContentModeler\API\validation\validate_max;
@@ -475,6 +476,48 @@ class TestValidationFunctions extends Integration_TestCase {
 		$this->expectExceptionMessage( $message );
 
 		validate_number( null, $message );
+	}
+
+	/**
+	 * @testWith
+	 * [ -1 ]
+	 * [ "-1" ]
+	 * [ -1.0 ]
+	 * [ "-1.0" ]
+	 * [ 0 ]
+	 * [ "0" ]
+	 * [ 1 ]
+	 * [ "1" ]
+	 * [ 1.0 ]
+	 * [ "1.0" ]
+	 */
+	public function test_validate_integer_will_return_null_on_success( $value ) {
+		$this->assertNull( validate_integer( $value ) );
+	}
+
+	/**
+	 * @testWith
+	 * [ "" ]
+	 * [ "not_an_integer" ]
+	 * [ [] ]
+	 * [ true ]
+	 * [ false ]
+	 * [ null ]
+	 * [ 1.1 ]
+	 * [ "1.1" ]
+	 */
+	public function test_validate_integer_will_throw_an_exception_on_error( $value ) {
+		$this->expectException( Validation_Exception::class );
+		$this->expectExceptionMessage( 'Value must be a valid number' );
+
+		validate_integer( $value );
+	}
+
+	public function test_validate_integer_will_use_the_custom_message() {
+		$message = 'That value is not a number';
+		$this->expectExceptionMessage( $message );
+
+		validate_integer( null, $message );
 	}
 
 	/**

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -761,77 +761,93 @@ class TestValidationFunctions extends Integration_TestCase {
 	}
 
 	/**
-	 * Checks that invalid numbers do not pass type validation.
+	 * Checks that invalid numbers do not pass type validation for their type.
 	 *
 	 * @testWith
-	 * [ -1, "decimal", "Must be a decimal" ]
-	 * [ 4, "decimal", "Must be a decimal" ]
-	 * [ 1000, "decimal", "Must be a decimal" ]
-	 * [ 0.00001, "integer", "Must be an integer" ]
-	 * [ "0.00001", "integer", "Must be an integer" ]
-	 * [ -1.1, "integer", "Must be an integer" ]
-	 * [ 4.0, "integer", "Must be an integer" ]
-	 * [ "4.0", "integer", "Must be an integer" ]
-	 * [ 1000.0, "integer", "Must be an integer" ]
-	 * [ "1000.0", "integer", "Must be an integer" ]
-	 * [ 10.1, "integer", "Must be an integer" ]
-	 * [ "10.1", "integer", "Must be an integer" ]
+	 * [ "not_a_decimal", "decimal", "Value must be a valid decimal" ]
+	 * [ "not_an_integer", "integer", "Value must be a valid integer" ]
+	 * [ null, "decimal", "Value must be a valid decimal" ]
+	 * [ null, "integer", "Value must be a valid integer" ]
+	 * [ [], "decimal", "Value must be a valid decimal" ]
+	 * [ [], "integer", "Value must be a valid integer" ]
+	 * [ true, "decimal", "Value must be a valid decimal" ]
+	 * [ true, "integer", "Value must be a valid integer" ]
+	 * [ false, "decimal", "Value must be a valid decimal" ]
+	 * [ false, "integer", "Value must be a valid integer" ]
+	 * [ "", "decimal", "Value must be a valid decimal" ]
+	 * [ "", "integer", "Value must be a valid integer" ]
+	 * [ 0.00001, "integer", "Value must be a valid integer" ]
+	 * [ "0.00001", "integer", "Value must be a valid integer" ]
+	 * [ -1.1, "integer", "Value must be a valid integer" ]
+	 * [ 10.1, "integer", "Value must be a valid integer" ]
+	 * [ "10.1", "integer", "Value must be a valid integer" ]
 	 */
-	public function test_validate_number_type_rejects_invalid_numbers( $value, $type, $message ) {
+	public function test_validate_number_type_rejects_invalid_numbers( $value, $type, $expected_message ) {
+		$this->expectException( Validation_Exception::class );
+		$this->expectExceptionMessage( $expected_message );
+		validate_number_type( $value, $type );
+	}
+
+	/**
+	 * Checks that valid integers pass validation.
+	 *
+	 * @testWith
+	 * [ -1, "integer" ]
+	 * [ "-1", "integer" ]
+	 * [ -0, "integer" ]
+	 * [ "-0", "integer" ]
+	 * [ -0.0, "integer" ]
+	 * [ "-0.0", "integer" ]
+	 * [ 0, "integer" ]
+	 * [ "0", "integer" ]
+	 * [ 0.0, "integer" ]
+	 * [ "0.0", "integer" ]
+	 * [ 1, "integer" ]
+	 * [ "1", "integer" ]
+	 */
+	public function test_validate_number_type_accepts_valid_integer_numbers( $value, $type ) {
+		$this->assertNull( validate_number_type( $value, $type ) );
+	}
+
+	/**
+	 * Ensure the custom exception message is passed per type.
+	 *
+	 * @testWith
+	 * [ "not_numeric", "integer", "The value is not an integer" ]
+	 * [ "not_numeric", "decimal", "The value is not an decimal" ]
+	 */
+	public function test_validate_number_passes_the_custom_exception_message( $value, $type, $message ) {
 		$this->expectExceptionMessage( $message );
 		validate_number_type( $value, $type, $message );
 	}
 
 	/**
-	 * Checks that valid integer numbers pass validation.
+	 * Checks that valid decimals pass validation.
 	 *
 	 * @testWith
-	 * [ -0, "integer", "Must be an integer" ]
-	 * [ "-0", "integer", "Must be an integer" ]
-	 * [ -0.0, "integer", "Must be an integer" ]
-	 * [ "-0.0", "integer", "Must be an integer" ]
-	 * [ 0, "integer", "Must be an integer" ]
-	 * [ "0", "integer", "Must be an integer" ]
-	 * [ 0.0, "integer", "Must be an integer" ]
-	 * [ "0.0", "integer", "Must be an integer" ]
-	 * [ -1, "integer", "Must be an integer" ]
-	 * [ "-1", "integer", "Must be an integer" ]
-	 * [ 1, "integer", "Must be an integer" ]
-	 * [ "1", "integer", "Must be an integer" ]
-	 * [ 33, "integer", "Must be an integer" ]
-	 * [ "33", "integer", "Must be an integer" ]
+	 * [ -1.11, "decimal" ]
+	 * [ "-1.11", "decimal" ]
+	 * [ -1.0, "decimal" ]
+	 * [ "-1.0", "decimal" ]
+	 * [ -0, "decimal" ]
+	 * [ "-0", "decimal" ]
+	 * [ -0.0, "decimal" ]
+	 * [ "-0.0", "decimal" ]
+	 * [ 0, "decimal" ]
+	 * [ "0", "decimal" ]
+	 * [ 0.0, "decimal" ]
+	 * [ "0.0", "decimal" ]
+	 * [ 3.1415926535, "decimal" ]
+	 * [ "3.1415926535", "decimal" ]
+	 * [ 4.0, "decimal" ]
+	 * [ "4.0", "decimal" ]
+	 * [ 4.1, "decimal" ]
+	 * [ "4.1", "decimal" ]
+	 * [ 44.1, "decimal" ]
+	 * [ "44.1", "decimal" ]
 	 */
-	public function test_validate_number_type_accepts_valid_integer_numbers( $value, $type, $message ) {
-		$this->assertNull( validate_number_type( $value, $type, $message ) );
-	}
-
-	/**
-	 * Checks that valid decimal numbers pass validation.
-	 *
-	 * @testWith
-	 * [ -0, "decimal", "Must be a decimal" ]
-	 * [ "-0", "decimal", "Must be a decimal" ]
-	 * [ -0.0, "decimal", "Must be a decimal" ]
-	 * [ "-0.0", "decimal", "Must be a decimal" ]
-	 * [ 0, "decimal", "Must be a decimal" ]
-	 * [ "0", "decimal", "Must be a decimal" ]
-	 * [ 0.0, "decimal", "Must be a decimal" ]
-	 * [ "0.0", "decimal", "Must be a decimal" ]
-	 * [ -1.0, "decimal", "Must be a decimal" ]
-	 * [ "-1.0", "decimal", "Must be a decimal" ]
-	 * [ -1.11, "decimal", "Must be a decimal" ]
-	 * [ "-1.11", "decimal", "Must be a decimal" ]
-	 * [ 3.1415926535, "decimal", "Must be a decimal" ]
-	 * [ "3.1415926535", "decimal", "Must be a decimal" ]
-	 * [ 4.0, "decimal", "Must be a decimal" ]
-	 * [ "4.0", "decimal", "Must be a decimal" ]
-	 * [ 4.1, "decimal", "Must be a decimal" ]
-	 * [ "4.1", "decimal", "Must be a decimal" ]
-	 * [ 44.1, "decimal", "Must be a decimal" ]
-	 * [ "44.1", "decimal", "Must be a decimal" ]
-	 */
-	public function test_validate_number_type_accepts_valid_decimal_numbers( $value, $type, $message ) {
-		$this->assertNull( validate_number_type( $value, $type, $message ) );
+	public function test_validate_number_type_accepts_valid_decimal_numbers( $value, $type ) {
+		$this->assertNull( validate_number_type( $value, $type ) );
 	}
 
 	/**

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -9,6 +9,7 @@ use function WPE\AtlasContentModeler\API\validation\validate_in_array;
 use function WPE\AtlasContentModeler\API\validation\validate_array;
 use function WPE\AtlasContentModeler\API\validation\validate_string;
 use function WPE\AtlasContentModeler\API\validation\validate_number;
+use function WPE\AtlasContentModeler\API\validation\validate_decimal;
 use function WPE\AtlasContentModeler\API\validation\validate_date;
 use function WPE\AtlasContentModeler\API\validation\validate_min;
 use function WPE\AtlasContentModeler\API\validation\validate_max;
@@ -470,6 +471,49 @@ class TestValidationFunctions extends Integration_TestCase {
 	}
 
 	public function test_validate_number_will_use_the_custom_message() {
+		$message = 'That value is not a number';
+		$this->expectExceptionMessage( $message );
+
+		validate_number( null, $message );
+	}
+
+	/**
+	 * @testWith
+	 * [ -1 ]
+	 * [ "-1" ]
+	 * [ -1.0 ]
+	 * [ "-1.0" ]
+	 * [ 0 ]
+	 * [ "0" ]
+	 * [ 0.1 ]
+	 * [ "0.1" ]
+	 * [ 1 ]
+	 * [ "1" ]
+	 * [ 1.1 ]
+	 * [ "1.1" ]
+	 */
+	public function test_validate_decimal_will_return_null_on_success( $value ) {
+		$this->assertNull( validate_decimal( $value ) );
+	}
+
+	/**
+	 * @testWith
+	 * [ "" ]
+	 * [ "not_a_decimal" ]
+	 * [ [] ]
+	 * [ true ]
+	 * [ false ]
+	 * [ null ]
+	 * [ "1.1.1" ]
+	 */
+	public function test_validate_decimal_will_throw_an_exception_on_error( $value ) {
+		$this->expectException( Validation_Exception::class );
+		$this->expectExceptionMessage( 'Value must be a valid number' );
+
+		validate_number( $value );
+	}
+
+	public function test_validate_decimal_will_use_the_custom_message() {
 		$message = 'That value is not a number';
 		$this->expectExceptionMessage( $message );
 

--- a/tests/integration/api/test-validation-function.php
+++ b/tests/integration/api/test-validation-function.php
@@ -508,13 +508,13 @@ class TestValidationFunctions extends Integration_TestCase {
 	 */
 	public function test_validate_integer_will_throw_an_exception_on_error( $value ) {
 		$this->expectException( Validation_Exception::class );
-		$this->expectExceptionMessage( 'Value must be a valid number' );
+		$this->expectExceptionMessage( 'Value must be a valid integer' );
 
 		validate_integer( $value );
 	}
 
 	public function test_validate_integer_will_use_the_custom_message() {
-		$message = 'That value is not a number';
+		$message = 'That value is not an integer';
 		$this->expectExceptionMessage( $message );
 
 		validate_integer( null, $message );
@@ -551,13 +551,13 @@ class TestValidationFunctions extends Integration_TestCase {
 	 */
 	public function test_validate_decimal_will_throw_an_exception_on_error( $value ) {
 		$this->expectException( Validation_Exception::class );
-		$this->expectExceptionMessage( 'Value must be a valid number' );
+		$this->expectExceptionMessage( 'Value must be a valid decimal' );
 
 		validate_decimal( $value );
 	}
 
 	public function test_validate_decimal_will_use_the_custom_message() {
-		$message = 'That value is not a number';
+		$message = 'That value is not a decimal';
 		$this->expectExceptionMessage( $message );
 
 		validate_decimal( null, $message );


### PR DESCRIPTION
## Description

This pull request changes the way the `validate_number_type()` function when validate decimal values ending in 0 for `integer` type.

This pull request also added the `validate_integer()` and `validate_decimal()` functions.

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.
