### PR TITLE
MERL-923: Run phpunit tests against latest nightly WP build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,3 +638,53 @@ workflows:
                # tag ex. 1.0.0
                only: /^\S+/
            context: wpe-wporg-svn-creds
+
+  nightly-testing:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ nightly_testing, << pipeline.schedule.name >> ]
+    jobs:
+      - plugin-checkout:
+          slug: atlas-content-modeler
+          filename: atlas-content-modeler.php
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
+      - plugin-build-composer:
+          slug: atlas-content-modeler
+          requires:
+            - plugin-checkout
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
+      - plugin-build-npm:
+          slug: atlas-content-modeler
+          requires:
+            - plugin-checkout
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
+      - plugin-test-unit:
+          matrix:
+            parameters:
+              wordpress-version: [ "nightly" ]
+          requires:
+            - plugin-build-zip
+            - plugin-build-composer
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/
+      - plugin-test-content-connect:
+          slug: atlas-content-modeler
+          requires:
+            - plugin-build-zip
+            - plugin-build-composer
+          # run this job for any build, any branch
+          filters:
+            tags:
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,8 +388,9 @@ jobs:
           MYSQL_PASSWORD: wp_pass
           MYSQL_ROOT_PASSWORD: password
     parameters:
-      slug:
+      wordpress-version:
         type: string
+        default: "latest"
     steps:
       - attach_workspace:
           at: .
@@ -401,13 +402,13 @@ jobs:
       - run:
           name: Setup WordPress testing framework
           command: |
-            /bin/bash tests/install-wp-tests.sh wp_database wp_user wp_pass 127.0.0.1 6.0 true
-          working_directory: <<parameters.slug>>
+            /bin/bash tests/install-wp-tests.sh wp_database wp_user wp_pass 127.0.0.1 <<parameters.wordpress-version>> true
+          working_directory: "atlas-content-modeler"
       - run:
           name: Run testing suite
           command: |
             composer test
-          working_directory: <<parameters.slug>>
+          working_directory: "atlas-content-modeler"
 
   plugin-test-content-connect:
     docker:
@@ -571,7 +572,9 @@ workflows:
             tags:
               only: /.*/
       - plugin-test-unit:
-          slug: atlas-content-modeler
+          matrix:
+            parameters:
+              wordpress-version: [ "nightly", "6.2" ]
           requires:
             - plugin-build-zip
             - plugin-build-composer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,7 +574,7 @@ workflows:
       - plugin-test-unit:
           matrix:
             parameters:
-              wordpress-version: [ "nightly", "6.2" ]
+              wordpress-version: [ "nightly", "6.3" ]
           requires:
             - plugin-build-zip
             - plugin-build-composer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
   plugin-test-e2e:
     docker:
       - image: cimg/php:7.4-browsers
-      - image: cimg/mysql:5.7
+      - image: cimg/mysql:8.0
         environment:
           MYSQL_ROOT_PASSWORD: wordpress
           MYSQL_DATABASE: wordpress
@@ -381,7 +381,7 @@ jobs:
   plugin-test-unit:
     docker:
       - image: cimg/php:7.4
-      - image: cimg/mysql:5.7
+      - image: cimg/mysql:8.0
         environment:
           MYSQL_DATABASE: wp_database
           MYSQL_USER: wp_user
@@ -413,7 +413,7 @@ jobs:
   plugin-test-content-connect:
     docker:
       - image: cimg/php:7.4
-      - image: cimg/mysql:5.7
+      - image: cimg/mysql:8.0
         environment:
           MYSQL_DATABASE: wp_database
           MYSQL_USER: wp_user

--- a/.docker/Dockerfile-phpunit
+++ b/.docker/Dockerfile-phpunit
@@ -1,8 +1,8 @@
-FROM devwithlando/php:7.4-fpm-2
+FROM devwithlando/php:7.4-fpm-4
 
 COPY ../tests/install-wp-tests.sh /install-wp-tests.sh
 
 RUN apt-get update; \
 	apt-get install -y subversion; \
 	chmod +x /install-wp-tests.sh; \
-	bash /install-wp-tests.sh wordpress wordpress wordpress phpunitdatabase latest true
+	bash /install-wp-tests.sh wordpress wordpress wordpress phpunitdatabase 6.3 true

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,10 @@
         "lucatume/wp-browser": "3.0.9",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "phpcompatibility/phpcompatibility-wp": "^2.1.3",
-        "phpunit/phpunit": "~7.5.20",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.6.0",
         "wp-coding-standards/wpcs": "^2.3.0",
-        "yoast/phpunit-polyfills": "^1.0.3"
+        "yoast/phpunit-polyfills": "^2.0"
     },
     "scripts": {
         "lint": "parallel-lint -e php --no-colors --exclude vendor .",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28cfe43607c5041b1d2bf76f8ffe46ac",
+    "content-hash": "9d07e97f113186938f9b2ccb39f37290",
     "packages": [],
     "packages-dev": [
         {
@@ -6623,30 +6623,29 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+                "reference": "c758753e8f9dac251fed396a73c8305af3f17922"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c758753e8f9dac251fed396a73c8305af3f17922",
+                "reference": "c758753e8f9dac251fed396a73c8305af3f17922",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "yoast/yoastcs": "^2.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev",
-                    "dev-develop": "1.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -6680,7 +6679,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-11-23T01:37:03+00:00"
+            "time": "2023-06-06T20:28:24+00:00"
         },
         {
             "name": "zordius/lightncandy",

--- a/docker-compose-phpunit.yml
+++ b/docker-compose-phpunit.yml
@@ -11,7 +11,7 @@ services:
 
   phpunitdatabase:
     platform: linux/x86_64
-    image: mysql:5.7
+    image: mysql:8.0
     ports:
       - 3307:3306
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,9 @@ services:
       - ./.docker/mysql:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", 'mysqladmin ping']
-      interval: 10s
+      interval: 2s
       timeout: 2s
-      retries: 10
+      retries: 15
 
 volumes:
   wordpress:

--- a/tests/integration/api-validation/test-graphql-endpoints.php
+++ b/tests/integration/api-validation/test-graphql-endpoints.php
@@ -6,6 +6,7 @@ use PHPUnit\Runner\Exception as PHPUnitRunnerException;
 class GraphQLEndpointTests extends WP_UnitTestCase {
 
 	private $test_models;
+	public $factory;
 
 	public function set_up(): void {
 		parent::set_up();

--- a/tests/integration/api-validation/test-graphql-model-data.php
+++ b/tests/integration/api-validation/test-graphql-model-data.php
@@ -7,6 +7,8 @@ class GraphQLModelDataTests extends WP_UnitTestCase {
 
 	private $test_models;
 
+	public $factory;
+
 	private $create_mutation_query;
 
 	public function set_up(): void {

--- a/tests/integration/api-validation/test-rest-field-endpoints.php
+++ b/tests/integration/api-validation/test-rest-field-endpoints.php
@@ -14,6 +14,8 @@ class RestFieldEndpointTests extends WP_UnitTestCase {
 	private $route     = '/atlas/content-model-field';
 	private $test_models;
 
+	public $factory;
+
 	public function set_up(): void {
 		parent::set_up();
 

--- a/tests/integration/api-validation/test-rest-model-data.php
+++ b/tests/integration/api-validation/test-rest-model-data.php
@@ -16,6 +16,8 @@ class RestModelDataTests extends WP_UnitTestCase {
 	private $private_route       = '/privates';
 	private $post_ids;
 
+	public $factory;
+
 	public function set_up(): void {
 		parent::set_up();
 

--- a/tests/integration/api-validation/test-rest-model-endpoints.php
+++ b/tests/integration/api-validation/test-rest-model-endpoints.php
@@ -18,6 +18,8 @@ class RestModelEndpointTests extends WP_UnitTestCase {
 	private $route     = '/atlas/content-model';
 	private $test_models;
 
+	public $factory;
+
 	public function set_up(): void {
 		parent::set_up();
 

--- a/tests/integration/api-validation/test-rest-models-endpoints.php
+++ b/tests/integration/api-validation/test-rest-models-endpoints.php
@@ -18,6 +18,8 @@ class RestModelsEndpointTests extends WP_UnitTestCase {
 	private $route     = '/atlas/content-models';
 	private $test_models;
 
+	public $factory;
+
 	public function set_up(): void {
 		parent::set_up();
 

--- a/tests/integration/blueprints/test-blueprint-export.php
+++ b/tests/integration/blueprints/test-blueprint-export.php
@@ -56,7 +56,7 @@ class BlueprintExportTest extends WP_UnitTestCase {
 		],
 	];
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		delete_option( 'atlas_content_modeler_post_types' );
 		delete_option( 'atlas_content_modeler_taxonomies' );

--- a/tests/integration/blueprints/test-blueprint-import.php
+++ b/tests/integration/blueprints/test-blueprint-import.php
@@ -33,7 +33,7 @@ class BlueprintImportTest extends WP_UnitTestCase {
 	private $upload_dir;
 	private $blueprint_folder;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		delete_option( 'atlas_content_modeler_post_types' );
 		delete_option( 'atlas_content_modeler_taxonomies' );
@@ -338,7 +338,7 @@ class BlueprintImportTest extends WP_UnitTestCase {
 		}
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->reset_taxonomies();
 		$this->reset_registered_post_types();
 

--- a/tests/integration/blueprints/test-reset.php
+++ b/tests/integration/blueprints/test-reset.php
@@ -36,7 +36,7 @@ class ResetTest extends WP_UnitTestCase {
 	private $blueprint_folder;
 	private $media_ids_old_new;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		delete_option( 'atlas_content_modeler_post_types' );
@@ -246,7 +246,7 @@ class ResetTest extends WP_UnitTestCase {
 		}
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->reset_taxonomies();
 		$this->reset_registered_post_types();
 		parent::tearDown();

--- a/tests/integration/content-registration/test-custom-post-type-registration.php
+++ b/tests/integration/content-registration/test-custom-post-type-registration.php
@@ -18,6 +18,7 @@ class PostTypeRegistrationTestCases extends WP_UnitTestCase {
 	private $models;
 	private $all_registered_post_types;
 	private $original_wp_rewrite;
+	public $factory;
 
 	public function set_up() {
 		global $wp_rewrite;

--- a/tests/integration/publisher/test-content-creation.php
+++ b/tests/integration/publisher/test-content-creation.php
@@ -15,6 +15,7 @@ class TestContentCreation extends WP_UnitTestCase {
 
 	private $models;
 	private $post_ids;
+	public $factory;
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/integration/publisher/test-permalinks.php
+++ b/tests/integration/publisher/test-permalinks.php
@@ -13,6 +13,7 @@ use function WPE\AtlasContentModeler\ContentRegistration\update_registered_conte
 class TestPermalinks extends WP_UnitTestCase {
 
 	private $post_ids;
+	public $factory;
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/integration/publisher/test-post-type-archives.php
+++ b/tests/integration/publisher/test-post-type-archives.php
@@ -10,6 +10,8 @@ use function WPE\AtlasContentModeler\ContentRegistration\update_registered_conte
 class TestPostTypeArchives extends WP_UnitTestCase {
 	private $post_ids;
 
+	public $factory;
+
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/integration/publisher/test-script-dependencies.php
+++ b/tests/integration/publisher/test-script-dependencies.php
@@ -31,8 +31,6 @@ class TestPublisherScriptDependencies extends WP_UnitTestCase {
 		$pubex = new FormEditingExperience();
 		$pubex->bootstrap();
 
-		do_action( 'init' );
-
 		set_current_screen( 'post.php' );
 		global $current_screen;
 		$current_screen->post_type = 'recipe';

--- a/tests/integration/wp-cli/test-model-change-id.php
+++ b/tests/integration/wp-cli/test-model-change-id.php
@@ -38,6 +38,8 @@ class ModelChangeIdTest extends WP_UnitTestCase {
 
 	private $term_id;
 
+	public $factory;
+
 	public function set_up() {
 		parent::set_up();
 


### PR DESCRIPTION
## Description

This updates the pipeline to test against WP 6.3 and latest nightly builds.

This also fixes compatibility issues in the test files, which showed up once we bumped the test suite beyond 6.0.

Also updates to test against MySQL 8.

https://wpengine.atlassian.net/browse/MERL-923

## Testing
Automated tests continue to pass.

- See CircleCI output
- Run tests locally using `make test-php-unit`. Requires Docker. See setup instructions here: https://github.com/wpengine/atlas-content-modeler/blob/main/docs/DEVELOPMENT.md#testing

