### PR TITLE
MTKA-1807: fix failing phpunit test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,7 +410,7 @@ jobs:
       - run:
           name: Setup WordPress testing framework
           command: |
-            /bin/bash tests/install-wp-tests.sh wp_database wp_user wp_pass 127.0.0.1 latest true
+            /bin/bash tests/install-wp-tests.sh wp_database wp_user wp_pass 127.0.0.1 6.0 true
           working_directory: <<parameters.slug>>
       - run:
           name: Run testing suite
@@ -441,7 +441,7 @@ jobs:
       - run:
           name: Setup WordPress testing framework
           command: |
-            /bin/bash tests/install-wp-tests.sh wp_database wp_user wp_pass 127.0.0.1 latest true
+            /bin/bash tests/install-wp-tests.sh wp_database wp_user wp_pass 127.0.0.1 6.0 true
           working_directory: <<parameters.slug>>
       - run:
           name: Run content connect testing suite


### PR DESCRIPTION
This temporarily changes the WP test suite version to 6.0, to get around a caching issue in CircleCI that's causing the tests to fail. [Example failure](https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/3590/workflows/044e36ce-c338-43a8-bf82-9eed23f0e8b6/jobs/40111).

These failures do not happen locally. Through the process of elimination, @rfmeier and I determined that it's some kind of cache issue on CircleCI.


## Description

<!--
What changed and why?
-->

<!--
Link to the JIRA ticket if available.
-->

https://wpengine.atlassian.net/browse/MTKA-1807

## Checklist

I have:

- [ ] Added an entry to CHANGELOG.md.

## Testing

<!--
What automated tests did you add to prove the changes work?
-->

<!--
What steps should reviewers take to test manually?
-->

## Screenshots

<!--
Add screenshots from before and after if your change is visual.
-->

## Documentation Changes

<!--
Add links to documentation or wiki changes.
-->

## Dependent PRs

<!--
List dependent PRs awaiting review with this syntax:

Depends on #1234.
-->
