### PR TITLE
ci: fix phpunit tests

### DIFF
--- a/tests/install-wp-tests.sh
+++ b/tests/install-wp-tests.sh
@@ -154,7 +154,6 @@ install_plugin_dependencies() {
 	if [ ! -d $WP_CORE_DIR/wp-content/plugins/wp-graphql ]; then
 		download https://downloads.wordpress.org/plugin/wp-graphql.latest-stable.zip $WP_CORE_DIR/wp-content/plugins/wp-graphql.latest-stable.zip
 		cd $WP_CORE_DIR/wp-content/plugins
-		ls -la
 		unzip wp-graphql*.zip
 	fi
 }

--- a/tests/install-wp-tests.sh
+++ b/tests/install-wp-tests.sh
@@ -19,7 +19,7 @@ WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
     if [ `which curl` ]; then
-        curl -s "$1" > "$2";
+        curl -L -s "$1" > "$2";
     elif [ `which wget` ]; then
         wget -nv -O "$2" "$1"
     fi

--- a/tests/install-wp-tests.sh
+++ b/tests/install-wp-tests.sh
@@ -154,6 +154,7 @@ install_plugin_dependencies() {
 	if [ ! -d $WP_CORE_DIR/wp-content/plugins/wp-graphql ]; then
 		download https://downloads.wordpress.org/plugin/wp-graphql.latest-stable.zip $WP_CORE_DIR/wp-content/plugins/wp-graphql.latest-stable.zip
 		cd $WP_CORE_DIR/wp-content/plugins
+		ls -la
 		unzip wp-graphql*.zip
 	fi
 }

--- a/tests/install-wp-tests.sh
+++ b/tests/install-wp-tests.sh
@@ -154,7 +154,7 @@ install_plugin_dependencies() {
 	if [ ! -d $WP_CORE_DIR/wp-content/plugins/wp-graphql ]; then
 		download https://downloads.wordpress.org/plugin/wp-graphql.latest-stable.zip $WP_CORE_DIR/wp-content/plugins/wp-graphql.latest-stable.zip
 		cd $WP_CORE_DIR/wp-content/plugins
-		unzip wp-graphql.latest-stable.zip
+		unzip wp-graphql*.zip
 	fi
 }
 


### PR DESCRIPTION
## Description

Updates the `install-wp-tests.sh` script so that `curl` follows redirects (`-L` option).

Without this, the zip WPGraphQL zip file downloaded from wp.org was 0 bytes. Example failure: https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/3797/workflows/012da7ed-af2c-4d0d-89ca-6419712e8ec2/jobs/42786

## Testing

Automated phpunit tests should pass with this.

Example of tests passing with this fix: https://app.circleci.com/pipelines/github/wpengine/atlas-content-modeler/3803/workflows/c3498e01-d855-4964-a4c7-d48965a5bc53/jobs/42894

