### PR TITLE
Add 'wp acm model change-id' WP-CLI command to migrate model-ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Atlas Content Modeler Changelog
 
 ## Unreleased
+### Added
+- New `wp acm model change-id` WP-CLI command to change a model's ID and migrate existing posts to the new ID.
+
 ### Changed
 - Models can no longer be registered with IDs that match special WordPress Core names, such as ‘type’ and ‘theme’.
 - Existing models using reserved model IDs are disabled to prevent fatal errors and unexpected behavior from WordPress Core.

--- a/atlas-content-modeler.php
+++ b/atlas-content-modeler.php
@@ -68,8 +68,10 @@ function atlas_content_modeler_loader(): void {
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		include_once ATLAS_CONTENT_MODELER_INCLUDES_DIR . '/wp-cli/class-blueprint.php';
 		include_once ATLAS_CONTENT_MODELER_INCLUDES_DIR . '/wp-cli/class-reset.php';
+		include_once ATLAS_CONTENT_MODELER_INCLUDES_DIR . '/wp-cli/class-model.php';
 		\WP_CLI::add_command( 'acm blueprint', 'WPE\AtlasContentModeler\WP_CLI\Blueprint' );
 		\WP_CLI::add_command( 'acm reset', new WPE\AtlasContentModeler\WP_CLI\Reset() );
+		\WP_CLI::add_command( 'acm model', 'WPE\AtlasContentModeler\WP_CLI\Model' );
 	}
 
 	\WPE\AtlasContentModeler\VersionUpdater\update_plugin();

--- a/docs/wp-cli/index.md
+++ b/docs/wp-cli/index.md
@@ -109,3 +109,32 @@ wp acm reset --yes
 wp acm reset --all
 wp acm reset --yes --all
 ```
+
+## wp acm model change-id
+
+Requires: ACM 0.22.0+.
+
+### Description
+
+Change a model's ID (post type slug), migrating posts and taxonomy data.
+
+### Synopsis
+
+`wp acm model change-id <oldid> <newid> [--yes]`
+
+### Options
+
+`<oldid>`
+The original ID of the model to change.
+
+`<newid>`
+The new ID of the model. 20 character max, lowercase alphanumeric, underscores and hyphens only.
+
+`[--yes]`
+Skip prompt to confirm model ID change.
+
+### Examples
+
+```
+wp acm model change-id oldid newid
+```

--- a/includes/wp-cli/class-model.php
+++ b/includes/wp-cli/class-model.php
@@ -88,7 +88,7 @@ class Model {
 	 * @return bool True if ID change succeeded. Useful when running outside of the context of WP_CLI.
 	 * @throws \Exception Exception if ID change failed and function is run outside of the context of WP_CLI.
 	 */
-	public function change_id( $args, $assoc_args ) {
+	public function change_id( $args, $assoc_args = [] ) {
 		$old_id = $args[0];
 		$new_id = $args[1];
 

--- a/includes/wp-cli/class-model.php
+++ b/includes/wp-cli/class-model.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * WP-CLI command to alter and migrate ACM model data.
+ *
+ * `wp acm model change-id [oldid] [newid]`
+ *
+ * @package AtlasContentModeler
+ */
+
+declare(strict_types=1);
+
+namespace WPE\AtlasContentModeler\WP_CLI;
+
+require_once ATLAS_CONTENT_MODELER_INCLUDES_DIR . '/wp-cli/trait-acm-log.php';
+
+use WP_Error;
+
+use function WPE\AtlasContentModeler\ContentRegistration\get_registered_content_types;
+use function WPE\AtlasContentModeler\ContentRegistration\reserved_post_types;
+use function WPE\AtlasContentModeler\ContentRegistration\Taxonomies\get_acm_taxonomies;
+use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
+
+/**
+ * Adjust ACM model data.
+ */
+class Model {
+	use ACM_Log;
+
+	/**
+	 * ACM taxonomies.
+	 *
+	 * @var array
+	 */
+	private $taxonomies;
+
+	/**
+	 * ACM models.
+	 *
+	 * @var array
+	 */
+	private $models;
+
+	/**
+	 * Reserved post types.
+	 *
+	 * @var array
+	 */
+	private $reserved_post_types;
+
+	/**
+	 * Other post types, including those registered by other plugins.
+	 *
+	 * @var array
+	 */
+	private $post_types;
+
+	/**
+	 * Sets up data needed for the reset command.
+	 */
+	public function __construct() {
+		$this->taxonomies          = get_acm_taxonomies();
+		$this->models              = get_registered_content_types();
+		$this->reserved_post_types = reserved_post_types();
+		$this->post_types          = get_post_types();
+	}
+
+	/**
+	 * Change a model's ID (post type slug), migrating posts and taxonomy data.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <oldid>
+	 * : The original ID of the model to change.
+	 *
+	 * <newid>
+	 * : The new ID of the model. 20 character max, lowercase alphanumeric, underscores and hyphens only.
+	 *
+	 * [--yes]
+	 * : Skip prompt to confirm model ID change.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp acm model change-id oldid newid
+	 *
+	 * @subcommand change-id
+	 * @param array $args Options passed to the command, keyed by integer.
+	 * @param array $assoc_args Options keyed by string.
+	 * @return bool True if ID change succeeded. Useful when running outside of the context of WP_CLI.
+	 * @throws \Exception Exception if ID change failed and function is run outside of the context of WP_CLI.
+	 */
+	public function change_id( $args, $assoc_args ) {
+		$old_id = $args[0];
+		$new_id = $args[1];
+
+		if ( ! array_key_exists( $old_id, $this->models ) ) {
+			self::error( sprintf( 'No model exists with the old ID of ‘%s’.', $old_id ) );
+		}
+
+		$is_new_model_id_valid = $this->is_new_model_id_valid( $new_id );
+
+		if ( is_wp_error( $is_new_model_id_valid ) ) {
+			self::error( $is_new_model_id_valid );
+		}
+
+		self::confirm( sprintf( 'Change model ID from ‘%1$s’ to ‘%2$s’?', $old_id, $new_id ), $assoc_args );
+
+		$model_id_changed = $this->update_model_id( $old_id, $new_id );
+
+		if ( ! $model_id_changed ) {
+			self::error( 'Model ID update failed.' );
+		} else {
+			self::log( 'Model ID updated.' );
+		}
+
+		$posts_changed = $this->change_post_type( $old_id, $new_id );
+
+		if ( is_numeric( $posts_changed ) ) {
+			self::log(
+				/* translators: 1: singular number of posts, 2: plural number of posts  */
+				sprintf( _n( '%s post updated.', '%s posts updated.', $posts_changed, 'atlas-content-modeler' ), $posts_changed )
+			);
+		}
+
+		$taxonomies_changed = $this->update_taxonomy_ids( $old_id, $new_id );
+
+		if ( $taxonomies_changed ) {
+			self::log( 'Taxonomies updated.' );
+		}
+
+		self::success( sprintf( 'Model ID changed from ‘%1$s’ to ‘%2$s’.', $old_id, $new_id ) );
+
+		return true;
+	}
+
+	/**
+	 * Checks if `$new_id` is valid and available for use as an ACM model.
+	 *
+	 * @param string $new_id The new model ID.
+	 * @return bool|WP_Error True if valid, else WPError with explanation in message.
+	 */
+	private function is_new_model_id_valid( string $new_id ) {
+		if ( strlen( $new_id ) > 20 ) {
+			return new WP_Error(
+				'acm_invalid_model_id',
+				__( 'New model ID must not exceed 20 characters.', 'atlas-content-modeler' )
+			);
+		}
+
+		if ( is_numeric( $new_id[0] ) ) {
+			return new WP_Error(
+				'acm_invalid_model_id',
+				__( 'New model ID must not start with a number.', 'atlas-content-modeler' )
+			);
+		}
+
+		if ( sanitize_key( $new_id ) !== $new_id ) {
+			return new WP_Error(
+				'acm_invalid_model_id',
+				__( 'New model ID must only contain lowercase alphanumeric characters, underscores and hyphens.', 'atlas-content-modeler' )
+			);
+		}
+
+		if ( array_key_exists( $new_id, $this->models ) ) {
+			return new WP_Error(
+				'acm_invalid_model_id',
+				// translators: model name.
+				sprintf( __( 'New ID of ‘%s’ is in use by another model.', 'atlas-content-modeler' ), $new_id )
+			);
+		}
+
+		if ( in_array( $new_id, $this->reserved_post_types, true ) ) {
+			return new WP_Error(
+				'acm_invalid_model_id',
+				// translators: model name.
+				sprintf( __( 'New ID of ‘%s’ is reserved or in use by WordPress Core.', 'atlas-content-modeler' ), $new_id )
+			);
+		}
+
+		if ( in_array( $new_id, $this->post_types, true ) ) {
+			return new WP_Error(
+				'acm_invalid_model_id',
+				// translators: model name.
+				sprintf( __( 'New ID of ‘%s’ is in use by a custom post type.', 'atlas-content-modeler' ), $new_id )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Updates the ACM model ID from `$old_type` to `$new_type`.
+	 *
+	 * Also updates references to `$old_type` in field data, such as the
+	 * 'reference' key in relationship fields.
+	 *
+	 * @param string $old_type Old model ID.
+	 * @param string $new_type New model ID.
+	 * @return boolean True if content type was updated, false if update failed or `$old_type` does not exist.
+	 */
+	private function update_model_id( string $old_type, string $new_type ) {
+		if ( ! array_key_exists( $old_type, $this->models ) ) {
+			return false;
+		}
+
+		$this->models[ $new_type ] = $this->models[ $old_type ];
+		unset( $this->models[ $old_type ] );
+
+		$this->models[ $new_type ]['slug'] = $new_type;
+
+		$this->replace_relationship_references( $old_type, $new_type );
+
+		return update_registered_content_types( $this->models );
+	}
+
+	/**
+	 * Changes post types from `$old_type` to `$new_type` in the WP posts table.
+	 *
+	 * @param string $old_type Old model ID. Should be an existing post type slug.
+	 * @param string $new_type New model ID. Confirm this is a valid post slug before passing to this function.
+	 * @return int|bool Number of rows affected or false on error.
+	 */
+	private function change_post_type( string $old_type, string $new_type ) {
+		global $wpdb;
+
+		return $wpdb->query( // phpcs:ignore -- direct database call for speed/simplicity.
+			$wpdb->prepare(
+				"UPDATE `{$wpdb->posts}` SET `post_type` = %s WHERE `post_type` = %s;",
+				sanitize_key( $new_type ),
+				sanitize_key( $old_type )
+			)
+		);
+	}
+
+	/**
+	 * Updates ACM taxonomies that reference `$old_type` to use `$new_type`.
+	 *
+	 * @param string $old_type Old model ID.
+	 * @param string $new_type New model ID.
+	 * @return bool True if taxonomy data changed, false otherwise.
+	 */
+	private function update_taxonomy_ids( string $old_type, string $new_type ) {
+		foreach ( $this->taxonomies as $taxonomy => $data ) {
+			if ( ! array_key_exists( 'types', $data ) ) {
+				continue;
+			}
+
+			$this->taxonomies[ $taxonomy ]['types'] = str_replace(
+				$old_type,
+				$new_type,
+				$data['types']
+			);
+		}
+
+		return update_option( 'atlas_content_modeler_taxonomies', $this->taxonomies );
+	}
+
+	/**
+	 * Replaces `$old_type` with `$new_type` in relationship field references.
+	 *
+	 * Example: `replace_relationship_references( 'old', 'new' )` turns a field
+	 * with these properties:
+	 *
+	 * `[ 'type' => 'relationship', 'reference' => 'old', … ]`
+	 *
+	 * Into this:
+	 *
+	 * `[ 'type' => 'relationship', 'reference' => 'new', … ]`
+	 *
+	 * The `$this->models` property is mutated directly, so nothing is returned.
+	 * Callers should do `update_registered_content_types( $this->models )` if
+	 * they want to commit changes to the WP database.
+	 *
+	 * @param string $old_type Old model ID.
+	 * @param string $new_type New model ID.
+	 */
+	private function replace_relationship_references( string $old_type, string $new_type ) {
+		foreach ( $this->models as $model_id => $model_data ) {
+			if ( ! array_key_exists( 'fields', $model_data ) ) {
+				continue;
+			}
+
+			foreach ( $model_data['fields'] as $field_id => $field_data ) {
+				if ( $field_data['type'] !== 'relationship' ) {
+					continue;
+				}
+
+				if ( ! array_key_exists( 'reference', $field_data ) ) {
+					continue;
+				}
+
+				$this->models[ $model_id ]['fields'][ $field_id ]['reference'] = str_replace(
+					$old_type,
+					$new_type,
+					$field_data['reference']
+				);
+			}
+		}
+	}
+}

--- a/includes/wp-cli/trait-acm-log.php
+++ b/includes/wp-cli/trait-acm-log.php
@@ -23,9 +23,9 @@ trait ACM_Log {
 	/**
 	 * Logs output with WP_CLI if available.
 	 *
-	 * @param [type] $message Message to write to STDOUT.
+	 * @param string $message Message to write to STDOUT.
 	 */
-	public static function log( $message ) {
+	public static function log( string $message ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::log( $message );
 		}
@@ -54,7 +54,7 @@ trait ACM_Log {
 	 *
 	 * @param string $message Message to write to STDOUT.
 	 */
-	public static function success( $message ) {
+	public static function success( string $message ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::success( $message );
 		}
@@ -66,7 +66,7 @@ trait ACM_Log {
 	 * @param string $question Question to display before the prompt.
 	 * @param array  $args Skips prompt if 'yes' key exists and is `true`.
 	 */
-	public static function confirm( $question, $args ) {
+	public static function confirm( string $question, array $args ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::confirm( $question, $args );
 		}

--- a/includes/wp-cli/trait-acm-log.php
+++ b/includes/wp-cli/trait-acm-log.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Trait to log messages or throw exceptions in contexts where WP_CLI may or
+ * may not be available.
+ *
+ * Allows classes to `use ACM_Log;` then call `self::error( 'message' );`.
+ * That class can safely be used and tested whether or not `WP_CLI::error()`
+ * is available.
+ *
+ * For examples see `includes/wp-cli/class-model.php`.
+ *
+ * @package AtlasContentModeler
+ */
+
+namespace WPE\AtlasContentModeler\WP_CLI;
+
+use WP_Error;
+
+/**
+ * ACM_Log trait to wrap WP_CLI static methods for safe use outside of WP_CLI.
+ */
+trait ACM_Log {
+	/**
+	 * Logs output with WP_CLI if available.
+	 *
+	 * @param [type] $message Message to write to STDOUT.
+	 */
+	public static function log( $message ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::log( $message );
+		}
+	}
+
+	/**
+	 * Errors and exits if WP_CLI is available, otherwise throws an exception.
+	 *
+	 * @param string|WP_Error $message Message to write to STDERR.
+	 * @throws \Exception Exception if WP_CLI is not available.
+	 */
+	public static function error( $message ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::error( $message );
+		}
+
+		if ( is_wp_error( $message ) ) {
+			$message = $message->get_error_message();
+		}
+
+		throw new \Exception( $message );
+	}
+
+	/**
+	 * Logs a success message with WP_CLI if available.
+	 *
+	 * @param string $message Message to write to STDOUT.
+	 */
+	public static function success( $message ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::success( $message );
+		}
+	}
+
+	/**
+	 * Prompts user to confirm an action if WP_CLI is available.
+	 *
+	 * @param string $question Question to display before the prompt.
+	 * @param array  $args Skips prompt if 'yes' key exists and is `true`.
+	 */
+	public static function confirm( $question, $args ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::confirm( $question, $args );
+		}
+	}
+}

--- a/tests/integration/content-registration/test-relationships-db.php
+++ b/tests/integration/content-registration/test-relationships-db.php
@@ -2,13 +2,6 @@
 use WPE\AtlasContentModeler\ContentConnect\Tables\PostToPost;
 
 class TestRelationshipsDB extends WP_UnitTestCase {
-	public function tear_down(): void {
-		global $wpdb;
-		parent::tear_down();
-		$table = $wpdb->prefix . 'acm_post_to_post';
-		$wpdb->query( "DROP TABLE IF EXISTS $table" );
-	}
-
 	public function test_relationships_db_exists(): void {
 		/**
 		 * @var \wpdb $wpdb

--- a/tests/integration/wp-cli/test-model-change-id.php
+++ b/tests/integration/wp-cli/test-model-change-id.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Tests model ID migration.
+ *
+ * @package AtlasContentModeler
+ */
+
+use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
+
+require_once ATLAS_CONTENT_MODELER_INCLUDES_DIR . '/wp-cli/class-model.php';
+
+/**
+ * Class ModelChangeIdTest
+ *
+ * @covers WPE\AtlasContentModeler\WP_CLI\Model
+ */
+class ModelChangeIdTest extends WP_UnitTestCase {
+	private $model;
+
+	public function set_up() {
+		parent::set_up();
+
+		$models = [
+			'old-id' => [
+				'slug'     => 'old-id',
+				'singular' => 'Old ID',
+				'plural'   => 'Old IDs',
+				'fields'   => [],
+			],
+		];
+
+		update_registered_content_types( $models );
+
+		$this->model = new \WPE\AtlasContentModeler\WP_CLI\Model();
+	}
+
+	public function test_model_id_is_not_updated_if_old_id_not_in_model_list() {
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'No model exists with the old ID of ‘bad-old-id’.' );
+
+		$this->model->change_id( [ 'bad-old-id', 'new-id' ] );
+	}
+
+	public function test_model_id_is_not_updated_if_new_id_is_longer_than_20_chars() {
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'New model ID must not exceed 20 characters.' );
+
+		$this->model->change_id( [ 'old-id', 'bad-new-id-that-is-longer-than-20-characters' ] );
+	}
+
+	public function test_model_id_is_not_updated_if_new_id_starts_with_number() {
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'New model ID must not start with a number.' );
+
+		$this->model->change_id( [ 'old-id', '7bad-new-id' ] );
+	}
+
+	public function test_model_id_is_not_updated_if_new_id_has_invalid_characters() {
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'New model ID must only contain lowercase alphanumeric characters, underscores and hyphens.' );
+
+		$this->model->change_id( [ 'old-id', 'bad-new-id-@!!!' ] );
+	}
+
+	public function test_model_id_is_not_updated_if_new_id_is_in_use_by_another_model() {
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'New ID of ‘old-id’ is in use by another model.' );
+
+		$this->model->change_id( [ 'old-id', 'old-id' ] );
+	}
+
+	public function test_model_id_is_not_updated_if_new_id_is_a_reserved_slug() {
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'New ID of ‘theme’ is reserved or in use by WordPress Core.' );
+
+		$this->model->change_id( [ 'old-id', 'theme' ] );
+	}
+
+	public function test_model_id_is_not_updated_if_new_id_is_in_use_by_a_custom_post_type() {
+		register_post_type( 'custom-post-type', [] );
+		$this->model = new \WPE\AtlasContentModeler\WP_CLI\Model();
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'New ID of ‘custom-post-type’ is in use by a custom post type.' );
+
+		$this->model->change_id( [ 'old-id', 'custom-post-type' ] );
+	}
+}

--- a/tests/integration/wp-cli/test-model-change-id.php
+++ b/tests/integration/wp-cli/test-model-change-id.php
@@ -36,8 +36,6 @@ class ModelChangeIdTest extends WP_UnitTestCase {
 	 */
 	private $post_count = 2;
 
-	private $relationships_registry;
-
 	private $term_id;
 
 	public function set_up() {
@@ -82,8 +80,7 @@ class ModelChangeIdTest extends WP_UnitTestCase {
 		update_registered_content_types( $models );
 		save_taxonomy( $test_taxonomy, false );
 		register_acm_taxonomies();
-		$this->relationships_registry = \WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->get_registry();
-		register_relationships( $this->relationships_registry );
+		register_relationships( \WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->get_registry() );
 
 		$this->term_id = $this->factory()->term->create(
 			[


### PR DESCRIPTION
## Description

Adds a `wp acm model change id [old-id] [new-id]` WP-CLI command to help users change model IDs and migrate posts between the old and new ID.

I've written this in a way that the same logic will work outside of a WP-CLI context (used in this PR's tests without invoking WP-CLI, but also useful as a backup to support customers who don't/won't use WP-CLI). For example, save [this file](https://gist.github.com/nickcernis/118b21d6661088a0d4383fb423f1cb12) in `/plugins/`, then activate the plugin and you'll be able to change model IDs by visiting `/wp-admin/plugins.php?acm_old_model_id=old&acm_new_model_id=new`.

https://wpengine.atlassian.net/browse/MTKA-1615

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

Includes tests.

To test manually:

1. Create a model with a relationship field and a custom taxonomy.
2. Add posts that relate to other posts and tag some with custom taxonomy terms.
3. In WP-CLI, run `wp acm model change-id [old-id] [new-id]` where `old-id` is the model ID of your model. (Optionally skip the confirmation prompt with `--yes`.)

After you refresh your admin page in WordPress, the model you changed the ID for should still be accessible (it will have the same label, but your new model ID). Posts should still be present, with any relationships and taxonomy terms.

## Screenshots

```
> wp acm model change-id type type
Error: New ID of ‘type’ is in use by another model.

x wp acm model change-id type bad!@model@name
Error: New model ID must only contain lowercase alphanumeric characters, underscores and hyphens.

x wp acm model change-id type 1badmodelname
Error: New model ID must not start with a number.

x wp acm model change-id type modelnamethatexceeds20characters
Error: New model ID must not exceed 20 characters.

x wp acm model change-id type author
Error: New ID of ‘author’ is reserved or in use by WordPress Core.

x wp acm model change-id type acf-field
Error: New ID of ‘acf-field’ is in use by a custom post type.

x wp acm model change-id type this-should-work
Change model ID from ‘type’ to ‘this-should-work’? [y/n] y
Model ID updated.
2 posts updated.
Success: Model ID changed from ‘type’ to ‘this-should-work’.
```

## Documentation Changes

Extended existing CLI docs.