### PR TITLE
[NOJIRA] ci: add plugin-build-zip job to nightly-testing workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,6 +668,16 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - plugin-build-zip:
+          slug: atlas-content-modeler
+          requires:
+            - plugin-build-composer
+            - plugin-build-npm
+            - plugin-build-pot
+          # Run this job on every commit/PR so the plugin is available as a build artifact
+          filters:
+            tags:
+              only: /.*/
       - plugin-test-unit:
           matrix:
             parameters:


### PR DESCRIPTION
## Description

This adds the `plugin-build-zip` job to the `nightly-testing` workflow. This fixes a problem that occurred during the schedule test runs last night. Interesting to note, CircleCI's CLI tool said the previous config was valid, despite the missing job.

[Reference](https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler)

Screenshot
![image](https://github.com/wpengine/atlas-content-modeler/assets/1254870/5c30e015-fc79-4db0-a416-c362a6a47ebb)
