### PR TITLE
MTKA-1784: Add support for post type archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Added
-- Added a “Post Type Archives” option on the edit model screen enable custom post type archives (The WordPress `has_archive` setting. false by default).
+- Added a “Post Type Archives” option on the edit model screen to control custom post type archives (The WordPress `has_archive` setting. false by default).
 
 ## 0.22.0 - 2022-09-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Added
+- Added a “Post Type Archives” option on the edit model screen enable custom post type archives (The WordPress `has_archive` setting. false by default).
+
 ## 0.22.0 - 2022-09-22
 ### Added
 - New `wp acm model change-id` WP-CLI command to change a model's ID and migrate existing posts to the new ID.

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -388,7 +388,7 @@ function generate_custom_post_type_args( array $args ): array {
 		'rest_controller_class' => __NAMESPACE__ . '\REST_Posts_Controller',
 		'rewrite'               => [
 			'with_front' => $args['with_front'] ?? true,
-			'slug'       => $args['slug'],
+			'slug'       => $args['slug'] ?? sanitize_key( $args['singular'] ),
 		],
 		'has_archive'           => (bool) ( $args['has_archive'] ?? false ),
 	];

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -589,13 +589,12 @@ function register_content_fields_with_graphql( TypeRegistry $type_registry ) {
 						if ( $is_repeatable_field ) {
 							return array_map(
 								function( $media_id ) use ( $context ) {
-									return DataSource::resolve_post_object( (int) $media_id, $context );
+									return $context->get_loader( 'post' )->load_deferred( (int) $media_id );
 								},
 								$value
 							);
 						}
-
-						return DataSource::resolve_post_object( (int) $value, $context );
+						return $context->get_loader( 'post' )->load_deferred( (int) $value );
 					}
 
 					// If the multiple choice field has no saved data, return an empty array.

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -388,7 +388,9 @@ function generate_custom_post_type_args( array $args ): array {
 		'rest_controller_class' => __NAMESPACE__ . '\REST_Posts_Controller',
 		'rewrite'               => [
 			'with_front' => $args['with_front'] ?? true,
+			'slug'       => $args['slug'],
 		],
+		'has_archive'           => (bool) ( $args['has_archive'] ?? false ),
 	];
 
 	if ( ! empty( $args['api_visibility'] ) && 'private' === $args['api_visibility'] ) {

--- a/includes/rest-api/models.php
+++ b/includes/rest-api/models.php
@@ -282,6 +282,10 @@ function update_model( string $post_type_slug, array $args ) {
 		$args['with_front'] = 0;
 	}
 
+	if ( empty( $args['has_archive'] ) ) {
+		$args['has_archive'] = 0;
+	}
+
 	$new_args = wp_parse_args( $args, $content_types[ $post_type_slug ] );
 
 	// Updating the slug is unsupported.

--- a/includes/settings/js/src/components/EditModelModal.jsx
+++ b/includes/settings/js/src/components/EditModelModal.jsx
@@ -349,23 +349,33 @@ export function EditModelModal({ model, isOpen, setIsOpen }) {
 				</div>
 
 				<div className="row">
-					<div className="field col-sm">
-						<label htmlFor="model_icon">
-							{__("Model Icon", "atlas-content-modeler")}
-						</label>
+					<div className="field form-check form-check-inline col-sm">
+						<label htmlFor="has_archive">Post Type Archive</label>
 						<p className="help">
 							{__(
-								"Choose an icon to represent your model.",
+								"Whether there should be a post type archive. (Sets “has_archive”.)",
 								"atlas-content-modeler"
 							)}
 						</p>
 
-						<IconPicker
-							setValue={setValue}
-							buttonClasses="primary first"
-							register={register}
-							modelIcon={model.model_icon}
+						<input
+							name="has_archive"
+							id="has_archive"
+							type="checkbox"
+							value="1"
+							ref={register}
+							defaultChecked={model?.has_archive ?? false}
 						/>
+
+						<label
+							htmlFor="has_archive"
+							className="form-check-label"
+						>
+							{__(
+								"Enable post type archive",
+								"atlas-content-modeler"
+							)}
+						</label>
 					</div>
 					<div
 						className={
@@ -400,6 +410,27 @@ export function EditModelModal({ model, isOpen, setIsOpen }) {
 								"atlas-content-modeler"
 							)}
 						</label>
+					</div>
+				</div>
+
+				<div className="row">
+					<div className="field col-sm">
+						<label htmlFor="model_icon">
+							{__("Model Icon", "atlas-content-modeler")}
+						</label>
+						<p className="help">
+							{__(
+								"Choose an icon to represent your model.",
+								"atlas-content-modeler"
+							)}
+						</p>
+
+						<IconPicker
+							setValue={setValue}
+							buttonClasses="primary first"
+							register={register}
+							modelIcon={model.model_icon}
+						/>
 					</div>
 				</div>
 

--- a/tests/acceptance/EditContentModelCest.php
+++ b/tests/acceptance/EditContentModelCest.php
@@ -25,6 +25,8 @@ class EditContentModelCest {
 		$i->fillField( [ 'name' => 'description' ], 'Cats are better than candy.' );
 		$i->see( '27/250', 'span.count' );
 		$i->uncheckOption( [ 'name' => 'with_front' ] );
+		$i->dontSeeCheckboxIsChecked( [ 'name' => 'has_archive' ] );
+		$i->checkOption( [ 'name' => 'has_archive' ] );
 
 		// Change the model's icon.
 		$i->click( '.dashicons-picker' );
@@ -55,6 +57,7 @@ class EditContentModelCest {
 		$i->click( '.model-list button.options' );
 		$i->click( '.dropdown-content a.edit' );
 		$i->dontSeeCheckboxIsChecked( [ 'name' => 'with_front' ] );
+		$i->seeCheckboxIsChecked( [ 'name' => 'has_archive' ] );
 		$i->seeInField( [ 'name' => 'singular' ], 'Cat' );
 		$i->seeInField( [ 'name' => 'plural' ], 'Cats' );
 	}

--- a/tests/integration/api-validation/test-data/models.php
+++ b/tests/integration/api-validation/test-data/models.php
@@ -16,6 +16,8 @@ return array(
 		'api_visibility'  => 'public',
 		'model_icon'      => 'dashicons-admin-post',
 		'description'     => "A public model for testing\n",
+		'with_front'      => true,
+		'has_archive'     => true,
 		'fields'          => array(),
 	),
 	'private'        => array(

--- a/tests/integration/publisher/test-post-type-archives.php
+++ b/tests/integration/publisher/test-post-type-archives.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests Post Type Archives
+ *
+ * @package AtlasContentModeler
+ */
+
+use function WPE\AtlasContentModeler\ContentRegistration\update_registered_content_types;
+
+class TestPostTypeArchives extends WP_UnitTestCase {
+	private $post_ids;
+
+	public function set_up() {
+		parent::set_up();
+
+		/**
+		 * Reset the WPGraphQL schema before each test.
+		 * Lazy loading types only loads part of the schema,
+		 * so we refresh for each test.
+		 */
+		WPGraphQL::clear_schema();
+
+		// Start each test with a fresh relationships registry.
+		\WPE\AtlasContentModeler\ContentConnect\Plugin::instance()->setup();
+
+		update_registered_content_types( $this->get_models() );
+
+		do_action( 'init' );
+
+		$this->post_ids = $this->get_post_ids();
+	}
+
+	private function get_models() {
+		return include dirname( __DIR__ ) . '/api-validation/test-data/models.php';
+	}
+
+	private function get_post_ids() {
+		include_once dirname( __DIR__ ) . '/api-validation/test-data/posts.php';
+
+		return create_test_posts( $this );
+	}
+
+	public function test_has_archive_is_not_used_by_default(): void {
+		$post_type    = get_post_type( $this->post_ids['public_fields_post_id'] );
+		$archive_link = get_post_type_archive_link( $post_type );
+		self::assertSame( false, $archive_link );
+	}
+
+	public function test_has_archive_is_used_when_model_is_configured_to_have_an_archive(): void {
+		$this->set_permalink_structure( '/moo/%postname%/' );
+		$post_type    = get_post_type( $this->post_ids['public_post_id'] );
+		$archive_link = get_post_type_archive_link( $post_type );
+		self::assertSame( 'http://example.org/moo/public/', $archive_link );
+
+		$this->set_permalink_structure( '/%postname%/' );
+		$archive_link = get_post_type_archive_link( $post_type );
+		self::assertSame( 'http://example.org/public/', $archive_link );
+	}
+}


### PR DESCRIPTION
## Description
Adds an option to the Edit Model modal that lets users control whether a post type archive is supported.

Enabling this option tells ACM to pass the `has_archive => true` option to `register_post_type()`. This results in WordPress enabling post type archives on the front end - e.g. `https://example.com/rabbits` to see a list of all rabbits. This also results in `get_post_type_archive_link()` returning a valid archive URL for the given post type, which otherwise returns `false`.

`has_archive` is not enabled by default in WordPress, and is therefore not enabled by default in ACM. The checkbox must be ticked to enable the feature.

https://wpengine.atlassian.net/browse/MTKA-1784

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.
- [X] Added tests.

## Testing

<!--
What automated tests did you add to prove the changes work?
-->

<!--
What steps should reviewers take to test manually?
-->

## Screenshots
Screenshot of new "Post Type Archive" option highlighted:
![image](https://user-images.githubusercontent.com/1254870/201410174-43bef634-fd97-43ad-9a22-619b497c12bb.png)


