### PR TITLE
MERL-1192 - Fix return errors on relationships with no connections

### DIFF
--- a/includes/content-registration/custom-post-types-registration.php
+++ b/includes/content-registration/custom-post-types-registration.php
@@ -745,10 +745,7 @@ function register_relationship_connection( array $parent_model, array $reference
 					$relationship_ids = $relationship->get_related_object_ids( $post->ID );
 
 					if ( empty( $relationship_ids ) ) {
-						return [
-							'edges' => [],
-							'nodes' => [],
-						];
+						return;
 					}
 
 					$resolver = new PostObjectConnectionResolver(


### PR DESCRIPTION
Return null instead of array of empty nodes and edges.

Closes #663.

Related: See previous fix related to this here: https://github.com/wpengine/atlas-content-modeler/pull/648

## Description

<!--
What changed and why?
-->

<!--
Link to the JIRA ticket if available.
-->

https://wpengine.atlassian.net/browse/

## Checklist

I have:

- [ ] Added an entry to CHANGELOG.md.

## Testing

<!--
What automated tests did you add to prove the changes work?
-->

<!--
What steps should reviewers take to test manually?
-->

## Screenshots

<!--
Add screenshots from before and after if your change is visual.
-->

## Documentation Changes

<!--
Add links to documentation or wiki changes.
-->

## Dependent PRs

<!--
List dependent PRs awaiting review with this syntax:

Depends on #1234.
-->
