### PR TITLE
ci: fix nightly-testing workflow by removing unused requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,7 +673,6 @@ workflows:
           requires:
             - plugin-build-composer
             - plugin-build-npm
-            - plugin-build-pot
           # Run this job on every commit/PR so the plugin is available as a build artifact
           filters:
             tags:


### PR DESCRIPTION
## Description

Fixes the scheduled nightly tests by removing an unused job from the requirements.

Example failure here: https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/3716