### PR TITLE
Do not show list of entries when browser loses and regains focus unless necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Atlas Content Modeler Changelog
+## 0.26.1 - 2024-01-17
+### Fixed
+- Fixed issue where having empty repeater fields would show a list of entries when the browser tab loses and regains focus. GitHub issue #627.
+### Added
+- Added changelog for 0.26.0, which was accidentally omitted from the previous release. Please read the changes for 0.26.0 to learn more about the deprecation of ACM.
+
 ## 0.26.0 - 2024-01-16
 ### Added
 - Added an admin notice about the deprecation of Atlas Content Modeler. ACM will be maintained for security and compatibility through 2024. Read more about the plan and recommended replacement here: https://github.com/wpengine/atlas-content-modeler/blob/main/docs/end-of-life/index.md
--
+
 ## 0.25.0 - 2023-11-08
 ### Fixed
 - GraphQL queries now work properly when repeating Rich Text fields are optional and have no values.

--- a/includes/publisher/js/src/components/relationship/index.jsx
+++ b/includes/publisher/js/src/components/relationship/index.jsx
@@ -76,6 +76,7 @@ export default function Relationship({ field, modelSlug }) {
 		if (
 			pageLostFocus.current &&
 			pageIsVisible &&
+			selectedEntries?.length > 0 &&
 			!relationshipModalIsOpen
 		) {
 			pageLostFocus.current = false;

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,11 @@ You can submit feature requests and open bug reports in our [GitHub repo](https:
 
 == Changelog ==
 
+= 0.26.0 - 2024-01-16 =
+
+* **Added:** Added an admin notice about the deprecation of Atlas Content Modeler. ACM will be maintained for security and compatibility through 2024. Read more about the plan and recommended replacement here: https://github.com/wpengine/atlas-content-modeler/blob/main/docs/end-of-life/index.md
+-
+
 = 0.25.0 - 2023-11-08 =
 
 * **Fixed:** GraphQL queries now work properly when repeating Rich Text fields are optional and have no values.

--- a/readme.txt
+++ b/readme.txt
@@ -56,10 +56,14 @@ You can submit feature requests and open bug reports in our [GitHub repo](https:
 
 == Changelog ==
 
+= 0.26.1 - 2024-01-17 =
+
+* **Fixed:** Fixed issue where having empty repeater fields would show a list of entries when the browser tab loses and regains focus. GitHub issue #627.
+* **Added:** Added changelog for 0.26.0, which was accidentally omitted from the previous release. Please read the changes for 0.26.0 to learn more about the deprecation of ACM.
+
 = 0.26.0 - 2024-01-16 =
 
 * **Added:** Added an admin notice about the deprecation of Atlas Content Modeler. ACM will be maintained for security and compatibility through 2024. Read more about the plan and recommended replacement here: https://github.com/wpengine/atlas-content-modeler/blob/main/docs/end-of-life/index.md
--
 
 = 0.25.0 - 2023-11-08 =
 


### PR DESCRIPTION
## Description
Fixes an issue where a list of entries was shown on relationship fields when the browser tab lost and regained focus. 

Fixes #627 

Also adds the changelog to readme.txt from 0.26.0, as it was accidentally omitted in that release.

## Checklist

I have:

- [x] Added an entry to CHANGELOG.md.

## Testing

See testing instructions in #627. Reproduce the issue in the `main` branch before checking out this branch.

**Note:** when checking out this repo/branch, you'll need to run `npm ci` and `npm run start`.

Automated tests should continue to work as expected.

**Note:** The e2e tests are flaky in Circle. You can run them locally with Docker and `make test-e2e`. If you want to limit the e2e tests to specific tests instead of running the whole suite, you can do this:

`TEST=PublishModelCest:I_see_submission_errors_in_number_fields_when_input_is_more_than_max_for_the_number_type make test-e2e`

See development docs for more info on running tests locally https://github.com/wpengine/atlas-content-modeler/blob/main/docs/DEVELOPMENT.md#running-a-single-end-to-end-acceptance-test