### PR TITLE
fix: ensure value is array when passing to array_map(). Closes #626.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Atlas Content Modeler Changelog
+## Unreleased
+### Fixed
+- GraphQL queries now work properly when repeating Rich Text fields are optional and have no values.
 
 ## 0.24.0 - 2023-02-23
 ### Fixed

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -605,7 +605,7 @@ function register_content_fields_with_graphql( TypeRegistry $type_registry ) {
 					// Fixes caption shortcode for GraphQL output.
 					if ( 'richtext' === $acm_field_type ) {
 						if ( $is_repeatable_field ) {
-							return array_map( 'do_shortcode', $value );
+							return array_map( 'do_shortcode', (array) $value );
 						}
 
 						return do_shortcode( $value );

--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -573,6 +573,14 @@ function register_content_fields_with_graphql( TypeRegistry $type_registry ) {
 				if ( 'relationship' !== $acm_field_type ) {
 					$value = get_post_meta( $post->databaseId, $field['slug'], true );
 
+					if ( $is_repeatable_field && empty( $value ) ) {
+						$value = [];
+					}
+
+					if ( $is_repeatable_field && ! is_array( $value ) ) {
+						$value = (array) $value;
+					}
+
 					/**
 					 * If WPGraphQL expects a float and something else is returned instead
 					 * it causes a runaway PHP process and it eventually dies due to
@@ -605,7 +613,7 @@ function register_content_fields_with_graphql( TypeRegistry $type_registry ) {
 					// Fixes caption shortcode for GraphQL output.
 					if ( 'richtext' === $acm_field_type ) {
 						if ( $is_repeatable_field ) {
-							return array_map( 'do_shortcode', (array) $value );
+							return array_map( 'do_shortcode', $value );
 						}
 
 						return do_shortcode( $value );
@@ -613,14 +621,6 @@ function register_content_fields_with_graphql( TypeRegistry $type_registry ) {
 
 					if ( $acm_field_type === 'boolean' ) {
 						return $value === 'on' ? true : false;
-					}
-
-					if ( $is_repeatable_field && empty( $value ) ) {
-						$value = [];
-					}
-
-					if ( $is_repeatable_field && ! is_array( $value ) ) {
-						$value = (array) $value;
 					}
 
 					return $value;

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -497,4 +497,42 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
 		}
 	}
+
+	public function test_graphql_queries_work_with_repeating_rich_text_fields_that_have_no_data_saved(): void {
+		$new_field = array(
+			'show_in_rest'         => true,
+			'show_in_graphql'      => true,
+			'type'                 => 'richtext',
+			'id'                   => '1646070399',
+			'position'             => '350000',
+			'name'                 => 'RichTextRepeatableOptional',
+			'slug'                 => 'richTextRepeatableOptional',
+			'required'             => false,
+			'isRepeatableRichText' => 'true',
+		);
+
+		$this->test_models['public-fields']['fields']['1646070399'] = $new_field;
+		update_registered_content_types( $this->test_models );
+
+		try {
+			$results = graphql(
+				[
+					'query' => '
+				{
+					publicsFields {
+						nodes {
+							databaseId
+							richTextRepeatableOptional
+						}
+					}
+				}
+				',
+				]
+			);
+
+			self::assertSame( [], $results['data']['publicsFields']['nodes'][0]['richTextRepeatableOptional'] );
+		} catch ( Exception $exception ) {
+			throw new PHPUnitRunnerException( sprintf( __FUNCTION__ . ' failed with exception: %s', $exception->getMessage() ) );
+		}
+	}
 }


### PR DESCRIPTION
## Description
Ensures values for repeating rich text fields are cast as an array before passing through `array_map()`. This fixes issues where optional repeating rich text fields are empty, but the plugin incorrectly assumes it will have an array value.

<!--
Link to the JIRA ticket if available.
-->

https://wpengine.atlassian.net/browse/

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.
- [x] Added tests

## Testing

<!--
What automated tests did you add to prove the changes work?
-->

<!--
What steps should reviewers take to test manually?
-->

## Screenshots

<!--
Add screenshots from before and after if your change is visual.
-->

## Documentation Changes

<!--
Add links to documentation or wiki changes.
-->

## Dependent PRs

<!--
List dependent PRs awaiting review with this syntax:

Depends on #1234.
-->
