### PR TITLE
fix: return empty nodes/edges values when no connections exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Atlas Content Modeler Changelog
 
+## Unreleased
+### Fixed
+- Querying posts with optional relationships will no longer raise an error in WPGraphQL when connections do not exist. Addresses changes made in WPGraphQL 1.13.x.
 ## 0.23.0 - 2022-11-15
 ### Added
 - Added a “Post Type Archives” option on the edit model screen to control custom post type archives (The WordPress `has_archive` setting. false by default).

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -745,7 +745,10 @@ function register_relationship_connection( array $parent_model, array $reference
 					$relationship_ids = $relationship->get_related_object_ids( $post->ID );
 
 					if ( empty( $relationship_ids ) ) {
-						return array();
+						return [
+							'edges' => [],
+							'nodes' => [],
+						];
 					}
 
 					$resolver = new PostObjectConnectionResolver(


### PR DESCRIPTION
Closes #643

## Description

Fixes an issue where WPGraphQL would raise an "internal server error" with the text "Cannot return null for non-nullable field" when an optional relationship on a post entry has no connections to another post object.

This was introduced in changes in WPGraphQL 1.13.x.

See #643 for reproduction steps.

<!--
Link to the JIRA ticket if available.
-->

https://wpengine.atlassian.net/browse/MTKA-1977

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

<!--
What automated tests did you add to prove the changes work?
-->

<!--
What steps should reviewers take to test manually?
-->

## Screenshots

<!--
Add screenshots from before and after if your change is visual.
-->

## Documentation Changes

<!--
Add links to documentation or wiki changes.
-->

## Dependent PRs

<!--
List dependent PRs awaiting review with this syntax:

Depends on #1234.
-->
