### PR TITLE
Prepare for 0.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Atlas Content Modeler Changelog
 
-## Unreleased
+## 0.22.0 - 2022-09-22
 ### Added
 - New `wp acm model change-id` WP-CLI command to change a model's ID and migrate existing posts to the new ID.
 

--- a/atlas-content-modeler.php
+++ b/atlas-content-modeler.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpengine.com/
  * Text Domain: atlas-content-modeler
  * Domain Path: /languages
- * Version: 0.21.1
+ * Version: 0.22.0
  * Requires at least: 5.7
  * Requires PHP: 7.2
  * License: GPLv2 or later

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "atlas-content-modeler",
-  "version": "0.21.1",
+  "name": "@wpengine/atlas-content-modeler",
+  "version": "0.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "atlas-content-modeler",
-      "version": "0.21.1",
+      "name": "@wpengine/atlas-content-modeler",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-jsx": "^7.12.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "atlas-content-modeler",
-  "version": "0.21.1",
+  "name": "@wpengine/atlas-content-modeler",
+  "version": "0.22.0",
   "description": "",
   "targets": {
     "settings": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.2
-Stable tag: 0.21.1
+Stable tag: 0.22.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Author: WP Engine
@@ -53,6 +53,13 @@ ACM is primarily intended for headless WordPress applications. For that reason, 
 You can submit feature requests and open bug reports in our [GitHub repo](https://github.com/wpengine/atlas-content-modeler).
 
 == Changelog ==
+
+= 0.22.0 - 2022-09-22 =
+
+* **Added:** New `wp acm model change-id` WP-CLI command to change a model's ID and migrate existing posts to the new ID.
+* **Changed:** Models can no longer be registered with IDs that match special WordPress Core names, such as ‘type’ and ‘theme’.
+* **Changed:** Existing models using reserved model IDs are disabled to prevent fatal errors and unexpected behavior from WordPress Core.
+* **Changed:** Disabled models with reserved model IDs display a message on the model index page, with a link to docs explaining how to change the model ID: https://github.com/wpengine/atlas-content-modeler/blob/main/docs/help/model-id-conflicts.md.
 
 = 0.21.1 - 2022-09-07 =
 


### PR DESCRIPTION
Bumps versions and adjusts docs for the 0.22.0 release.

* **Added:** New `wp acm model change-id` WP-CLI command to change a model's ID and migrate existing posts to the new ID.
* **Changed:** Models can no longer be registered with IDs that match special WordPress Core names, such as ‘type’ and ‘theme’.
* **Changed:** Existing models using reserved model IDs are disabled to prevent fatal errors and unexpected behavior from WordPress Core.
* **Changed:** Disabled models with reserved model IDs display a message on the model index page, with a link to docs explaining how to change the model ID: https://github.com/wpengine/atlas-content-modeler/blob/main/docs/help/model-id-conflicts.md.